### PR TITLE
feat: bearer-token auth gate (SCRIBE_AUTH_TOKEN)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CLEANUP_PROVIDER=none
 # Server port (PORT also honored for back-compat; SCRIBE_PORT takes precedence)
 SCRIBE_PORT=1943
 
+# Auth: if set, require "Authorization: Bearer <token>" on all routes except
+# /health and /.parachute/info. Leave unset for open (loopback-only) deployments.
+# SCRIBE_AUTH_TOKEN=
+
 # --- Transcription provider config ---
 
 # onnx-asr

--- a/README.md
+++ b/README.md
@@ -142,7 +142,27 @@ CUSTOM_CLEANUP_MODEL=...
 
 # Server
 SCRIBE_PORT=1943                     # HTTP server port (PORT also honored for back-compat)
+
+# Auth (optional)
+SCRIBE_AUTH_TOKEN=                   # If set, require Authorization: Bearer <token> on all routes
+                                     # except /health and /.parachute/info. Unset = open (loopback-only).
 ```
+
+## Auth
+
+By default scribe is open — any caller on a network it's bound to can transcribe. For exposed deployments (tailnet, funnel, shared hosts), set `SCRIBE_AUTH_TOKEN` and pass it as `Authorization: Bearer <token>` on every request. `/health` and `/.parachute/info` stay open so liveness probes and module discovery work without a secret.
+
+```bash
+SCRIBE_AUTH_TOKEN=$(openssl rand -hex 32) bun src/cli.ts serve
+```
+
+```bash
+curl -H "Authorization: Bearer $SCRIBE_AUTH_TOKEN" \
+  -F "file=@recording.wav" \
+  http://localhost:1943/v1/audio/transcriptions
+```
+
+401 response shape: `{"error":"unauthorized","message":"SCRIBE_AUTH_TOKEN required"}`. CORS headers are included so browser clients can read the error.
 
 ## Vault-aware cleanup (optional)
 

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  AUTH_EXEMPT_PATHS,
+  enforceAuth,
+  extractBearer,
+  isAuthRequired,
+  unauthorizedResponse,
+  validateToken,
+} from "./auth.ts";
+
+describe("auth", () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+    delete process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  describe("extractBearer", () => {
+    test("pulls the token out of 'Bearer <token>'", () => {
+      expect(extractBearer("Bearer abc123")).toBe("abc123");
+    });
+
+    test("is case-insensitive on the 'Bearer' prefix", () => {
+      expect(extractBearer("bearer abc123")).toBe("abc123");
+      expect(extractBearer("BEARER abc123")).toBe("abc123");
+    });
+
+    test("trims surrounding whitespace on the token", () => {
+      expect(extractBearer("Bearer   abc123  ")).toBe("abc123");
+    });
+
+    test("returns undefined for a missing or malformed header", () => {
+      expect(extractBearer(null)).toBeUndefined();
+      expect(extractBearer(undefined)).toBeUndefined();
+      expect(extractBearer("")).toBeUndefined();
+      expect(extractBearer("abc123")).toBeUndefined();
+      expect(extractBearer("Basic abc123")).toBeUndefined();
+    });
+  });
+
+  describe("validateToken (open mode — SCRIBE_AUTH_TOKEN unset)", () => {
+    test("accepts any token as valid with empty scopes", () => {
+      expect(validateToken(undefined)).toEqual({ valid: true, scopes: [] });
+      expect(validateToken("whatever")).toEqual({ valid: true, scopes: [] });
+    });
+
+    test("isAuthRequired reports false", () => {
+      expect(isAuthRequired()).toBe(false);
+    });
+  });
+
+  describe("validateToken (closed mode — SCRIBE_AUTH_TOKEN set)", () => {
+    beforeEach(() => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    });
+
+    test("rejects a missing token", () => {
+      const result = validateToken(undefined);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toBe("token-required");
+    });
+
+    test("rejects a mismatched token", () => {
+      const result = validateToken("wrong");
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toBe("token-mismatch");
+    });
+
+    test("accepts the matching token and grants scopes", () => {
+      const result = validateToken("s3cret");
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.scopes).toContain("scribe:transcribe");
+        expect(result.scopes).toContain("scribe:admin");
+      }
+    });
+
+    test("isAuthRequired reports true", () => {
+      expect(isAuthRequired()).toBe(true);
+    });
+  });
+
+  describe("enforceAuth middleware", () => {
+    test("exempt paths pass without a token even when auth is required", () => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+      for (const path of AUTH_EXEMPT_PATHS) {
+        const req = new Request(`http://localhost${path}`);
+        expect(enforceAuth(req, path)).toBeNull();
+      }
+    });
+
+    test("returns 401 on non-exempt paths when token is missing", async () => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+      const req = new Request("http://localhost/v1/models");
+      const res = enforceAuth(req, "/v1/models");
+      expect(res).not.toBeNull();
+      expect(res?.status).toBe(401);
+      const body = await res?.json();
+      expect(body).toEqual({ error: "unauthorized", message: "SCRIBE_AUTH_TOKEN required" });
+    });
+
+    test("returns 401 on non-exempt paths when token is wrong", () => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+      const req = new Request("http://localhost/v1/models", {
+        headers: { Authorization: "Bearer nope" },
+      });
+      expect(enforceAuth(req, "/v1/models")?.status).toBe(401);
+    });
+
+    test("returns null on non-exempt paths when token matches", () => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+      const req = new Request("http://localhost/v1/models", {
+        headers: { Authorization: "Bearer s3cret" },
+      });
+      expect(enforceAuth(req, "/v1/models")).toBeNull();
+    });
+
+    test("open mode (SCRIBE_AUTH_TOKEN unset) never challenges", () => {
+      const req = new Request("http://localhost/v1/models");
+      expect(enforceAuth(req, "/v1/models")).toBeNull();
+    });
+  });
+
+  test("unauthorizedResponse shape is stable and CORS-compatible", async () => {
+    const res = unauthorizedResponse();
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    const body = await res.json();
+    expect(body).toEqual({ error: "unauthorized", message: "SCRIBE_AUTH_TOKEN required" });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,44 @@
+/**
+ * Single seam for all authorization decisions. Today: shared-secret bearer
+ * token from SCRIBE_AUTH_TOKEN. Tomorrow (hub-issued JWTs): swap the body
+ * of `validateToken` — callers don't change.
+ */
+
+export type AuthResult =
+  | { valid: true; scopes: readonly string[] }
+  | { valid: false; reason: "token-required" | "token-mismatch" };
+
+export const AUTH_EXEMPT_PATHS = new Set(["/health", "/.parachute/info"]);
+
+export function extractBearer(authHeader: string | null | undefined): string | undefined {
+  if (!authHeader) return undefined;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+export function validateToken(token: string | undefined): AuthResult {
+  const required = process.env.SCRIBE_AUTH_TOKEN;
+  if (!required) return { valid: true, scopes: [] };
+  if (!token) return { valid: false, reason: "token-required" };
+  if (token !== required) return { valid: false, reason: "token-mismatch" };
+  return { valid: true, scopes: ["scribe:transcribe", "scribe:admin"] };
+}
+
+export function isAuthRequired(): boolean {
+  return Boolean(process.env.SCRIBE_AUTH_TOKEN);
+}
+
+export function unauthorizedResponse(): Response {
+  return Response.json(
+    { error: "unauthorized", message: "SCRIBE_AUTH_TOKEN required" },
+    { status: 401 },
+  );
+}
+
+export function enforceAuth(req: Request, pathname: string): Response | null {
+  if (AUTH_EXEMPT_PATHS.has(pathname)) return null;
+  const token = extractBearer(req.headers.get("authorization"));
+  const result = validateToken(token);
+  if (result.valid) return null;
+  return unauthorizedResponse();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,8 @@ Environment:
   SCRIBE_CONFIG                       Path to config.json (default: ~/.parachute/scribe/config.json)
   PARACHUTE_HOME                      Override ~/.parachute base (e.g. Docker: /app/.parachute)
   SCRIBE_PORT                         Server port (default: 1943; PORT also honored)
+  SCRIBE_AUTH_TOKEN                   Require Bearer <token> on all routes except
+                                      /health and /.parachute/info (optional)
 
 Examples:
   parachute-scribe recording.wav

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createFetchHandler, type ServerDeps } from "./server.ts";
+import type { ResolvedConfig } from "./config-schema.ts";
+
+const RESOLVED: ResolvedConfig = {
+  transcribeProvider: "parakeet-mlx",
+  cleanupProvider: "none",
+  cleanupDefault: false,
+  port: 1943,
+  vault: { configured: false, url: null, cacheTtlSeconds: null },
+};
+
+function buildHandler(): (req: Request) => Promise<Response> {
+  const deps: ServerDeps = {
+    transcribe: async () => "stub text",
+    cleanup: async (text) => text,
+    resolvedConfig: RESOLVED,
+    scribeConfig: {},
+  };
+  return createFetchHandler(deps);
+}
+
+describe("createFetchHandler — auth gate", () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  describe("SCRIBE_AUTH_TOKEN unset — open mode", () => {
+    beforeEach(() => {
+      delete process.env.SCRIBE_AUTH_TOKEN;
+    });
+
+    test("any caller can reach /health, /v1/models, /.parachute/config", async () => {
+      const handler = buildHandler();
+      for (const path of ["/health", "/v1/models", "/.parachute/config", "/.parachute/info"]) {
+        const res = await handler(new Request(`http://localhost${path}`));
+        expect(res.status).toBe(200);
+      }
+    });
+  });
+
+  describe("SCRIBE_AUTH_TOKEN set — closed mode", () => {
+    beforeEach(() => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    });
+
+    test("/health passes without a token (exempt — liveness probes)", async () => {
+      const res = await buildHandler()(new Request("http://localhost/health"));
+      expect(res.status).toBe(200);
+    });
+
+    test("/.parachute/info passes without a token (exempt — module identity)", async () => {
+      const res = await buildHandler()(new Request("http://localhost/.parachute/info"));
+      expect(res.status).toBe(200);
+    });
+
+    test("/v1/models returns 401 without a token", async () => {
+      const res = await buildHandler()(new Request("http://localhost/v1/models"));
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({
+        error: "unauthorized",
+        message: "SCRIBE_AUTH_TOKEN required",
+      });
+    });
+
+    test("/.parachute/config returns 401 without a token", async () => {
+      const res = await buildHandler()(new Request("http://localhost/.parachute/config"));
+      expect(res.status).toBe(401);
+    });
+
+    test("/.parachute/config returns 401 on wrong token", async () => {
+      const res = await buildHandler()(
+        new Request("http://localhost/.parachute/config", {
+          headers: { Authorization: "Bearer wrong" },
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    test("/.parachute/config returns 200 on matching token", async () => {
+      const res = await buildHandler()(
+        new Request("http://localhost/.parachute/config", {
+          headers: { Authorization: "Bearer s3cret" },
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(RESOLVED);
+    });
+
+    test("/v1/audio/transcriptions returns 401 without a token", async () => {
+      const form = new FormData();
+      form.set("file", new File(["fake audio"], "test.wav"));
+      const res = await buildHandler()(
+        new Request("http://localhost/v1/audio/transcriptions", {
+          method: "POST",
+          body: form,
+        }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    test("OPTIONS preflight passes through without auth (CORS)", async () => {
+      const res = await buildHandler()(
+        new Request("http://localhost/v1/audio/transcriptions", { method: "OPTIONS" }),
+      );
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+
+    test("401 responses carry CORS headers (browser clients can read the error)", async () => {
+      const res = await buildHandler()(new Request("http://localhost/v1/models"));
+      expect(res.status).toBe(401);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
-import { transcribers, cleaners, getProvider } from "./providers.ts";
-import { loadConfig } from "./config.ts";
+import { cleaners, getProvider, transcribers, type Cleaner } from "./providers.ts";
+import { loadConfig, type ScribeConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
 import { preflight, withCors } from "./cors.ts";
 import { upsertService } from "./services-manifest.ts";
@@ -17,7 +17,86 @@ import {
   handleConfig,
   handleConfigSchema,
 } from "./config-schema.ts";
+import { enforceAuth, isAuthRequired } from "./auth.ts";
 import pkg from "../package.json" with { type: "json" };
+
+export type ServerDeps = {
+  transcribe: (file: File) => Promise<string>;
+  cleanup: Cleaner;
+  resolvedConfig: ResolvedConfig;
+  scribeConfig: ScribeConfig;
+};
+
+export function createFetchHandler(deps: ServerDeps) {
+  return async (req: Request): Promise<Response> => {
+    if (req.method === "OPTIONS") return preflight();
+    const url = new URL(req.url);
+    const authErr = enforceAuth(req, url.pathname);
+    if (authErr) return withCors(authErr);
+    return withCors(await route(req, url, deps));
+  };
+}
+
+async function route(req: Request, url: URL, deps: ServerDeps): Promise<Response> {
+  if (url.pathname.startsWith("/.parachute/")) {
+    if (req.method !== "GET") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (url.pathname === "/.parachute/info") return handleParachuteInfo();
+    if (url.pathname === "/.parachute/icon.svg") return handleParachuteIcon();
+    if (url.pathname === "/.parachute/config/schema") return handleConfigSchema();
+    if (url.pathname === "/.parachute/config") return handleConfig(deps.resolvedConfig);
+    return new Response("Not found", { status: 404 });
+  }
+
+  if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
+    return handleTranscription(req, deps);
+  }
+
+  if (url.pathname === "/health") {
+    return Response.json({ ok: true });
+  }
+
+  if (url.pathname === "/v1/models") {
+    return Response.json({
+      data: [{ id: deps.resolvedConfig.transcribeProvider, object: "model" }],
+    });
+  }
+
+  return new Response("Not found", { status: 404 });
+}
+
+async function handleTranscription(req: Request, deps: ServerDeps): Promise<Response> {
+  const form = await req.formData();
+  const file = form.get("file");
+
+  if (!(file instanceof File)) {
+    return Response.json({ error: "missing 'file' field" }, { status: 400 });
+  }
+
+  const { cleanupProvider, cleanupDefault } = deps.resolvedConfig;
+  const cleanupParam = form.get("cleanup");
+  const doCleanup =
+    cleanupProvider !== "none" &&
+    (cleanupParam === "true" || cleanupParam === "1"
+      ? true
+      : cleanupParam === "false" || cleanupParam === "0"
+        ? false
+        : cleanupDefault);
+
+  try {
+    let text = await deps.transcribe(file);
+    if (doCleanup) {
+      const properNouns = await fetchProperNouns(deps.scribeConfig);
+      text = await deps.cleanup(text, properNouns);
+    }
+    return Response.json({ text });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "transcription failed";
+    console.error("Transcription error:", message);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
 
 export async function startServer() {
   const config = await loadConfig();
@@ -45,17 +124,22 @@ export async function startServer() {
   console.log(`scribe listening on :${PORT}`);
   console.log(`  transcribe: ${TRANSCRIBE}`);
   console.log(`  cleanup:    ${CLEANUP}${CLEANUP !== "none" ? ` (default: ${CLEANUP_DEFAULT})` : ""}`);
+  console.log(`  auth:       ${isAuthRequired() ? "bearer (SCRIBE_AUTH_TOKEN)" : "open"}`);
   if (config.vault?.url && config.vault.contexts?.length) {
     console.log(`  vault:      ${config.vault.url} (${config.vault.contexts.length} contexts)`);
   }
 
+  const handler = createFetchHandler({
+    transcribe,
+    cleanup,
+    resolvedConfig,
+    scribeConfig: config,
+  });
+
   Bun.serve({
     hostname: "0.0.0.0",
     port: PORT,
-    async fetch(req) {
-      if (req.method === "OPTIONS") return preflight();
-      return withCors(await route(req));
-    },
+    fetch: handler,
   });
 
   try {
@@ -72,65 +156,5 @@ export async function startServer() {
     console.warn(
       `scribe: skipped services manifest update: ${err instanceof Error ? err.message : err}`,
     );
-  }
-
-  async function route(req: Request): Promise<Response> {
-    const url = new URL(req.url);
-
-    if (url.pathname.startsWith("/.parachute/")) {
-      if (req.method !== "GET") {
-        return Response.json({ error: "Method not allowed" }, { status: 405 });
-      }
-      if (url.pathname === "/.parachute/info") return handleParachuteInfo();
-      if (url.pathname === "/.parachute/icon.svg") return handleParachuteIcon();
-      if (url.pathname === "/.parachute/config/schema") return handleConfigSchema();
-      if (url.pathname === "/.parachute/config") return handleConfig(resolvedConfig);
-      return new Response("Not found", { status: 404 });
-    }
-
-    if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
-      return handleTranscription(req);
-    }
-
-    if (url.pathname === "/health") {
-      return Response.json({ ok: true });
-    }
-
-    if (url.pathname === "/v1/models") {
-      return Response.json({
-        data: [{ id: TRANSCRIBE, object: "model" }],
-      });
-    }
-
-    return new Response("Not found", { status: 404 });
-  }
-
-  async function handleTranscription(req: Request): Promise<Response> {
-    const form = await req.formData();
-    const file = form.get("file");
-
-    if (!(file instanceof File)) {
-      return Response.json({ error: "missing 'file' field" }, { status: 400 });
-    }
-
-    const cleanupParam = form.get("cleanup");
-    const doCleanup = CLEANUP !== "none" && (
-      cleanupParam === "true" || cleanupParam === "1" ? true :
-      cleanupParam === "false" || cleanupParam === "0" ? false :
-      CLEANUP_DEFAULT
-    );
-
-    try {
-      let text = await transcribe(file);
-      if (doCleanup) {
-        const properNouns = await fetchProperNouns(config);
-        text = await cleanup(text, properNouns);
-      }
-      return Response.json({ text });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "transcription failed";
-      console.error("Transcription error:", message);
-      return Response.json({ error: message }, { status: 500 });
-    }
   }
 }


### PR DESCRIPTION
## Summary

First PR of a three-part sequence that turns scribe into a standalone auth-gated stateless utility. Ships the auth gate and the handler refactor that enables the rest.

- **`SCRIBE_AUTH_TOKEN`** env: when set, require `Authorization: Bearer <token>` on every route except `/health` and `/.parachute/info`. Unset = open (current behavior preserved). Designed for loopback-free deployments (tailnet, funnel).
- 401 body: `{"error":"unauthorized","message":"SCRIBE_AUTH_TOKEN required"}`. Full CORS headers on 401 so browser clients can read the error.
- OPTIONS preflight unaffected.

### Validator seam

All auth decisions go through `validateToken(token) → AuthResult`. Today: string compare. Tomorrow (hub-issued JWTs): swap the body, callers unchanged. Matching tokens grant `scribe:transcribe` and `scribe:admin` scopes (consistent with the `x-scopes` declaration added in #14).

### Refactor: `createFetchHandler(deps)`

The fetch handler is now a pure factory that takes a `ServerDeps` object. `startServer` builds deps and passes the handler to `Bun.serve`. Motivated by this PR (lets auth tests exercise real routing without binding a port) and the next two PRs in the sequence (request context + vault-client removal both need clean dep injection).

### What's next

- **PR 2 — Caller-provided context.** Accept `context` multipart part + `--context <path>` CLI flag. Plumb into the cleanup prompt. Legacy `config.vault` fallback stays with a deprecation warning.
- **PR 3 — Remove built-in vault client.** Delete `src/vault.ts` + `config.vault`; mark schema entry as `removed` for one release.

Ordering lets vault cut over to bearer auth + payload context (PRs 1+2) before scribe rips out the old path (PR 3).

## Test plan

- [x] `bun test` → 59/59 pass (26 new: 16 in `auth.test.ts`, 10 in `server.test.ts`)
- [x] `bunx tsc --noEmit` → clean
- [x] Live smoke, closed mode (`SCRIBE_AUTH_TOKEN=s3cret`):
  - [x] `/health` → 200 without token (exempt)
  - [x] `/.parachute/info` → 200 without token (exempt)
  - [x] `/v1/models` no token → 401 with CORS headers
  - [x] `/v1/models` wrong token → 401
  - [x] `/v1/models` correct token → 200
  - [x] Startup banner: `auth: bearer (SCRIBE_AUTH_TOKEN)`
- [x] Live smoke, open mode (env unset):
  - [x] `/v1/models` no token → 200 (current behavior preserved)
  - [x] Startup banner: `auth: open`

## Out of scope (later PRs / later phases)

- Caller-provided cleanup context (PR 2 of this sequence).
- Removal of the built-in vault client (PR 3).
- Hub-issued JWT validation, per-user quotas, rate limiting — future phases. The validator seam here is shaped so they compose cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)