### PR TITLE
feat: move config to ~/.parachute/scribe/config.json + auto-migrate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,9 @@ PORT=3200
 
 # --- Optional: vault-aware proper-noun injection ---
 # Point scribe at a Parachute Vault for person/project context.
-# Copy scribe.config.example.json to scribe.config.json and edit,
+# Copy scribe.config.example.json to ~/.parachute/scribe/config.json and edit,
 # or set SCRIBE_CONFIG to a custom path.
-# SCRIBE_CONFIG=./scribe.config.json
+# SCRIBE_CONFIG=/path/to/config.json
 
 # Gemini
 # GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ PORT=3200                            # HTTP server port
 
 Point scribe at a [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) and the cleanup pass will learn the proper nouns you care about — correcting mishearings ("learn by build" → "Learn Vibe Build") and wrapping matches in `[[wikilinks]]` so transcribed memos land pre-linked in your graph.
 
-Copy `scribe.config.example.json` to `scribe.config.json` and edit:
+Copy `scribe.config.example.json` to `~/.parachute/scribe/config.json` (or `$PARACHUTE_HOME/scribe/config.json`) and edit:
 
 ```json
 {
@@ -157,7 +157,7 @@ Copy `scribe.config.example.json` to `scribe.config.json` and edit:
 
 Scribe fetches the proper-noun list once per `cache_ttl_seconds` (default 300) and injects it into the cleanup prompt. If the vault is unreachable, cleanup still runs — just without the context.
 
-Set `SCRIBE_CONFIG=/path/to/scribe.config.json` (or pass `--config <path>` on the CLI) to point at a non-default location.
+Default config path is `${PARACHUTE_HOME:-~/.parachute}/scribe/config.json`. Set `SCRIBE_CONFIG=/path/to/config.json` (or pass `--config <path>` on the CLI) to point somewhere else. An older `~/.parachute/scribe.config.json` is auto-migrated to the new path on first run.
 
 ## How vault uses scribe
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,8 @@ Options:
 Environment:
   TRANSCRIBE_PROVIDER                 Default transcription provider
   CLEANUP_PROVIDER                    Default cleanup provider
-  SCRIBE_CONFIG                       Path to scribe.config.json (default: ./scribe.config.json)
+  SCRIBE_CONFIG                       Path to config.json (default: ~/.parachute/scribe/config.json)
+  PARACHUTE_HOME                      Override ~/.parachute base (e.g. Docker: /app/.parachute)
   PORT                                Server port (default: 3200)
 
 Examples:

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, resolveDefaultConfigPath } from "./config.ts";
+
+describe("config loading + legacy migration", () => {
+  let home: string;
+  let prevCwd: string;
+  let prevHome: string | undefined;
+  let prevScribeCfg: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "scribe-home-"));
+    prevCwd = process.cwd();
+    prevHome = process.env.PARACHUTE_HOME;
+    prevScribeCfg = process.env.SCRIBE_CONFIG;
+    process.env.PARACHUTE_HOME = home;
+    delete process.env.SCRIBE_CONFIG;
+    process.chdir(home);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(home, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.PARACHUTE_HOME;
+    else process.env.PARACHUTE_HOME = prevHome;
+    if (prevScribeCfg === undefined) delete process.env.SCRIBE_CONFIG;
+    else process.env.SCRIBE_CONFIG = prevScribeCfg;
+  });
+
+  test("resolveDefaultConfigPath honors PARACHUTE_HOME", () => {
+    expect(resolveDefaultConfigPath()).toBe(join(home, "scribe", "config.json"));
+  });
+
+  test("reads from the new canonical path when it exists", async () => {
+    mkdirSync(join(home, "scribe"), { recursive: true });
+    writeFileSync(
+      join(home, "scribe", "config.json"),
+      JSON.stringify({ cleanup: { provider: "claude" } }),
+    );
+    const cfg = await loadConfig();
+    expect(cfg.cleanup?.provider).toBe("claude");
+  });
+
+  test("migrates legacy config on first load and reads contents", async () => {
+    const legacy = join(home, "scribe.config.json");
+    const canonical = join(home, "scribe", "config.json");
+    writeFileSync(legacy, JSON.stringify({ cleanup: { provider: "ollama" } }));
+
+    const cfg = await loadConfig();
+
+    expect(cfg.cleanup?.provider).toBe("ollama");
+    expect(existsSync(legacy)).toBe(false);
+    expect(existsSync(canonical)).toBe(true);
+    expect(JSON.parse(readFileSync(canonical, "utf8"))).toEqual({
+      cleanup: { provider: "ollama" },
+    });
+  });
+
+  test("migration is idempotent across repeated loads", async () => {
+    const legacy = join(home, "scribe.config.json");
+    writeFileSync(legacy, JSON.stringify({ cleanup: { provider: "claude" } }));
+    await loadConfig();
+    const cfg = await loadConfig();
+    expect(cfg.cleanup?.provider).toBe("claude");
+    expect(existsSync(legacy)).toBe(false);
+  });
+
+  test("when both paths exist, new path wins and legacy is left in place", async () => {
+    mkdirSync(join(home, "scribe"), { recursive: true });
+    writeFileSync(
+      join(home, "scribe", "config.json"),
+      JSON.stringify({ cleanup: { provider: "new" } }),
+    );
+    const legacy = join(home, "scribe.config.json");
+    writeFileSync(legacy, JSON.stringify({ cleanup: { provider: "legacy" } }));
+
+    const cfg = await loadConfig();
+
+    expect(cfg.cleanup?.provider).toBe("new");
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  test("explicit --config path does not trigger migration", async () => {
+    const explicit = join(home, "custom.json");
+    writeFileSync(explicit, JSON.stringify({ cleanup: { provider: "explicit" } }));
+    const legacy = join(home, "scribe.config.json");
+    writeFileSync(legacy, JSON.stringify({ cleanup: { provider: "legacy" } }));
+
+    const cfg = await loadConfig(explicit);
+
+    expect(cfg.cleanup?.provider).toBe("explicit");
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  test("returns empty config when nothing is present", async () => {
+    const cfg = await loadConfig();
+    expect(cfg).toEqual({});
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
 export type VaultContext = {
   tag: string;
   exclude_tag?: string | string[];
@@ -21,20 +25,49 @@ export type ScribeConfig = {
   };
 };
 
-export async function loadConfig(path?: string): Promise<ScribeConfig> {
-  const configPath = path ?? process.env.SCRIBE_CONFIG;
-  const candidates = configPath ? [configPath] : ["./scribe.config.json"];
+function parachuteHome(): string {
+  return process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+}
 
-  for (const p of candidates) {
-    const file = Bun.file(p);
-    if (await file.exists()) {
-      try {
-        return (await file.json()) as ScribeConfig;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to parse config ${p}: ${message}`);
-      }
-    }
+export function resolveDefaultConfigPath(): string {
+  return join(parachuteHome(), "scribe", "config.json");
+}
+
+function legacyConfigPath(): string {
+  return join(parachuteHome(), "scribe.config.json");
+}
+
+function migrateLegacyConfig(canonical: string): void {
+  const legacy = legacyConfigPath();
+  if (!existsSync(legacy) || existsSync(canonical)) return;
+  mkdirSync(dirname(canonical), { recursive: true });
+  renameSync(legacy, canonical);
+  console.log(`scribe: migrated config ${legacy} → ${canonical}`);
+}
+
+async function readJsonConfig(path: string): Promise<ScribeConfig | undefined> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return undefined;
+  try {
+    return (await file.json()) as ScribeConfig;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse config ${path}: ${message}`);
+  }
+}
+
+export async function loadConfig(path?: string): Promise<ScribeConfig> {
+  const explicit = path ?? process.env.SCRIBE_CONFIG;
+  if (explicit) {
+    return (await readJsonConfig(explicit)) ?? {};
+  }
+
+  const canonical = resolveDefaultConfigPath();
+  migrateLegacyConfig(canonical);
+
+  for (const candidate of [canonical, "./scribe.config.json"]) {
+    const result = await readJsonConfig(candidate);
+    if (result !== undefined) return result;
   }
 
   return {};


### PR DESCRIPTION
## Summary
- New canonical config path: `${PARACHUTE_HOME:-~/.parachute}/scribe/config.json`. Matches the per-service layout every other Parachute service follows.
- Legacy `~/.parachute/scribe.config.json` is auto-migrated (filesystem `rename`) on first `loadConfig()` — contents preserved, new parent dir created as needed.
- Preserves existing overrides: explicit `--config <path>` and `SCRIBE_CONFIG=...` win over the canonical path and do **not** trigger migration.
- Preserves the CWD `./scribe.config.json` dev fallback (last-resort candidate when neither override nor canonical exists).
- Picks up `PARACHUTE_HOME` for Docker / tailnet use; scribe already read it in `services-manifest.ts`, now config respects it too.

## Why
Scribe's config was sitting flat at the ecosystem root — out of convention and the kind of stray file the upcoming `parachute migrate` would otherwise archive. Having scribe own its own move is more modular than teaching the CLI about scribe's specific filename.

## Candidate order (no explicit override)
1. `${PARACHUTE_HOME:-~/.parachute}/scribe/config.json` — canonical
2. `${PARACHUTE_HOME:-~/.parachute}/scribe.config.json` — legacy; if found here alone, migrate to (1) then read
3. `./scribe.config.json` — CWD dev fallback
4. `{}`

When both (1) and (2) exist, (1) wins and the legacy file is left in place — the user or `parachute migrate` can clean it up; scribe won't overwrite a possibly-edited canonical with old data.

## Test plan
- [x] `bun test` 22/22 pass (7 new config tests + existing suites)
- [x] `bunx tsc --noEmit` exit 0
- [x] Live smoke: dropped a legacy `scribe.config.json` under a fresh `$PARACHUTE_HOME` tmpdir, ran `loadConfig()` once — file moved to `scribe/config.json`, contents preserved, log line emitted, idempotent on repeat
- [ ] After merge: vault's filesystem-hygiene PR + CLI's `parachute migrate` PR see a clean ecosystem root for scribe

## Test coverage
- Canonical path read when new file exists
- Legacy read + migration moves file, preserves contents
- Migration idempotent across repeated loads
- Both-exist: new path wins, legacy untouched
- Explicit `--config` path does not trigger migration
- `PARACHUTE_HOME` resolution
- Empty `{}` fallback when nothing present

## Docs touched
- `README.md`: config setup block + SCRIBE_CONFIG line updated with the new canonical path and migration note
- `src/cli.ts` `usage()`: environment block lists new default + `PARACHUTE_HOME`
- `.env.example`: updated instruction + example path

`CLAUDE.md` didn't reference the config path, no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)