### PR TITLE
feat: add CORS to HTTP server

### DIFF
--- a/src/cors.test.ts
+++ b/src/cors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { preflight, withCors } from "./cors.ts";
+
+describe("cors", () => {
+  test("preflight returns 204 with CORS headers", () => {
+    const res = preflight();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Allow-Headers")).toContain("Content-Type");
+  });
+
+  test("withCors adds CORS headers to a JSON response", () => {
+    const res = withCors(Response.json({ text: "hello" }));
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  test("withCors preserves non-200 status codes and bodies", async () => {
+    const res = withCors(new Response("not found", { status: 404 }));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await res.text()).toBe("not found");
+  });
+});

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,21 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+} as const;
+
+export function preflight(): Response {
+  return new Response(null, { status: 204, headers: corsHeaders });
+}
+
+export function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { transcribers, cleaners, getProvider } from "./providers.ts";
 import { loadConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
+import { preflight, withCors } from "./cors.ts";
 
 export async function startServer() {
   const config = await loadConfig();
@@ -24,25 +25,30 @@ export async function startServer() {
     hostname: "0.0.0.0",
     port: PORT,
     async fetch(req) {
-      const url = new URL(req.url);
-
-      if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
-        return handleTranscription(req);
-      }
-
-      if (url.pathname === "/health") {
-        return Response.json({ ok: true });
-      }
-
-      if (url.pathname === "/v1/models") {
-        return Response.json({
-          data: [{ id: TRANSCRIBE, object: "model" }],
-        });
-      }
-
-      return new Response("Not found", { status: 404 });
+      if (req.method === "OPTIONS") return preflight();
+      return withCors(await route(req));
     },
   });
+
+  async function route(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
+      return handleTranscription(req);
+    }
+
+    if (url.pathname === "/health") {
+      return Response.json({ ok: true });
+    }
+
+    if (url.pathname === "/v1/models") {
+      return Response.json({
+        data: [{ id: TRANSCRIBE, object: "model" }],
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
 
   async function handleTranscription(req: Request): Promise<Response> {
     const form = await req.formData();


### PR DESCRIPTION
## Summary
- Add `src/cors.ts` with `preflight()` and `withCors()` helpers; wire into `Bun.serve` so every response (success, error, 404, health, /v1/models) carries CORS headers, and OPTIONS short-circuits to 204.
- Add `src/cors.test.ts` unit tests for preflight status/headers, JSON passthrough, and non-200 preservation.

## Why
Lens v0.2 (parachute-lens#19) now calls `/v1/audio/transcriptions` directly from the browser. Browsers preflight the multipart POST with OPTIONS — without CORS the preflight fails and the real request never fires, so transcription silently doesn't work. This unblocks Lens-in-browser end-to-end.

## CORS policy
```
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: POST, GET, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization
```
Open origin is reasonable today — scribe is expected to run behind a trusted network boundary (tailnet, LAN, reverse proxy with auth). If/when scribe grows its own auth (bearer token, Tailscale Funnel exposure), we should tighten origin and tie it to the auth story. Not in scope here.

## Test plan
- [x] `bun test` → 10/10 pass (3 new cors tests + existing vault suite)
- [x] `bunx tsc --noEmit` clean (exit 0)
- [x] Live curl OPTIONS preflight → 204 with all three Access-Control-* headers
- [x] Live curl GET /health → 200 with CORS headers
- [x] Live curl 404 path → 404 with CORS headers
- [ ] Lens in-browser /capture smoke test (Aaron to confirm once merged)

### Curl reproducer
```
curl -i -X OPTIONS http://localhost:3200/v1/audio/transcriptions \
  -H "Origin: https://example.com" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: Content-Type"
```
Returns `HTTP/1.1 204 No Content` with `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: POST, GET, OPTIONS`, `Access-Control-Allow-Headers: Content-Type, Authorization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)