### PR TITLE
docs: refresh CLAUDE.md (10 days stale, ~8 PRs of drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,64 +1,76 @@
 # Parachute Scribe
 
-Audio transcription + LLM cleanup service. Exposes a Whisper-compatible API so any client (Parachute Daily app, curl, etc.) can send audio and get back clean text.
+Audio-to-text + optional LLM cleanup. Whisper-compatible HTTP API, standalone CLI, and library. Runs on Bun, no Node.
 
-## What this is
-
-A tiny Bun service that takes audio in and returns transcribed, optionally LLM-cleaned text. The pipeline:
+## Architecture
 
 ```
-Audio (wav/mp3/m4a) → Transcription engine → Raw transcript → LLM cleanup (optional) → Clean text
+Audio (wav/mp3/m4a)  →  transcriber  →  raw text  →  [cleanup LLM]  →  clean text
+                         (pluggable)                  (pluggable, optional)
+
+CLI (parachute-scribe <file>)  ─┐
+HTTP (POST /v1/audio/...)      ─┼─→  createFetchHandler(deps)  →  Bun.serve on :1943
+Library (import transcribe)    ─┘
 ```
 
-## API shape
+- **`src/server.ts`** — `createFetchHandler(deps)` (pure factory, testable without port-binding; extracted in PR #16) + `startServer()` (builds deps, binds `Bun.serve`, writes `services.json`).
+- **`src/providers.ts`** — `transcribers` + `cleaners` registries (record maps). Everything else looks up by name; adding a provider means editing one file.
+- **`src/auth.ts`** (PR #16) — single `validateToken(token) → {valid, scopes}` seam. Today: shared-secret string compare against `SCRIBE_AUTH_TOKEN`. Tomorrow: hub-issued JWT, body swap, callers unchanged.
+- **`src/config.ts` / `src/config-schema.ts`** — file shape + loader; draft-07 JSON Schema served at `/.parachute/config/schema` (provider enums sourced from the live registry so the schema can't drift).
+- **`src/parachute-info.ts`** — `/.parachute/info` + `/.parachute/icon.svg` (hub discovery contract).
+- **`src/services-manifest.ts`** — atomic upsert into `~/.parachute/services.json` on `serve` boot so the CLI coordinator can find scribe.
 
-Whisper-compatible — same format as OpenAI's `/v1/audio/transcriptions`:
+## Key design decisions
+
+- **Stateless by design** — scribe never initiates outbound HTTP. Callers provide whatever context they want cleaned-up around (names, project glossary) in the request payload. The built-in vault client is being removed; see the "stateless-scribe" initiative (PRs #16, and the two follow-ups tracking context-in-payload + `vault.ts` deletion).
+- **Auth gate is opt-in** — `SCRIBE_AUTH_TOKEN` unset = open (loopback-trusted). Set = require `Authorization: Bearer <token>` on every route except `/health` and `/.parachute/info` (liveness probes and module discovery stay open so hub/CLI can reach scribe without knowing a secret). 401 responses carry full CORS headers so browser clients can read the error.
+- **Scopes declared, not yet enforced** — `scribe:transcribe` + `scribe:admin` are listed under `x-scopes` in the config schema. When the hub starts issuing JWTs, scribe enforces without an API-shape change.
+- **Provider resolution precedence**: `--flag` > `config.json` > env > default. Same three-tier pattern for every knob.
+- **Fail loud, not silent** — malformed `services.json` throws rather than get overwritten (protects sibling services' entries). Malformed config.json throws with the file path in the error.
+- **Bun-native**: `Bun.serve` for HTTP, `Bun.file` for I/O, `Bun.$` for provider subprocesses (parakeet-mlx, whisper), `bun test`. No Express, no Node-only deps.
+
+## Running
+
+```bash
+parachute-scribe <file>              # transcribe a file (uses default provider)
+parachute-scribe <file> --cleanup claude
+parachute-scribe <file> --transcribe groq --cleanup ollama
+parachute-scribe serve               # HTTP server on :1943
+parachute-scribe providers           # list available transcribers + cleaners
+parachute-scribe --help              # full flag/env reference
+```
+
+The live config shape is always the authoritative source — query it instead of memorizing schema:
+
+```bash
+curl http://localhost:1943/.parachute/config         # resolved runtime values
+curl http://localhost:1943/.parachute/config/schema  # draft-07 JSON Schema
+```
+
+## Config
+
+- **File:** `~/.parachute/scribe/config.json` (since PR #10 — legacy `~/.parachute/scribe.config.json` is auto-migrated on first boot).
+- **Override base dir:** `PARACHUTE_HOME=/some/path` → `$PARACHUTE_HOME/scribe/config.json`. Used in Docker and tailnet deployments.
+- **Override file directly:** `--config <path>` flag or `SCRIBE_CONFIG=<path>` env. When either is set, migration is skipped (explicit path, trust it).
+
+Env knobs (full list in `src/cli.ts` `usage()` and `.env.example`):
 
 ```
-POST /v1/audio/transcriptions
-Content-Type: multipart/form-data
-
-file: <audio file>
-model: <string>        # e.g., "parakeet", "whisper-large-v3"
-language: <string>     # optional, e.g., "en"
-cleanup: <bool>        # optional, parachute extension — run LLM cleanup on result
-
-Response: { "text": "..." }
+SCRIBE_PORT=1943              # server port. PORT also honored for PaaS back-compat.
+SCRIBE_AUTH_TOKEN=            # optional; when set, bearer required on non-exempt routes.
+PARACHUTE_HOME=~/.parachute   # ecosystem root. Overrides default.
+TRANSCRIBE_PROVIDER=parakeet-mlx
+CLEANUP_PROVIDER=none
 ```
 
-Any client that speaks Whisper API can use this without modification. The `cleanup` param is our extension.
+## Naming / canonical values
 
-## Transcription backends (to explore)
+- **Bin:** `parachute-scribe` (renamed from `scribe` in PR #9).
+- **npm:** `@openparachute/scribe`.
+- **Port:** `1943` (in the Parachute 1939–1949 band; vault is 1940).
+- **Mount path (for hub aggregation):** `/scribe`.
+- **Icon color:** `#6A9B77` sage (differentiated from vault's `#879B7E`).
 
-- **whisper.cpp** — C++ whisper, runs locally, well-supported
-- **Parakeet** — NVIDIA's ASR model, what the Flutter app uses via Sherpa-ONNX
-- **Proxy to external API** — forward to OpenAI/Groq/Deepgram Whisper API (user provides key)
+## Post-merge hygiene
 
-## LLM cleanup backends (to explore)
-
-- **Ollama** — local LLM, free, no API key needed
-- **Claude API** — high quality, needs API key
-- **None** — just return raw transcript
-
-## Bun-native
-
-Use Bun for everything:
-
-- `Bun.serve()` for HTTP (not express, not hono)
-- `Bun.file` for file I/O
-- `Bun.$` for shell commands
-- `bun test` for tests
-
-## Context
-
-- **Parachute Daily** (Flutter app) already has offline transcription via Sherpa-ONNX. This service adds a server-side option with higher quality + LLM cleanup.
-- **Parachute Vault** is the knowledge graph where transcribed notes land. Scribe doesn't know about the vault — it just returns text. The client (app or agent) stores it.
-- Domain: `parachute.computer`, this would be at `scribe.parachute.computer`
-- Sister repos: [@openparachute/vault](https://github.com/ParachuteComputer/@openparachute/vault), [@openparachute/daily](https://github.com/ParachuteComputer/@openparachute/daily)
-
-## Open questions
-
-- Which transcription engine to start with? whisper.cpp is most portable. Parakeet via Sherpa-ONNX is what the app already uses.
-- How to handle LLM cleanup — what prompt? What model? Is Ollama the right default for self-hosted?
-- Should this be installable like vault (`bun install -g`)? Or just a docker container / simple `bun run`?
-- Do we need an MCP server for this, or is the REST API sufficient?
+When a PR is merged, the next thing you do is `git checkout main && git pull`. The `bun link`-linked install follows your checkout — leaving the repo on a feature branch means Aaron is running stale code. Caught 2026-04-21.


### PR DESCRIPTION
## Summary

CLAUDE.md was last touched 2026-04-11 and has drifted past ~8 PRs of reality (bin rename, services.json write, CORS, config path migration, hub parity, `kind: "api"`, config schema endpoints, in-flight auth gate + statelessness initiative).

Rewritten to reflect current reality, under 150 lines, matching the `parachute-vault/CLAUDE.md` format. Sections:

- **Architecture** — diagram + one-liner per source file (server, providers, auth, config/schema, parachute-info, services-manifest).
- **Key design decisions** — stateless direction, opt-in auth gate, `x-scopes` declaration, provider resolution precedence, fail-loud-on-malformed, Bun-native.
- **Running** — canonical CLI invocations, plus a pointer to `/.parachute/config` + `/.parachute/config/schema` as the authoritative live-shape source (so agents query instead of memorizing).
- **Config** — file location, `PARACHUTE_HOME` + `SCRIBE_CONFIG` + `--config` override precedence, env knobs.
- **Naming / canonical values** — bin, npm scope, port 1943, mount path, icon color.
- **Post-merge hygiene** — the reminder from the 2026-04-21 incident, verbatim as requested.

In-flight PRs are annotated inline (PR #16 for auth + handler extraction) so readers entering the repo before merge can reconcile against `git log`.

## Scope decision

Opened separate from the auth-series PRs (#16, and PRs 2–3 to follow). Docs shouldn't be coupled to behavior changes, and any review feedback on the auth PR could reshape the architecture paragraph — cleaner to let the docs land independently.

## Test plan

- [x] File is 76 lines, well under the 150-line budget
- [x] All file path claims cross-checked (`src/server.ts`, `src/auth.ts`, `src/providers.ts`, `src/config.ts`, `src/config-schema.ts`, `src/parachute-info.ts`, `src/services-manifest.ts`)
- [x] `Bun.$` usage claim verified in `src/transcribe/parakeet-mlx.ts`
- [x] PR-number references (#9 for bin rename, #10 for config path, #16 for auth) match `git log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)