### PR TITLE
feat: hub parity — /.parachute/info + port 1943 + enriched services entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ TRANSCRIBE_PROVIDER=parakeet-mlx
 # Cleanup provider: claude | ollama | openai | gemini | groq | custom | none
 CLEANUP_PROVIDER=none
 
-# Server port
-PORT=3200
+# Server port (PORT also honored for back-compat; SCRIBE_PORT takes precedence)
+SCRIBE_PORT=1943
 
 # --- Transcription provider config ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ parachute-scribe <file> --cleanup claude  # Transcribe + LLM cleanup
 parachute-scribe <file> --transcribe groq # Use a specific transcription provider
 parachute-scribe <file> --no-cleanup      # Skip cleanup even if configured
 parachute-scribe <file> --json            # Output JSON: {"text": "..."}
-parachute-scribe serve                    # Start HTTP server (port 3200)
+parachute-scribe serve                    # Start HTTP server (port 1943)
 parachute-scribe providers                # List available providers
 ```
 
@@ -132,7 +132,7 @@ CUSTOM_CLEANUP_API_KEY=...
 CUSTOM_CLEANUP_MODEL=...
 
 # Server
-PORT=3200                            # HTTP server port
+SCRIBE_PORT=1943                     # HTTP server port (PORT also honored for back-compat)
 ```
 
 ## Vault-aware cleanup (optional)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,7 @@ Environment:
   CLEANUP_PROVIDER                    Default cleanup provider
   SCRIBE_CONFIG                       Path to config.json (default: ~/.parachute/scribe/config.json)
   PARACHUTE_HOME                      Override ~/.parachute base (e.g. Docker: /app/.parachute)
-  PORT                                Server port (default: 3200)
+  SCRIBE_PORT                         Server port (default: 1943; PORT also honored)
 
 Examples:
   parachute-scribe recording.wav

--- a/src/parachute-info.test.ts
+++ b/src/parachute-info.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_PORT,
+  DISPLAY_NAME,
+  MOUNT_PATH,
+  SERVICE_NAME,
+  TAGLINE,
+  handleParachuteIcon,
+  handleParachuteInfo,
+} from "./parachute-info.ts";
+import pkg from "../package.json" with { type: "json" };
+
+describe("parachute-info", () => {
+  test("DEFAULT_PORT is 1943 (canonical scribe port in the 1939–1949 band)", () => {
+    expect(DEFAULT_PORT).toBe(1943);
+  });
+
+  test("handleParachuteInfo returns correct shape", async () => {
+    const res = handleParachuteInfo();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    const body = await res.json();
+    expect(body).toEqual({
+      name: SERVICE_NAME,
+      displayName: DISPLAY_NAME,
+      tagline: TAGLINE,
+      version: pkg.version,
+      iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
+    });
+  });
+
+  test("handleParachuteIcon returns SVG with correct headers", async () => {
+    const res = handleParachuteIcon();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+    const body = await res.text();
+    expect(body).toContain("<svg");
+    expect(body).toContain("</svg>");
+    expect(body).toContain(">S<");
+  });
+});

--- a/src/parachute-info.ts
+++ b/src/parachute-info.ts
@@ -1,0 +1,28 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const SERVICE_NAME = "parachute-scribe";
+export const DISPLAY_NAME = "Scribe";
+export const TAGLINE = "Audio transcription (Whisper-compatible API + LLM cleanup)";
+export const MOUNT_PATH = "/scribe";
+export const DEFAULT_PORT = 1943;
+
+const ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="30" fill="#6A9B77"/><text x="32" y="43" text-anchor="middle" font-family="system-ui,sans-serif" font-size="32" font-weight="600" fill="#FAFAF7">S</text></svg>`;
+
+export function handleParachuteInfo(): Response {
+  return Response.json({
+    name: SERVICE_NAME,
+    displayName: DISPLAY_NAME,
+    tagline: TAGLINE,
+    version: pkg.version,
+    iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
+  });
+}
+
+export function handleParachuteIcon(): Response {
+  return new Response(ICON_SVG, {
+    headers: {
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,15 @@ import { loadConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
 import { preflight, withCors } from "./cors.ts";
 import { upsertService } from "./services-manifest.ts";
+import {
+  DEFAULT_PORT,
+  DISPLAY_NAME,
+  MOUNT_PATH,
+  SERVICE_NAME,
+  TAGLINE,
+  handleParachuteIcon,
+  handleParachuteInfo,
+} from "./parachute-info.ts";
 import pkg from "../package.json" with { type: "json" };
 
 export async function startServer() {
@@ -10,7 +19,7 @@ export async function startServer() {
 
   const TRANSCRIBE = config.transcribe?.provider ?? process.env.TRANSCRIBE_PROVIDER ?? "parakeet-mlx";
   const CLEANUP = config.cleanup?.provider ?? process.env.CLEANUP_PROVIDER ?? "none";
-  const PORT = Number(process.env.PORT ?? 3200);
+  const PORT = Number(process.env.SCRIBE_PORT ?? process.env.PORT ?? DEFAULT_PORT);
   const CLEANUP_DEFAULT = config.cleanup?.default ?? true;
 
   const transcribe = getProvider(transcribers, TRANSCRIBE, "transcription");
@@ -34,11 +43,13 @@ export async function startServer() {
 
   try {
     upsertService({
-      name: "parachute-scribe",
+      name: SERVICE_NAME,
       port: PORT,
-      paths: ["/"],
+      paths: [MOUNT_PATH],
       health: "/health",
       version: pkg.version,
+      displayName: DISPLAY_NAME,
+      tagline: TAGLINE,
     });
   } catch (err) {
     console.warn(
@@ -48,6 +59,13 @@ export async function startServer() {
 
   async function route(req: Request): Promise<Response> {
     const url = new URL(req.url);
+
+    if (url.pathname === "/.parachute/info" || url.pathname === "/.parachute/icon.svg") {
+      if (req.method !== "GET") {
+        return Response.json({ error: "Method not allowed" }, { status: 405 });
+      }
+      return url.pathname === "/.parachute/info" ? handleParachuteInfo() : handleParachuteIcon();
+    }
 
     if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
       return handleTranscription(req);

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -6,10 +6,12 @@ import { resolveManifestPath, upsertService, type ServiceEntry } from "./service
 
 const SCRIBE_ENTRY: ServiceEntry = {
   name: "parachute-scribe",
-  port: 3200,
-  paths: ["/"],
+  port: 1943,
+  paths: ["/scribe"],
   health: "/health",
   version: "0.1.0",
+  displayName: "Scribe",
+  tagline: "Audio transcription (Whisper-compatible API + LLM cleanup)",
 };
 
 describe("services-manifest", () => {
@@ -34,11 +36,21 @@ describe("services-manifest", () => {
 
   test("updates existing entry by name (idempotent second start)", () => {
     upsertService(SCRIBE_ENTRY, path);
-    upsertService({ ...SCRIBE_ENTRY, port: 3300, version: "0.2.0" }, path);
+    upsertService({ ...SCRIBE_ENTRY, port: 1944, version: "0.2.0" }, path);
     const got = JSON.parse(readFileSync(path, "utf8"));
     expect(got.services).toHaveLength(1);
-    expect(got.services[0].port).toBe(3300);
+    expect(got.services[0].port).toBe(1944);
     expect(got.services[0].version).toBe("0.2.0");
+  });
+
+  test("persists paths, displayName, and tagline fields", () => {
+    upsertService(SCRIBE_ENTRY, path);
+    const got = JSON.parse(readFileSync(path, "utf8"));
+    expect(got.services[0].paths).toEqual(["/scribe"]);
+    expect(got.services[0].displayName).toBe("Scribe");
+    expect(got.services[0].tagline).toBe(
+      "Audio transcription (Whisper-compatible API + LLM cleanup)",
+    );
   });
 
   test("preserves entries owned by other services", () => {
@@ -56,7 +68,7 @@ describe("services-manifest", () => {
     const vault = got.services.find((s: ServiceEntry) => s.name === "parachute-vault");
     const scribe = got.services.find((s: ServiceEntry) => s.name === "parachute-scribe");
     expect(vault?.port).toBe(1940);
-    expect(scribe?.port).toBe(3200);
+    expect(scribe?.port).toBe(1943);
   });
 
   test("throws on malformed manifest rather than clobbering it", () => {

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -8,6 +8,8 @@ export interface ServiceEntry {
   paths: string[];
   health: string;
   version: string;
+  displayName?: string;
+  tagline?: string;
 }
 
 interface ServicesManifest {


### PR DESCRIPTION
## Summary
Brings scribe to parity with the vault hub contract (vault PR #143) so the CLI hub can render a scribe tile without hardcoding any copy.

## Three things in one PR

### 1. `/.parachute/info` + `/.parachute/icon.svg`
New module `src/parachute-info.ts` holds display copy + the SVG as constants. Server wires two routes:

- `GET /.parachute/info` → `{ name, displayName, tagline, version, iconUrl }`
  ```json
  {
    "name": "parachute-scribe",
    "displayName": "Scribe",
    "tagline": "Audio transcription (Whisper-compatible API + LLM cleanup)",
    "version": "0.1.0",
    "iconUrl": "/scribe/.parachute/icon.svg"
  }
  ```
- `GET /.parachute/icon.svg` → 64×64 monogram ("S" on a sage-green circle, `#6A9B77` / `#FAFAF7` — same palette family as vault's `#879B7E`, differentiated enough to read as a distinct tile). `content-type: image/svg+xml`, `cache-control: public, max-age=3600`.
- Non-GET on either path → `405 Method Not Allowed`. CORS `*` comes for free from the existing `withCors` wrapper.
- SVG is inline (no filesystem dep) so the endpoint works on a pristine install.

### 2. Default port 3200 → 1943
Part of the 1939–1949 Parachute band (1940 vault, 1941 channel, 1942 notes, **1943 scribe**). `const DEFAULT_PORT = 1943` lives in `parachute-info.ts` alongside other service-identity constants.

Env precedence: `SCRIBE_PORT` > `PORT` > `1943`. `PORT` kept as a back-compat fallback since it's the convention on several PaaS platforms — named port is primary, generic port is last-resort.

### 3. Enriched `services.json` entry
`ServiceEntry` gains optional `displayName` and `tagline` fields (shared ABI with vault/notes). Scribe's entry now writes:
```json
{
  "name": "parachute-scribe",
  "port": 1943,
  "paths": ["/scribe"],
  "health": "/health",
  "version": "0.1.0",
  "displayName": "Scribe",
  "tagline": "Audio transcription (Whisper-compatible API + LLM cleanup)"
}
```
`paths: ["/scribe"]` replaces the previous `["/"]` so `parachute expose` mounts scribe at `/scribe/`.

## Out of scope (unchanged)
- Transcription pipeline, CORS policy, auth, config shape.
- Config-path migration (PR #10).
- npm publish prep.

## Test plan
- [x] `bun test` 26/26 pass (3 new parachute-info tests + services-manifest test refreshed for new shape + existing suites)
- [x] `bunx tsc --noEmit` exit 0
- [x] Live `SCRIBE_PORT=1943 bun run src/cli.ts serve`:
  - `GET /.parachute/info` → 200, exact JSON shape ✓
  - `GET /.parachute/icon.svg` → 200, `content-type: image/svg+xml`, 245-byte inline SVG ✓
  - `POST /.parachute/info` → 405 ✓
  - `services.json` entry contains paths/displayName/tagline after startup ✓
- [ ] After merge: CLI hub picks up scribe tile, `parachute expose` mounts at `/scribe/`

## Docs
- `README.md`: port line updated (3200 → 1943), env section updated to `SCRIBE_PORT`
- `src/cli.ts` `usage()`: `SCRIBE_PORT` primary, `PORT` legacy
- `.env.example`: `SCRIBE_PORT=1943` with back-compat note

🤖 Generated with [Claude Code](https://claude.com/claude-code)