### PR TITLE
feat: add /.parachute/config + /.parachute/config/schema endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,18 @@ Response: `{ "text": "..." }`
 Other endpoints:
 
 ```
-GET  /v1/models    # List available transcription providers
-GET  /health       # Health check
+GET  /v1/models                    # List available transcription providers
+GET  /health                       # Health check
+GET  /.parachute/info              # Module identity (name, version, icon, kind)
+GET  /.parachute/icon.svg          # Inline SVG icon
+GET  /.parachute/config/schema     # Draft-07 JSON Schema for scribe's config
+GET  /.parachute/config            # Current resolved runtime config values
 ```
+
+Scribe reserves two scopes for future hub-issued-token enforcement:
+`scribe:transcribe` (request-time, per-call) and `scribe:admin` (config writes).
+Neither is enforced yet — scribe is loopback-trusted through launch — but the
+schema declares them under `x-scopes` for forward compat.
 
 ## Transcription providers
 

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { cleaners, transcribers } from "./providers.ts";
+import {
+  SCOPES,
+  buildConfigSchema,
+  handleConfig,
+  handleConfigSchema,
+  type ResolvedConfig,
+} from "./config-schema.ts";
+
+const SAMPLE: ResolvedConfig = {
+  transcribeProvider: "parakeet-mlx",
+  cleanupProvider: "ollama",
+  cleanupDefault: true,
+  port: 1943,
+  vault: {
+    configured: true,
+    url: "http://localhost:1940",
+    cacheTtlSeconds: 300,
+  },
+};
+
+describe("config-schema", () => {
+  test("buildConfigSchema is a valid draft-07 JSON Schema shape", () => {
+    const schema = buildConfigSchema();
+    expect(schema.$schema).toBe("http://json-schema.org/draft-07/schema#");
+    expect(schema.type).toBe("object");
+    expect(schema.title).toBeString();
+    expect(schema.properties).toBeDefined();
+    expect(Object.keys(schema.properties).length).toBeGreaterThan(0);
+  });
+
+  test("schema exposes transcribeProvider + cleanupProvider enums sourced from runtime providers", () => {
+    const schema = buildConfigSchema();
+    const transcribe = schema.properties.transcribeProvider;
+    const cleanup = schema.properties.cleanupProvider;
+    expect(transcribe.enum).toEqual(Object.keys(transcribers).sort());
+    expect(cleanup.enum).toEqual(Object.keys(cleaners).sort());
+    expect(cleanup.enum).toContain("none");
+  });
+
+  test("schema exposes port, cleanupDefault, and vault object", () => {
+    const schema = buildConfigSchema();
+    expect(schema.properties.port.type).toBe("integer");
+    expect(schema.properties.cleanupDefault.type).toBe("boolean");
+    expect(schema.properties.vault.type).toBe("object");
+    expect(schema.properties.vault.properties.url).toBeDefined();
+    expect(schema.properties.vault.properties.cacheTtlSeconds).toBeDefined();
+  });
+
+  test("schema declares scribe:transcribe and scribe:admin scopes via x-scopes", () => {
+    const schema = buildConfigSchema();
+    expect(schema["x-scopes"]).toBeDefined();
+    expect(schema["x-scopes"]).toHaveProperty("scribe:transcribe");
+    expect(schema["x-scopes"]).toHaveProperty("scribe:admin");
+    expect(SCOPES["scribe:transcribe"]).toBeString();
+    expect(SCOPES["scribe:admin"]).toBeString();
+  });
+
+  test("handleConfigSchema returns the schema as JSON", async () => {
+    const res = handleConfigSchema();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    const body = await res.json();
+    expect(body).toEqual(buildConfigSchema());
+  });
+
+  test("handleConfig returns the resolved runtime values", async () => {
+    const res = handleConfig(SAMPLE);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    const body = await res.json();
+    expect(body).toEqual(SAMPLE);
+  });
+
+  test("handleConfig reflects an unconfigured vault with nulls", async () => {
+    const res = handleConfig({
+      ...SAMPLE,
+      vault: { configured: false, url: null, cacheTtlSeconds: null },
+    });
+    const body = (await res.json()) as ResolvedConfig;
+    expect(body.vault.configured).toBe(false);
+    expect(body.vault.url).toBeNull();
+    expect(body.vault.cacheTtlSeconds).toBeNull();
+  });
+});

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,0 +1,85 @@
+import { cleaners, transcribers } from "./providers.ts";
+
+export const SCOPES = {
+  "scribe:transcribe": "Submit audio for transcription (request-time, per-call).",
+  "scribe:admin": "Read and write scribe configuration. Reserved — not enforced yet (scribe is loopback-trusted through launch).",
+} as const;
+
+export type ResolvedConfig = {
+  transcribeProvider: string;
+  cleanupProvider: string;
+  cleanupDefault: boolean;
+  port: number;
+  vault: {
+    configured: boolean;
+    url: string | null;
+    cacheTtlSeconds: number | null;
+  };
+};
+
+export function buildConfigSchema() {
+  const transcribeOptions = Object.keys(transcribers).sort();
+  const cleanupOptions = Object.keys(cleaners).sort();
+  return {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://parachute.computer/schemas/scribe/config.json",
+    title: "Scribe configuration",
+    type: "object",
+    properties: {
+      transcribeProvider: {
+        type: "string",
+        enum: transcribeOptions,
+        title: "Transcription provider",
+        description: "Engine used to turn audio into text.",
+      },
+      cleanupProvider: {
+        type: "string",
+        enum: cleanupOptions,
+        title: "LLM cleanup provider",
+        description: 'Optional LLM pass that fixes transcription artifacts — punctuation, filler words, formatting. Use "none" to skip cleanup.',
+      },
+      cleanupDefault: {
+        type: "boolean",
+        title: "Run cleanup by default",
+        description: "When a transcription request omits an explicit cleanup flag, run the cleanup pass anyway.",
+        default: true,
+      },
+      port: {
+        type: "integer",
+        minimum: 1,
+        maximum: 65535,
+        title: "Server port",
+        description: "Port scribe's HTTP server listens on. Default 1943 (Parachute 1939–1949 band). Requires restart to take effect.",
+      },
+      vault: {
+        type: "object",
+        title: "Vault integration",
+        description: "Optional — point scribe at a Parachute Vault so cleanup gets proper-noun context (names, projects, aliases).",
+        properties: {
+          url: {
+            type: "string",
+            format: "uri",
+            title: "Vault URL",
+            description: "Base URL of the Parachute Vault to query.",
+          },
+          cacheTtlSeconds: {
+            type: "integer",
+            minimum: 0,
+            title: "Cache TTL (seconds)",
+            description: "How long to cache the fetched proper-noun list before refetching.",
+            default: 300,
+          },
+        },
+      },
+    },
+    "x-scopes": SCOPES,
+  };
+}
+
+export function handleConfigSchema(): Response {
+  return Response.json(buildConfigSchema());
+}
+
+export function handleConfig(config: ResolvedConfig): Response {
+  return Response.json(config);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,11 @@ import {
   handleParachuteIcon,
   handleParachuteInfo,
 } from "./parachute-info.ts";
+import {
+  type ResolvedConfig,
+  handleConfig,
+  handleConfigSchema,
+} from "./config-schema.ts";
 import pkg from "../package.json" with { type: "json" };
 
 export async function startServer() {
@@ -24,6 +29,18 @@ export async function startServer() {
 
   const transcribe = getProvider(transcribers, TRANSCRIBE, "transcription");
   const cleanup = getProvider(cleaners, CLEANUP, "cleanup");
+
+  const resolvedConfig: ResolvedConfig = {
+    transcribeProvider: TRANSCRIBE,
+    cleanupProvider: CLEANUP,
+    cleanupDefault: CLEANUP_DEFAULT,
+    port: PORT,
+    vault: {
+      configured: Boolean(config.vault?.url),
+      url: config.vault?.url ?? null,
+      cacheTtlSeconds: config.vault?.cache_ttl_seconds ?? null,
+    },
+  };
 
   console.log(`scribe listening on :${PORT}`);
   console.log(`  transcribe: ${TRANSCRIBE}`);
@@ -60,11 +77,15 @@ export async function startServer() {
   async function route(req: Request): Promise<Response> {
     const url = new URL(req.url);
 
-    if (url.pathname === "/.parachute/info" || url.pathname === "/.parachute/icon.svg") {
+    if (url.pathname.startsWith("/.parachute/")) {
       if (req.method !== "GET") {
         return Response.json({ error: "Method not allowed" }, { status: 405 });
       }
-      return url.pathname === "/.parachute/info" ? handleParachuteInfo() : handleParachuteIcon();
+      if (url.pathname === "/.parachute/info") return handleParachuteInfo();
+      if (url.pathname === "/.parachute/icon.svg") return handleParachuteIcon();
+      if (url.pathname === "/.parachute/config/schema") return handleConfigSchema();
+      if (url.pathname === "/.parachute/config") return handleConfig(resolvedConfig);
+      return new Response("Not found", { status: 404 });
     }
 
     if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {


### PR DESCRIPTION
## Summary

Phase 2 module config discovery for scribe. Two read-only endpoints, no PUT:

- **`GET /.parachute/config/schema`** — draft-07 JSON Schema describing scribe's configurable shape (transcribe provider, cleanup provider, cleanup default, port, vault integration). Provider enums are sourced from the runtime provider registries in `providers.ts`, so the schema can't drift from what scribe actually supports.
- **`GET /.parachute/config`** — resolved current runtime values so a hub or CLI can show "here's what scribe is doing right now" without reading the file on disk.

## Scope declaration (forward compat)

Reserved scopes declared under `x-scopes` in the schema doc:

| Scope | Meaning |
|---|---|
| `scribe:transcribe` | Submit audio for transcription (request-time, per-call). |
| `scribe:admin` | Read and write scribe configuration. Reserved — not enforced yet. |

No enforcement wired up — scribe is loopback-trusted through launch. When the hub starts issuing tokens, scribe can check these without an API shape change.

## Phase 3 spec (PUT)

When the writer lands, it should:

- Require `scribe:admin` scope (enforcement lives on the scope-enforcement thread, not here).
- Accept a partial `ResolvedConfig` shape and validate against the schema before write.
- Persist to `~/.parachute/scribe/config.json` atomically (tempfile + rename) — same pattern scribe's services-manifest already uses.
- Return the new resolved config (same shape as `GET /.parachute/config`).
- Note: port changes require restart. PUT should persist but warn in the response body.

## Routing change

All `/.parachute/*` routes now share a single prefix branch in `server.ts`: 405 on non-GET, 404 on unknown subpaths. `info`, `icon.svg`, `config`, `config/schema` are all dispatched from there.

## Test plan

- [x] `bun test` → 33/33 pass (7 new tests in `config-schema.test.ts` covering schema shape, provider enums sourced from runtime, scope declaration, both handlers, and the null-vault case)
- [x] `bunx tsc --noEmit` → clean
- [x] Live smoke against a running server:
  - `GET /.parachute/config/schema` → returns valid draft-07 schema with correct enums and `x-scopes`
  - `GET /.parachute/config` → `{"transcribeProvider":"parakeet-mlx","cleanupProvider":"ollama","cleanupDefault":true,"port":1943,"vault":{"configured":true,"url":"http://localhost:1940","cacheTtlSeconds":300}}`
  - `POST /.parachute/config` → 405 Method not allowed
  - `GET /.parachute/nope` → 404 Not found
  - Existing `/.parachute/info` + `/.parachute/icon.svg` unaffected

## Out of scope

- No PUT / config writer (Phase 3).
- No scope enforcement (separate thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)