### PR TITLE
feat: scribe v1 — CLI + server with multi-backend transcription and LLM cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Transcription provider: parakeet-mlx | groq | openai
+TRANSCRIBE_PROVIDER=parakeet-mlx
+
+# Cleanup provider: claude | ollama | none
+CLEANUP_PROVIDER=none
+
+# Server port
+PORT=3200
+
+# Groq (if using groq transcription)
+# GROQ_API_KEY=
+# GROQ_MODEL=whisper-large-v3
+
+# OpenAI (if using openai transcription)
+# OPENAI_API_KEY=
+# OPENAI_MODEL=whisper-1
+
+# Claude (if using claude cleanup)
+# ANTHROPIC_API_KEY=
+# CLAUDE_MODEL=claude-sonnet-4-20250514
+
+# Ollama (if using ollama cleanup)
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_MODEL=llama3.1

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "parachute-scribe",
-  "module": "index.ts",
+  "module": "src/server.ts",
   "type": "module",
   "private": true,
+  "bin": {
+    "scribe": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts serve"
+  },
   "devDependencies": {
     "@types/bun": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parachute-scribe",
-  "module": "src/server.ts",
+  "module": "src/index.ts",
   "type": "module",
   "private": true,
   "bin": {

--- a/src/cleanup/claude.ts
+++ b/src/cleanup/claude.ts
@@ -1,0 +1,29 @@
+import { CLEANUP_PROMPT } from "./prompt.ts";
+
+export async function cleanup(text: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY not set");
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "content-type": "application/json",
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: process.env.CLAUDE_MODEL ?? "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: CLEANUP_PROMPT,
+      messages: [{ role: "user", content: text }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Claude API error ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as { content: Array<{ text: string }> };
+  return json.content[0]!.text;
+}

--- a/src/cleanup/ollama.ts
+++ b/src/cleanup/ollama.ts
@@ -1,0 +1,27 @@
+import { CLEANUP_PROMPT } from "./prompt.ts";
+
+export async function cleanup(text: string): Promise<string> {
+  const url = process.env.OLLAMA_URL ?? "http://localhost:11434";
+  const model = process.env.OLLAMA_MODEL ?? "llama3.1";
+
+  const res = await fetch(`${url}/api/chat`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model,
+      stream: false,
+      messages: [
+        { role: "system", content: CLEANUP_PROMPT },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Ollama error ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as { message: { content: string } };
+  return json.message.content;
+}

--- a/src/cleanup/openai-compat.ts
+++ b/src/cleanup/openai-compat.ts
@@ -1,0 +1,63 @@
+import { CLEANUP_PROMPT } from "./prompt.ts";
+
+type ProviderConfig = {
+  baseUrl: string;
+  apiKey: string | undefined;
+  defaultModel: string;
+};
+
+function makeCleanup(config: ProviderConfig) {
+  return async function cleanup(text: string): Promise<string> {
+    const apiKey = config.apiKey;
+    if (!apiKey) throw new Error(`API key not set for cleanup provider`);
+
+    const model = process.env.CLEANUP_MODEL ?? config.defaultModel;
+
+    const res = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: CLEANUP_PROMPT },
+          { role: "user", content: text },
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Cleanup API error ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { choices: Array<{ message: { content: string } }> };
+    return json.choices[0]!.message.content;
+  };
+}
+
+export const openai = makeCleanup({
+  baseUrl: "https://api.openai.com/v1",
+  get apiKey() { return process.env.OPENAI_API_KEY; },
+  defaultModel: "gpt-4o-mini",
+});
+
+export const gemini = makeCleanup({
+  baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+  get apiKey() { return process.env.GEMINI_API_KEY; },
+  defaultModel: "gemini-2.0-flash",
+});
+
+export const groqCleanup = makeCleanup({
+  baseUrl: "https://api.groq.com/openai/v1",
+  get apiKey() { return process.env.GROQ_API_KEY; },
+  defaultModel: "llama-3.1-8b-instant",
+});
+
+export const custom = makeCleanup({
+  baseUrl: process.env.CLEANUP_URL ?? "http://localhost:8080/v1",
+  get apiKey() { return process.env.CLEANUP_API_KEY; },
+  defaultModel: process.env.CLEANUP_MODEL ?? "default",
+});

--- a/src/cleanup/prompt.ts
+++ b/src/cleanup/prompt.ts
@@ -1,0 +1,9 @@
+export const CLEANUP_PROMPT = `You clean up voice memo transcripts. Your job:
+
+- Remove filler words (um, uh, like, you know, I mean, so, basically, right)
+- Fix punctuation, capitalization, and sentence boundaries
+- Break run-on sentences into proper paragraphs
+- Keep the speaker's voice, tone, and meaning — don't rewrite, just clean
+- Don't summarize, don't add anything, don't change meaning
+
+Return only the cleaned text. No commentary, no preamble.`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+
+import { transcribers, cleaners, getProvider } from "./providers.ts";
+import { startServer } from "./server.ts";
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function getFlag(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+function hasFlag(flag: string): boolean {
+  return args.includes(flag);
+}
+
+function usage() {
+  console.log(`scribe — audio transcription + LLM cleanup
+
+Usage:
+  scribe <file>                       Transcribe an audio file
+  scribe serve                        Start the HTTP server
+  scribe providers                    List available providers
+
+Options:
+  --transcribe <provider>             Transcription provider (default: parakeet-mlx)
+  --cleanup <provider>                Cleanup provider (default: none)
+  --no-cleanup                        Skip LLM cleanup even if configured
+  --json                              Output JSON instead of plain text
+
+Environment:
+  TRANSCRIBE_PROVIDER                 Default transcription provider
+  CLEANUP_PROVIDER                    Default cleanup provider
+  PORT                                Server port (default: 3200)
+
+Examples:
+  scribe recording.wav
+  scribe meeting.m4a --cleanup claude
+  scribe memo.mp3 --transcribe groq --cleanup ollama
+  scribe serve
+`);
+}
+
+switch (command) {
+  case "serve":
+    startServer();
+    break;
+
+  case "providers":
+    console.log(`Transcription: ${Object.keys(transcribers).join(", ")}`);
+    console.log(`Cleanup:       ${Object.keys(cleaners).join(", ")}`);
+    break;
+
+  case "help":
+  case "--help":
+  case "-h":
+  case undefined:
+    usage();
+    break;
+
+  default:
+    await cmdTranscribe(command);
+}
+
+async function cmdTranscribe(filePath: string) {
+  const file = Bun.file(filePath);
+  if (!(await file.exists())) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const transcribeProvider = getFlag("--transcribe") ?? process.env.TRANSCRIBE_PROVIDER ?? "parakeet-mlx";
+  const cleanupProvider = hasFlag("--no-cleanup")
+    ? "none"
+    : getFlag("--cleanup") ?? process.env.CLEANUP_PROVIDER ?? "none";
+  const outputJson = hasFlag("--json");
+
+  const transcribe = getProvider(transcribers, transcribeProvider, "transcription");
+  const cleanup = getProvider(cleaners, cleanupProvider, "cleanup");
+
+  const blob = await file.arrayBuffer();
+  const name = filePath.split("/").pop() ?? "audio.wav";
+  const audioFile = new File([blob], name);
+
+  let text = await transcribe(audioFile);
+
+  if (cleanupProvider !== "none") {
+    text = await cleanup(text);
+  }
+
+  if (outputJson) {
+    console.log(JSON.stringify({ text }));
+  } else {
+    console.log(text);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,49 @@
+export { transcribers, cleaners, getProvider } from "./providers.ts";
+export { CLEANUP_PROMPT } from "./cleanup/prompt.ts";
+
+import { transcribers, cleaners } from "./providers.ts";
+
+export type TranscribeOptions = {
+  provider?: string;
+  cleanup?: string;
+};
+
+/**
+ * Transcribe an audio file with optional LLM cleanup.
+ * This is the main entry point for using scribe as a library.
+ */
+export async function transcribe(
+  audio: File,
+  opts: TranscribeOptions = {},
+): Promise<string> {
+  const transcribeProvider = opts.provider ?? process.env.TRANSCRIBE_PROVIDER ?? "parakeet-mlx";
+  const cleanupProvider = opts.cleanup ?? process.env.CLEANUP_PROVIDER ?? "none";
+
+  const transcriber = transcribers[transcribeProvider];
+  if (!transcriber) {
+    throw new Error(`Unknown transcription provider: ${transcribeProvider}. Available: ${Object.keys(transcribers).join(", ")}`);
+  }
+
+  const cleaner = cleaners[cleanupProvider];
+  if (!cleaner) {
+    throw new Error(`Unknown cleanup provider: ${cleanupProvider}. Available: ${Object.keys(cleaners).join(", ")}`);
+  }
+
+  let text = await transcriber(audio);
+
+  if (cleanupProvider !== "none") {
+    text = await cleaner(text);
+  }
+
+  return text;
+}
+
+/**
+ * Check which transcription providers are available on this system.
+ */
+export function availableProviders() {
+  return {
+    transcription: Object.keys(transcribers),
+    cleanup: Object.keys(cleaners),
+  };
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,0 +1,29 @@
+import { transcribe as parakeetMlx } from "./transcribe/parakeet-mlx.ts";
+import { transcribe as onnxAsr } from "./transcribe/onnx-asr.ts";
+import { transcribe as groq } from "./transcribe/groq.ts";
+import { transcribe as openai } from "./transcribe/openai.ts";
+import { cleanup as claude } from "./cleanup/claude.ts";
+import { cleanup as ollama } from "./cleanup/ollama.ts";
+
+export const transcribers: Record<string, (audio: File) => Promise<string>> = {
+  "parakeet-mlx": parakeetMlx,
+  "onnx-asr": onnxAsr,
+  groq,
+  openai,
+};
+
+export const cleaners: Record<string, (text: string) => Promise<string>> = {
+  claude,
+  ollama,
+  none: async (text) => text,
+};
+
+export function getProvider<T>(map: Record<string, T>, key: string, label: string): T {
+  const provider = map[key];
+  if (!provider) {
+    console.error(`Unknown ${label} provider: ${key}`);
+    console.error(`Available: ${Object.keys(map).join(", ")}`);
+    process.exit(1);
+  }
+  return provider;
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -4,6 +4,7 @@ import { transcribe as groq } from "./transcribe/groq.ts";
 import { transcribe as openai } from "./transcribe/openai.ts";
 import { cleanup as claude } from "./cleanup/claude.ts";
 import { cleanup as ollama } from "./cleanup/ollama.ts";
+import { openai as openaiCleanup, gemini, groqCleanup, custom } from "./cleanup/openai-compat.ts";
 
 export const transcribers: Record<string, (audio: File) => Promise<string>> = {
   "parakeet-mlx": parakeetMlx,
@@ -15,6 +16,10 @@ export const transcribers: Record<string, (audio: File) => Promise<string>> = {
 export const cleaners: Record<string, (text: string) => Promise<string>> = {
   claude,
   ollama,
+  openai: openaiCleanup,
+  gemini,
+  groq: groqCleanup,
+  custom,
   none: async (text) => text,
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ export function startServer() {
   console.log(`  cleanup: ${CLEANUP}`);
 
   Bun.serve({
+    hostname: "0.0.0.0",
     port: PORT,
     async fetch(req) {
       const url = new URL(req.url);
@@ -23,6 +24,13 @@ export function startServer() {
 
       if (url.pathname === "/health") {
         return Response.json({ ok: true });
+      }
+
+      // Whisper-compatible models endpoint (used by clients for health checks)
+      if (url.pathname === "/v1/models") {
+        return Response.json({
+          data: [{ id: TRANSCRIBE, object: "model" }],
+        });
       }
 
       return new Response("Not found", { status: 404 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,54 @@
+import { transcribers, cleaners, getProvider } from "./providers.ts";
+
+const TRANSCRIBE = process.env.TRANSCRIBE_PROVIDER ?? "parakeet-mlx";
+const CLEANUP = process.env.CLEANUP_PROVIDER ?? "none";
+const PORT = Number(process.env.PORT ?? 3200);
+
+const transcribe = getProvider(transcribers, TRANSCRIBE, "transcription");
+const cleanup = getProvider(cleaners, CLEANUP, "cleanup");
+
+export function startServer() {
+  console.log(`scribe listening on :${PORT}`);
+  console.log(`  transcribe: ${TRANSCRIBE}`);
+  console.log(`  cleanup: ${CLEANUP}`);
+
+  Bun.serve({
+    port: PORT,
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
+        return handleTranscription(req);
+      }
+
+      if (url.pathname === "/health") {
+        return Response.json({ ok: true });
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+}
+
+async function handleTranscription(req: Request): Promise<Response> {
+  const form = await req.formData();
+  const file = form.get("file");
+
+  if (!(file instanceof File)) {
+    return Response.json({ error: "missing 'file' field" }, { status: 400 });
+  }
+
+  const doCleanup = form.get("cleanup") !== "false" && CLEANUP !== "none";
+
+  try {
+    let text = await transcribe(file);
+    if (doCleanup) {
+      text = await cleanup(text);
+    }
+    return Response.json({ text });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "transcription failed";
+    console.error("Transcription error:", message);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/transcribe/groq.ts
+++ b/src/transcribe/groq.ts
@@ -1,0 +1,22 @@
+export async function transcribe(audio: File): Promise<string> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) throw new Error("GROQ_API_KEY not set");
+
+  const form = new FormData();
+  form.set("file", audio);
+  form.set("model", process.env.GROQ_MODEL ?? "whisper-large-v3");
+
+  const res = await fetch("https://api.groq.com/openai/v1/audio/transcriptions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Groq API error ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as { text: string };
+  return json.text;
+}

--- a/src/transcribe/onnx-asr.ts
+++ b/src/transcribe/onnx-asr.ts
@@ -1,0 +1,17 @@
+import { $ } from "bun";
+
+export async function transcribe(audio: File): Promise<string> {
+  const id = crypto.randomUUID();
+  const ext = audio.name?.split(".").pop() ?? "wav";
+  const tmpFile = `/tmp/scribe-${id}.${ext}`;
+
+  await Bun.write(tmpFile, audio);
+
+  try {
+    const model = process.env.ONNX_ASR_MODEL ?? "nemo-parakeet-tdt-0.6b-v3";
+    const text = await $`onnx-asr ${model} ${tmpFile}`.text();
+    return text.trim();
+  } finally {
+    await $`rm -f ${tmpFile}`.nothrow().quiet();
+  }
+}

--- a/src/transcribe/openai.ts
+++ b/src/transcribe/openai.ts
@@ -1,0 +1,22 @@
+export async function transcribe(audio: File): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY not set");
+
+  const form = new FormData();
+  form.set("file", audio);
+  form.set("model", process.env.OPENAI_MODEL ?? "whisper-1");
+
+  const res = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`OpenAI API error ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as { text: string };
+  return json.text;
+}

--- a/src/transcribe/parakeet-mlx.ts
+++ b/src/transcribe/parakeet-mlx.ts
@@ -9,10 +9,28 @@ export async function transcribe(audio: File): Promise<string> {
   await Bun.write(tmpFile, audio);
 
   try {
-    await $`parakeet-mlx ${tmpFile} --output-format txt --output-dir ${tmpDir}`.quiet();
+    const result = await $`parakeet-mlx ${tmpFile} --output-format txt --output-dir ${tmpDir}`
+      .nothrow()
+      .quiet();
+
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString().trim();
+      throw new Error(
+        `parakeet-mlx exited with code ${result.exitCode}${stderr ? `: ${stderr}` : ""}`,
+      );
+    }
 
     const outFile = `${tmpDir}/scribe-${id}.txt`;
-    return (await Bun.file(outFile).text()).trim();
+    const file = Bun.file(outFile);
+    if (!(await file.exists())) {
+      // parakeet-mlx may use the original filename stem
+      const files = await Array.fromAsync(new Bun.Glob("*.txt").scan(tmpDir));
+      if (files.length === 0) {
+        throw new Error(`No .txt output found in ${tmpDir}`);
+      }
+      return (await Bun.file(`${tmpDir}/${files[0]}`).text()).trim();
+    }
+    return (await file.text()).trim();
   } finally {
     await $`rm -rf ${tmpFile} ${tmpDir}`.nothrow().quiet();
   }

--- a/src/transcribe/parakeet-mlx.ts
+++ b/src/transcribe/parakeet-mlx.ts
@@ -1,0 +1,19 @@
+import { $ } from "bun";
+
+export async function transcribe(audio: File): Promise<string> {
+  const id = crypto.randomUUID();
+  const ext = audio.name?.split(".").pop() ?? "wav";
+  const tmpFile = `/tmp/scribe-${id}.${ext}`;
+  const tmpDir = `/tmp/scribe-${id}-out`;
+
+  await Bun.write(tmpFile, audio);
+
+  try {
+    await $`parakeet-mlx ${tmpFile} --output-format txt --output-dir ${tmpDir}`.quiet();
+
+    const outFile = `${tmpDir}/scribe-${id}.txt`;
+    return (await Bun.file(outFile).text()).trim();
+  } finally {
+    await $`rm -rf ${tmpFile} ${tmpDir}`.nothrow().quiet();
+  }
+}


### PR DESCRIPTION
## Summary

- **CLI tool** (`scribe <file>`) and **HTTP server** (`scribe serve`) for audio transcription with optional LLM cleanup
- **Transcription backends**: parakeet-mlx (Mac), onnx-asr (Linux), Groq API, OpenAI API
- **Cleanup backends**: Claude, Ollama, OpenAI, Gemini, Groq, custom OpenAI-compatible endpoint, or none
- **Library export** (`import { transcribe } from "parachute-scribe"`) for use by parachute-vault
- Whisper-compatible API shape — works with Parachute Daily out of the box

## Details

Scribe is a lightweight audio transcription service. It accepts audio files, transcribes them via a configurable backend, and optionally cleans up the transcript with an LLM.

Each backend is a self-contained async function — no plugin framework, no abstractions. Adding a new backend is one file + one line in the provider map.

The CLI follows the same pattern as other parachute repos (tailshare, vault, pcc): `#!/usr/bin/env bun`, hand-rolled arg parsing, switch/case dispatch.

Vault integration: vault imports scribe as a library and serves the `/v1/audio/transcriptions` endpoint, so Daily users only configure one URL.

## Test plan

- [x] `scribe <file>` transcribes audio via parakeet-mlx
- [x] `scribe <file> --json` returns JSON output
- [x] `scribe serve` starts HTTP server on 0.0.0.0:3200
- [x] `curl -X POST /v1/audio/transcriptions -F file=@audio.wav` returns `{ "text": "..." }`
- [x] `GET /v1/models` returns provider list
- [x] `GET /health` returns ok
- [x] `scribe providers` lists all available backends
- [ ] Test cleanup providers (claude, ollama, openai, gemini, groq) with real API keys
- [ ] Test onnx-asr provider on Linux
- [ ] End-to-end test: Daily app → Vault → Scribe → transcribed text

🤖 Generated with [Claude Code](https://claude.com/claude-code)