### PR TITLE
feat: graceful cleanup failure — return raw transcription instead of 500

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,13 @@ export async function transcribe(
   let text = await transcriber(audio);
 
   if (cleanupProvider !== "none") {
-    const properNouns = await fetchProperNouns(config);
-    text = await cleaner(text, properNouns);
+    try {
+      const properNouns = await fetchProperNouns(config);
+      text = await cleaner(text, properNouns);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Cleanup failed (provider=${cleanupProvider}): ${message} — returning raw transcription`);
+    }
   }
 
   return text;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createFetchHandler, type ServerDeps } from "./server.ts";
 import type { ResolvedConfig } from "./config-schema.ts";
+import type { Cleaner } from "./providers.ts";
 
 const RESOLVED: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
@@ -10,14 +11,24 @@ const RESOLVED: ResolvedConfig = {
   vault: { configured: false, url: null, cacheTtlSeconds: null },
 };
 
-function buildHandler(): (req: Request) => Promise<Response> {
+function buildHandler(overrides: Partial<ServerDeps> = {}): (req: Request) => Promise<Response> {
   const deps: ServerDeps = {
     transcribe: async () => "stub text",
     cleanup: async (text) => text,
     resolvedConfig: RESOLVED,
     scribeConfig: {},
+    ...overrides,
   };
   return createFetchHandler(deps);
+}
+
+function transcribeReq(): Request {
+  const form = new FormData();
+  form.set("file", new File(["fake audio"], "test.wav"));
+  return new Request("http://localhost/v1/audio/transcriptions", {
+    method: "POST",
+    body: form,
+  });
 }
 
 describe("createFetchHandler — auth gate", () => {
@@ -95,14 +106,7 @@ describe("createFetchHandler — auth gate", () => {
     });
 
     test("/v1/audio/transcriptions returns 401 without a token", async () => {
-      const form = new FormData();
-      form.set("file", new File(["fake audio"], "test.wav"));
-      const res = await buildHandler()(
-        new Request("http://localhost/v1/audio/transcriptions", {
-          method: "POST",
-          body: form,
-        }),
-      );
+      const res = await buildHandler()(transcribeReq());
       expect(res.status).toBe(401);
     });
 
@@ -119,5 +123,71 @@ describe("createFetchHandler — auth gate", () => {
       expect(res.status).toBe(401);
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
     });
+  });
+});
+
+describe("createFetchHandler — cleanup failure behavior", () => {
+  const CLEANUP_RESOLVED: ResolvedConfig = {
+    ...RESOLVED,
+    cleanupProvider: "claude",
+    cleanupDefault: true,
+  };
+
+  let originalToken: string | undefined;
+  let originalError: typeof console.error;
+  let errors: string[];
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    errors = [];
+    originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map((a) => String(a)).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+    console.error = originalError;
+  });
+
+  test("cleanup throw → 200 with raw transcription, not 500", async () => {
+    const throwingCleanup: Cleaner = async () => {
+      throw new Error("upstream LLM unreachable");
+    };
+    const handler = buildHandler({
+      transcribe: async () => "raw transcribed words",
+      cleanup: throwingCleanup,
+      resolvedConfig: CLEANUP_RESOLVED,
+    });
+
+    const res = await handler(transcribeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ text: "raw transcribed words" });
+    expect(errors.some((e) => e.includes("Cleanup failed") && e.includes("upstream LLM unreachable"))).toBe(true);
+  });
+
+  test("transcription throw → still 500 (cleanup fallback only covers cleanup)", async () => {
+    const handler = buildHandler({
+      transcribe: async () => {
+        throw new Error("audio decode failed");
+      },
+      resolvedConfig: CLEANUP_RESOLVED,
+    });
+    const res = await handler(transcribeReq());
+    expect(res.status).toBe(500);
+  });
+
+  test("cleanup success → 200 with cleaned text", async () => {
+    const handler = buildHandler({
+      transcribe: async () => "raw",
+      cleanup: async (text) => `cleaned(${text})`,
+      resolvedConfig: CLEANUP_RESOLVED,
+    });
+    const res = await handler(transcribeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ text: "cleaned(raw)" });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -84,18 +84,26 @@ async function handleTranscription(req: Request, deps: ServerDeps): Promise<Resp
         ? false
         : cleanupDefault);
 
+  let text: string;
   try {
-    let text = await deps.transcribe(file);
-    if (doCleanup) {
-      const properNouns = await fetchProperNouns(deps.scribeConfig);
-      text = await deps.cleanup(text, properNouns);
-    }
-    return Response.json({ text });
+    text = await deps.transcribe(file);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "transcription failed";
     console.error("Transcription error:", message);
     return Response.json({ error: message }, { status: 500 });
   }
+
+  if (doCleanup) {
+    try {
+      const properNouns = await fetchProperNouns(deps.scribeConfig);
+      text = await deps.cleanup(text, properNouns);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Cleanup failed (provider=${cleanupProvider}): ${message} — returning raw transcription`);
+    }
+  }
+
+  return Response.json({ text });
 }
 
 export async function startServer() {


### PR DESCRIPTION
## Summary

- When the LLM cleanup step throws, return the raw transcription with **200** instead of failing the whole request with **500**.
- Applied symmetrically in the HTTP handler (`src/server.ts`) and the library entry point (`src/index.ts`).
- Transcription failures still return 500 — the fallback only covers the cleanup step.

## Why

Transcription and cleanup are separable concerns: audio→text is the contract; cleanup is best-effort polish. A scribe that hands back raw transcription when the LLM is unreachable is strictly better than one that drops the whole response on the floor.

The failure is logged with provider name + error message so the miss is visible in server logs. No response-shape change — still `{ text: "..." }` — so existing clients keep working unchanged.

## Test plan

- [x] New test: injected throwing cleanup → 200 with raw text + `Cleanup failed` log line
- [x] Existing auth tests unchanged (13 server tests pass)
- [x] New test: transcription failure still returns 500 (fallback doesn't mask the real contract)
- [x] `bun test` — 62 / 62 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)