### PR TITLE
chore: rename package to @openparachute/scribe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Use Bun for everything:
 - **Parachute Daily** (Flutter app) already has offline transcription via Sherpa-ONNX. This service adds a server-side option with higher quality + LLM cleanup.
 - **Parachute Vault** is the knowledge graph where transcribed notes land. Scribe doesn't know about the vault — it just returns text. The client (app or agent) stores it.
 - Domain: `parachute.computer`, this would be at `scribe.parachute.computer`
-- Sister repos: [parachute-vault](https://github.com/ParachuteComputer/parachute-vault), [parachute-daily](https://github.com/ParachuteComputer/parachute-daily)
+- Sister repos: [@openparachute/vault](https://github.com/ParachuteComputer/@openparachute/vault), [@openparachute/daily](https://github.com/ParachuteComputer/@openparachute/daily)
 
 ## Open questions
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
-  "name": "parachute-scribe",
+  "name": "@openparachute/scribe",
+  "version": "0.1.0",
+  "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary
- Rename `parachute-scribe` → `@openparachute/scribe` in package.json
- Add version and description fields
- Update CLAUDE.md cross-references to use scoped names

Part of the coordinated move to `@openparachute` npm scope across all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)