### PR TITLE
feat: register scribe in ~/.parachute/services.json on serve

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,8 @@ import { transcribers, cleaners, getProvider } from "./providers.ts";
 import { loadConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
 import { preflight, withCors } from "./cors.ts";
+import { upsertService } from "./services-manifest.ts";
+import pkg from "../package.json" with { type: "json" };
 
 export async function startServer() {
   const config = await loadConfig();
@@ -29,6 +31,20 @@ export async function startServer() {
       return withCors(await route(req));
     },
   });
+
+  try {
+    upsertService({
+      name: "parachute-scribe",
+      port: PORT,
+      paths: ["/"],
+      health: "/health",
+      version: pkg.version,
+    });
+  } catch (err) {
+    console.warn(
+      `scribe: skipped services manifest update: ${err instanceof Error ? err.message : err}`,
+    );
+  }
 
   async function route(req: Request): Promise<Response> {
     const url = new URL(req.url);

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveManifestPath, upsertService, type ServiceEntry } from "./services-manifest.ts";
+
+const SCRIBE_ENTRY: ServiceEntry = {
+  name: "parachute-scribe",
+  port: 3200,
+  paths: ["/"],
+  health: "/health",
+  version: "0.1.0",
+};
+
+describe("services-manifest", () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-manifest-"));
+    path = join(dir, "services.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("creates manifest with single entry when file does not exist", () => {
+    upsertService(SCRIBE_ENTRY, path);
+    const got = JSON.parse(readFileSync(path, "utf8"));
+    expect(got.services).toHaveLength(1);
+    expect(got.services[0]).toEqual(SCRIBE_ENTRY);
+  });
+
+  test("updates existing entry by name (idempotent second start)", () => {
+    upsertService(SCRIBE_ENTRY, path);
+    upsertService({ ...SCRIBE_ENTRY, port: 3300, version: "0.2.0" }, path);
+    const got = JSON.parse(readFileSync(path, "utf8"));
+    expect(got.services).toHaveLength(1);
+    expect(got.services[0].port).toBe(3300);
+    expect(got.services[0].version).toBe("0.2.0");
+  });
+
+  test("preserves entries owned by other services", () => {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        services: [
+          { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "1.0.0" },
+        ],
+      }),
+    );
+    upsertService(SCRIBE_ENTRY, path);
+    const got = JSON.parse(readFileSync(path, "utf8"));
+    expect(got.services).toHaveLength(2);
+    const vault = got.services.find((s: ServiceEntry) => s.name === "parachute-vault");
+    const scribe = got.services.find((s: ServiceEntry) => s.name === "parachute-scribe");
+    expect(vault?.port).toBe(1940);
+    expect(scribe?.port).toBe(3200);
+  });
+
+  test("throws on malformed manifest rather than clobbering it", () => {
+    writeFileSync(path, "not json at all");
+    expect(() => upsertService(SCRIBE_ENTRY, path)).toThrow();
+  });
+
+  test("resolveManifestPath honors PARACHUTE_HOME", () => {
+    const orig = process.env.PARACHUTE_HOME;
+    process.env.PARACHUTE_HOME = "/opt/parachute";
+    try {
+      expect(resolveManifestPath()).toBe("/opt/parachute/services.json");
+    } finally {
+      if (orig === undefined) delete process.env.PARACHUTE_HOME;
+      else process.env.PARACHUTE_HOME = orig;
+    }
+  });
+});

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -1,0 +1,43 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface ServiceEntry {
+  name: string;
+  port: number;
+  paths: string[];
+  health: string;
+  version: string;
+}
+
+interface ServicesManifest {
+  services: ServiceEntry[];
+}
+
+export function resolveManifestPath(): string {
+  const base = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+  return join(base, "services.json");
+}
+
+function readManifest(path: string): ServicesManifest {
+  if (!existsSync(path)) return { services: [] };
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  if (!raw || typeof raw !== "object" || !Array.isArray((raw as { services?: unknown }).services)) {
+    throw new Error(`services manifest at ${path} is malformed (missing "services" array)`);
+  }
+  return raw as ServicesManifest;
+}
+
+export function upsertService(
+  entry: ServiceEntry,
+  path: string = resolveManifestPath(),
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const manifest = readManifest(path);
+  const idx = manifest.services.findIndex((s) => s.name === entry.name);
+  if (idx >= 0) manifest.services[idx] = entry;
+  else manifest.services.push(entry);
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`);
+  renameSync(tmp, path);
+}


### PR DESCRIPTION
## Summary
- New `src/services-manifest.ts` with `resolveManifestPath()` and `upsertService()`. Atomic write (tmp + rename), upsert-by-name only, creates `{services: []}` if the file is missing, preserves entries owned by other services.
- Wires into `startServer()` after `Bun.serve` — every `scribe serve` upserts scribe's entry (port reflects the actual `PORT` in use, version from `package.json`).
- Schema matches the shape locked in by parachute-cli PR 1: `{name, port, paths, health, version}`.
- `src/services-manifest.test.ts`: 5 unit tests (create, update-in-place, preserve siblings, malformed throws, PARACHUTE_HOME resolution).
- No cross-package import — the write logic is duplicated tiny + intentionally minimal, per the brief.

## Why
Aaron greenlit a trimmed parachute CLI (install / status / expose) pre-launch. The coordinator reads `~/.parachute/services.json` (or `$PARACHUTE_HOME/services.json` in Docker) to know what's installed. Each service owns its own entry — scribe needs to register itself so `parachute status` surfaces it accurately.

## Behavior details
- Path: `$PARACHUTE_HOME/services.json` if the env var is set (Docker path), else `~/.parachute/services.json`.
- Idempotent: re-running `scribe serve` with a different `PORT` rewrites scribe's entry in place; other services' entries are untouched.
- Non-fatal: if the manifest write fails (permissions, malformed existing file), scribe logs a warning and keeps serving. Refusing to clobber a malformed manifest is intentional — protects other services' entries at the cost of the CLI briefly not seeing scribe.

## Test plan
- [x] `bun test` → 15/15 pass (5 new manifest tests + existing CORS + vault suites)
- [x] `bunx tsc --noEmit` clean (exit 0)
- [x] Live smoke via `PARACHUTE_HOME=/tmp/... PORT=3298 bun run src/cli.ts serve` → writes correct JSON on first start
- [x] Restart with `PORT=3297` → single entry's port updated in place (idempotent upsert confirmed)
- [ ] `parachute status` sees scribe after merge (Aaron / CLI pod to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)