### PR TITLE
chore: rename bin scribe → parachute-scribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Audio (wav/mp3/m4a) --> Transcription engine --> Raw text --> LLM cleanup (optio
 ## CLI
 
 ```bash
-scribe <file>                             # Transcribe a file
-scribe <file> --cleanup claude            # Transcribe + LLM cleanup
-scribe <file> --transcribe groq           # Use a specific transcription provider
-scribe <file> --no-cleanup                # Skip cleanup even if configured
-scribe <file> --json                      # Output JSON: {"text": "..."}
-scribe serve                              # Start HTTP server (port 3200)
-scribe providers                          # List available providers
+parachute-scribe <file>                   # Transcribe a file
+parachute-scribe <file> --cleanup claude  # Transcribe + LLM cleanup
+parachute-scribe <file> --transcribe groq # Use a specific transcription provider
+parachute-scribe <file> --no-cleanup      # Skip cleanup even if configured
+parachute-scribe <file> --json            # Output JSON: {"text": "..."}
+parachute-scribe serve                    # Start HTTP server (port 3200)
+parachute-scribe providers                # List available providers
 ```
 
 ## Library

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "license": "AGPL-3.0",
   "bin": {
-    "scribe": "src/cli.ts"
+    "parachute-scribe": "src/cli.ts"
   },
   "scripts": {
     "start": "bun run src/cli.ts serve"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,12 +18,12 @@ function hasFlag(flag: string): boolean {
 }
 
 function usage() {
-  console.log(`scribe — audio transcription + LLM cleanup
+  console.log(`parachute-scribe — audio transcription + LLM cleanup
 
 Usage:
-  scribe <file>                       Transcribe an audio file
-  scribe serve                        Start the HTTP server
-  scribe providers                    List available providers
+  parachute-scribe <file>             Transcribe an audio file
+  parachute-scribe serve              Start the HTTP server
+  parachute-scribe providers          List available providers
 
 Options:
   --transcribe <provider>             Transcription provider (default: parakeet-mlx)
@@ -39,10 +39,10 @@ Environment:
   PORT                                Server port (default: 3200)
 
 Examples:
-  scribe recording.wav
-  scribe meeting.m4a --cleanup claude
-  scribe memo.mp3 --transcribe groq --cleanup ollama
-  scribe serve
+  parachute-scribe recording.wav
+  parachute-scribe meeting.m4a --cleanup claude
+  parachute-scribe memo.mp3 --transcribe groq --cleanup ollama
+  parachute-scribe serve
 `);
 }
 


### PR DESCRIPTION
## Summary
- `package.json`: `bin.scribe` → `bin.parachute-scribe` (no other package-name changes — npm package stays `@openparachute/scribe`, repo stays `parachute-scribe`).
- `src/cli.ts`: `usage()` header + every example in the help text updated to `parachute-scribe`.
- `README.md`: CLI invocation block rewritten with `parachute-scribe`. `bun src/cli.ts ...` dev-invocation snippets elsewhere left untouched.

## Why
parachute CLI's `start`/`stop`/`restart`/`logs` lifecycle (PR 6) hardcodes `parachute-<service> <subcommand>` as the invocation pattern. Vault already moved to `parachute-vault`; scribe follows for ecosystem consistency. Services manifest entry was already `parachute-scribe`, so coordination with the CLI is unchanged.

## No backcompat shim
Scribe isn't on npm under any version yet, so there are no deployed users of the old `scribe` binary. Clean rename, zero compat burden.

## Test plan
- [x] `bun test` → 15/15 pass (tests invoke through `bun:test`, not the renamed binary)
- [x] `bunx tsc --noEmit` exit 0
- [x] `bun run src/cli.ts --help` prints `parachute-scribe` in header + all examples
- [x] `package.json` `start` script untouched (`bun run src/cli.ts serve`) — invokes via bun, not the bin
- [ ] After merge: `parachute start scribe` picks up the renamed bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)