### PR TITLE
feat: Linux transcription support (whisper + onnx-asr)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,46 @@
-# Transcription provider: parakeet-mlx | groq | openai
+# Transcription provider: parakeet-mlx | onnx-asr | whisper | groq | openai
+#   parakeet-mlx  — Mac (Apple Silicon, MLX)
+#   onnx-asr      — Linux (Parakeet via ONNX, pip install onnx-asr[cpu,hub])
+#   whisper        — Any platform (pip install whisper-ctranslate2)
+#   groq / openai  — Cloud API
 TRANSCRIBE_PROVIDER=parakeet-mlx
 
-# Cleanup provider: claude | ollama | none
+# Cleanup provider: claude | ollama | openai | gemini | groq | custom | none
 CLEANUP_PROVIDER=none
 
 # Server port
 PORT=3200
 
-# Groq (if using groq transcription)
+# --- Transcription provider config ---
+
+# onnx-asr
+# ONNX_ASR_MODEL=nemo-parakeet-tdt-0.6b-v3
+
+# whisper (whisper-ctranslate2)
+# WHISPER_MODEL=small
+
+# Groq (transcription or cleanup)
 # GROQ_API_KEY=
 # GROQ_MODEL=whisper-large-v3
 
-# OpenAI (if using openai transcription)
+# OpenAI (transcription or cleanup)
 # OPENAI_API_KEY=
 # OPENAI_MODEL=whisper-1
 
-# Claude (if using claude cleanup)
+# --- Cleanup provider config ---
+
+# Claude
 # ANTHROPIC_API_KEY=
 # CLAUDE_MODEL=claude-sonnet-4-20250514
 
-# Ollama (if using ollama cleanup)
+# Ollama
 # OLLAMA_URL=http://localhost:11434
 # OLLAMA_MODEL=llama3.1
+
+# Gemini
+# GEMINI_API_KEY=
+
+# Custom OpenAI-compatible endpoint
+# CLEANUP_URL=http://localhost:8080/v1
+# CLEANUP_API_KEY=
+# CLEANUP_MODEL=default

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,6 @@
 import { transcribe as parakeetMlx } from "./transcribe/parakeet-mlx.ts";
 import { transcribe as onnxAsr } from "./transcribe/onnx-asr.ts";
+import { transcribe as whisper } from "./transcribe/whisper.ts";
 import { transcribe as groq } from "./transcribe/groq.ts";
 import { transcribe as openai } from "./transcribe/openai.ts";
 import { cleanup as claude } from "./cleanup/claude.ts";
@@ -9,6 +10,7 @@ import { openai as openaiCleanup, gemini, groqCleanup, custom } from "./cleanup/
 export const transcribers: Record<string, (audio: File) => Promise<string>> = {
   "parakeet-mlx": parakeetMlx,
   "onnx-asr": onnxAsr,
+  whisper,
   groq,
   openai,
 };

--- a/src/transcribe/onnx-asr.ts
+++ b/src/transcribe/onnx-asr.ts
@@ -4,14 +4,43 @@ export async function transcribe(audio: File): Promise<string> {
   const id = crypto.randomUUID();
   const ext = audio.name?.split(".").pop() ?? "wav";
   const tmpFile = `/tmp/scribe-${id}.${ext}`;
+  const wavFile = `/tmp/scribe-${id}.wav`;
 
   await Bun.write(tmpFile, audio);
 
   try {
+    // onnx-asr only accepts WAV — convert if needed
+    if (ext !== "wav") {
+      await $`ffmpeg -i ${tmpFile} -ar 16000 -ac 1 -c:a pcm_s16le ${wavFile} -y`
+        .quiet();
+    } else {
+      await $`cp ${tmpFile} ${wavFile}`.quiet();
+    }
+
     const model = process.env.ONNX_ASR_MODEL ?? "nemo-parakeet-tdt-0.6b-v3";
-    const text = await $`onnx-asr ${model} ${tmpFile}`.text();
+
+    // Use --vad silero for audio over ~20s (Parakeet's context limit)
+    const result = await $`onnx-asr ${model} --vad silero ${wavFile}`
+      .nothrow()
+      .quiet();
+
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString().trim();
+      throw new Error(
+        `onnx-asr exited with code ${result.exitCode}${stderr ? `: ${stderr}` : ""}`,
+      );
+    }
+
+    // With --vad, output is timestamped lines like "[  0.0,  3.2]: text"
+    // Strip timestamps and join
+    const raw = result.stdout.toString().trim();
+    const lines = raw.split("\n").filter((l) => l.trim());
+    const text = lines
+      .map((l) => l.replace(/^\[\s*[\d.]+,\s*[\d.]+\]:\s*/, ""))
+      .join(" ");
+
     return text.trim();
   } finally {
-    await $`rm -f ${tmpFile}`.nothrow().quiet();
+    await $`rm -f ${tmpFile} ${wavFile}`.nothrow().quiet();
   }
 }

--- a/src/transcribe/whisper.ts
+++ b/src/transcribe/whisper.ts
@@ -1,0 +1,42 @@
+import { $ } from "bun";
+
+export async function transcribe(audio: File): Promise<string> {
+  const id = crypto.randomUUID();
+  const ext = audio.name?.split(".").pop() ?? "wav";
+  const tmpFile = `/tmp/scribe-${id}.${ext}`;
+  const tmpDir = `/tmp/scribe-${id}-out`;
+
+  await Bun.write(tmpFile, audio);
+
+  try {
+    const model = process.env.WHISPER_MODEL ?? "small";
+
+    const result = await $`whisper-ctranslate2 ${tmpFile} --model ${model} --output_format txt --output_dir ${tmpDir}`
+      .nothrow()
+      .quiet();
+
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString().trim();
+      throw new Error(
+        `whisper-ctranslate2 exited with code ${result.exitCode}${stderr ? `: ${stderr}` : ""}`,
+      );
+    }
+
+    // Output file is named after input file stem
+    const stem = `scribe-${id}`;
+    const outFile = `${tmpDir}/${stem}.txt`;
+    const file = Bun.file(outFile);
+
+    if (!(await file.exists())) {
+      const files = await Array.fromAsync(new Bun.Glob("*.txt").scan(tmpDir));
+      if (files.length === 0) {
+        throw new Error(`No .txt output found in ${tmpDir}`);
+      }
+      return (await Bun.file(`${tmpDir}/${files[0]}`).text()).trim();
+    }
+
+    return (await file.text()).trim();
+  } finally {
+    await $`rm -rf ${tmpFile} ${tmpDir}`.nothrow().quiet();
+  }
+}


### PR DESCRIPTION
## Summary

- **New `whisper` provider** — uses `whisper-ctranslate2` (faster-whisper). Works on Mac and Linux, accepts any audio format. `pip install whisper-ctranslate2` and go.
- **Improved `onnx-asr` provider** — auto-converts non-WAV to WAV via ffmpeg, uses `--vad silero` for long audio, proper error handling.
- Updated `.env.example` with full provider documentation.

## Linux setup

```bash
pip install whisper-ctranslate2
bun install -g parachute-scribe
TRANSCRIBE_PROVIDER=whisper scribe recording.wav
```

## Test plan

- [x] `whisper` provider transcribes audio correctly via CLI
- [x] `whisper` provider handles `--json` output
- [x] `onnx-asr` provider handles WAV conversion and VAD flag
- [x] All providers list correctly via `scribe providers`
- [ ] Test `onnx-asr` on Linux
- [ ] Test `whisper` with larger models (small, medium, large-v3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)