### PR TITLE
feat: add kind: "api" to /.parachute/info response

### DIFF
--- a/src/parachute-info.test.ts
+++ b/src/parachute-info.test.ts
@@ -24,6 +24,7 @@ describe("parachute-info", () => {
       name: SERVICE_NAME,
       displayName: DISPLAY_NAME,
       tagline: TAGLINE,
+      kind: "api",
       version: pkg.version,
       iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
     });

--- a/src/parachute-info.ts
+++ b/src/parachute-info.ts
@@ -13,6 +13,7 @@ export function handleParachuteInfo(): Response {
     name: SERVICE_NAME,
     displayName: DISPLAY_NAME,
     tagline: TAGLINE,
+    kind: "api",
     version: pkg.version,
     iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
   });


### PR DESCRIPTION
## Summary

- Adds `kind: "api"` to the `/.parachute/info` response so the hub renders scribe as a non-clickable API card that expands in place, rather than the default clickable/navigate `"frontend"` treatment.
- Additive — no existing consumer relies on the field's absence; `"frontend"` remains the default when the field is missing.

## Test plan

- [x] `bun test` → 26/26 pass
- [x] `bunx tsc --noEmit` → clean
- [x] Live smoke: `SCRIBE_PORT=1943 bun src/cli.ts serve` → `curl http://localhost:1943/.parachute/info` returns `"kind":"api"` alongside existing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)