### PR TITLE
feat: add claude-code cleanup provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@
 #   groq / openai  — Cloud API
 TRANSCRIBE_PROVIDER=parakeet-mlx
 
-# Cleanup provider: claude | ollama | openai | gemini | groq | custom | none
+# Cleanup provider: claude | claude-code | ollama | openai | gemini | groq | custom | none
+#   claude        — Anthropic API (requires ANTHROPIC_API_KEY)
+#   claude-code   — shells out to the `claude` CLI (uses your existing Claude Code auth)
 CLEANUP_PROVIDER=none
 
 # Server port (PORT also honored for back-compat; SCRIBE_PORT takes precedence)

--- a/src/cleanup/claude-code.test.ts
+++ b/src/cleanup/claude-code.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { makeCleaner, type SpawnFn } from "./claude-code.ts";
+import { cleaners } from "../providers.ts";
+
+type RecordedCall = {
+  cmd: string[];
+  stdin: string;
+  timeoutMs: number;
+};
+
+function recordingSpawn(
+  response: { stdout: string; stderr?: string; exitCode?: number | null } | Error,
+): { spawn: SpawnFn; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const spawn: SpawnFn = async (args) => {
+    calls.push(args);
+    if (response instanceof Error) throw response;
+    return {
+      stdout: response.stdout,
+      stderr: response.stderr ?? "",
+      exitCode: response.exitCode ?? 0,
+    };
+  };
+  return { spawn, calls };
+}
+
+describe("claude-code cleanup provider", () => {
+  test("pipes prompt + transcript to stdin and returns trimmed stdout", async () => {
+    const { spawn, calls } = recordingSpawn({ stdout: "  cleaned transcript  \n" });
+    const cleaner = makeCleaner(spawn);
+
+    const result = await cleaner("raw um like words");
+
+    expect(result).toBe("cleaned transcript");
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.cmd).toEqual(["claude", "-p"]);
+    expect(calls[0]!.stdin).toContain("voice memo transcripts");
+    expect(calls[0]!.stdin).toContain("raw um like words");
+    expect(calls[0]!.timeoutMs).toBeGreaterThan(0);
+  });
+
+  test("includes proper-nouns block in stdin when provided", async () => {
+    const { spawn, calls } = recordingSpawn({ stdout: "ok" });
+    const cleaner = makeCleaner(spawn);
+
+    await cleaner("some words", "## Proper nouns in this vault\n\nPeople:\n- [[People/Sam]]");
+
+    expect(calls[0]!.stdin).toContain("## Proper nouns in this vault");
+    expect(calls[0]!.stdin).toContain("[[People/Sam]]");
+  });
+
+  test("throws actionable message when claude is not on PATH (ENOENT)", async () => {
+    const { spawn } = recordingSpawn(new Error("ENOENT: claude not found on PATH"));
+    const cleaner = makeCleaner(spawn);
+
+    await expect(cleaner("hi")).rejects.toThrow(/claude not found on PATH.*install Claude Code/);
+  });
+
+  test("throws when subprocess exits non-zero, includes stderr detail", async () => {
+    const { spawn } = recordingSpawn({ stdout: "", stderr: "auth required", exitCode: 1 });
+    const cleaner = makeCleaner(spawn);
+
+    await expect(cleaner("hi")).rejects.toThrow(/claude -p exited 1.*auth required/);
+  });
+
+  test("throws when subprocess exits 0 but stdout is empty", async () => {
+    const { spawn } = recordingSpawn({ stdout: "   \n\n  ", exitCode: 0 });
+    const cleaner = makeCleaner(spawn);
+
+    await expect(cleaner("hi")).rejects.toThrow(/empty output/);
+  });
+
+  test("rethrows non-ENOENT spawn errors unchanged", async () => {
+    const { spawn } = recordingSpawn(new Error("EPERM: denied"));
+    const cleaner = makeCleaner(spawn);
+
+    await expect(cleaner("hi")).rejects.toThrow("EPERM: denied");
+  });
+});
+
+describe("claude-code provider registration", () => {
+  test("is available under key 'claude-code' in cleaners registry", () => {
+    expect(cleaners["claude-code"]).toBeDefined();
+    expect(typeof cleaners["claude-code"]).toBe("function");
+  });
+});

--- a/src/cleanup/claude-code.ts
+++ b/src/cleanup/claude-code.ts
@@ -1,0 +1,70 @@
+import { buildCleanupPrompt } from "./prompt.ts";
+
+export type SpawnResult = { stdout: string; stderr: string; exitCode: number | null };
+
+export type SpawnFn = (args: {
+  cmd: string[];
+  stdin: string;
+  timeoutMs: number;
+}) => Promise<SpawnResult>;
+
+export const TIMEOUT_MS = 60_000;
+
+const defaultSpawn: SpawnFn = async ({ cmd, stdin, timeoutMs }) => {
+  const bin = cmd[0]!;
+  if (Bun.which(bin) === null) {
+    throw new Error(`ENOENT: ${bin} not found on PATH`);
+  }
+
+  const proc = Bun.spawn(cmd, {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  proc.stdin.write(stdin);
+  await proc.stdin.end();
+
+  const killTimer = setTimeout(() => proc.kill(), timeoutMs);
+  try {
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    return { stdout, stderr, exitCode };
+  } finally {
+    clearTimeout(killTimer);
+  }
+};
+
+export function makeCleaner(spawnFn: SpawnFn = defaultSpawn) {
+  return async (text: string, properNouns?: string): Promise<string> => {
+    const prompt = buildCleanupPrompt(properNouns);
+    const stdin = `${prompt}\n\nTranscript to clean:\n\n${text}`;
+
+    let result: SpawnResult;
+    try {
+      result = await spawnFn({ cmd: ["claude", "-p"], stdin, timeoutMs: TIMEOUT_MS });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/ENOENT|not found/i.test(msg)) {
+        throw new Error(
+          "claude not found on PATH — install Claude Code (https://claude.com/claude-code) or switch cleanup provider",
+        );
+      }
+      throw err;
+    }
+
+    if (result.exitCode !== 0) {
+      const detail = (result.stderr || result.stdout).trim();
+      throw new Error(
+        `claude -p exited ${result.exitCode}${detail ? `: ${detail}` : ""}`,
+      );
+    }
+
+    const out = result.stdout.trim();
+    if (!out) throw new Error("claude -p produced empty output");
+    return out;
+  };
+}
+
+export const cleanup = makeCleaner();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ Examples:
   parachute-scribe recording.wav
   parachute-scribe meeting.m4a --cleanup claude
   parachute-scribe memo.mp3 --transcribe groq --cleanup ollama
+  parachute-scribe note.wav --cleanup claude-code    # uses your Claude Code auth
   parachute-scribe serve
 `);
 }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -4,6 +4,7 @@ import { transcribe as whisper } from "./transcribe/whisper.ts";
 import { transcribe as groq } from "./transcribe/groq.ts";
 import { transcribe as openai } from "./transcribe/openai.ts";
 import { cleanup as claude } from "./cleanup/claude.ts";
+import { cleanup as claudeCode } from "./cleanup/claude-code.ts";
 import { cleanup as ollama } from "./cleanup/ollama.ts";
 import { openai as openaiCleanup, gemini, groqCleanup, custom } from "./cleanup/openai-compat.ts";
 
@@ -19,6 +20,7 @@ export type Cleaner = (text: string, properNouns?: string) => Promise<string>;
 
 export const cleaners: Record<string, Cleaner> = {
   claude,
+  "claude-code": claudeCode,
   ollama,
   openai: openaiCleanup,
   gemini,


### PR DESCRIPTION
## Summary

- New cleanup provider `claude-code` that shells out to the `claude` CLI in headless print mode (`claude -p`) via `Bun.spawn`.
- Reuses the existing cleanup prompt from `src/cleanup/prompt.ts` — only the transport changes (HTTP → subprocess stdin/stdout).
- Registered in `src/providers.ts`; auto-picked up by the config schema enum.
- **Not** the default — opt-in via `{ cleanup: { provider: \"claude-code\" } }` or `--cleanup claude-code`.

## Why

Uses the user's existing Claude Code install + auth, so no separate `ANTHROPIC_API_KEY` is needed to get Claude-quality cleanup. Especially useful for local/personal use where Claude Code is already wired up.

## Failure modes (all actionable, all caught by PR #18's wrapper)

- `claude` not on PATH → `claude not found on PATH — install Claude Code (https://claude.com/claude-code) or switch cleanup provider`
- subprocess exits non-zero → `claude -p exited <code>: <stderr>`
- empty stdout → `claude -p produced empty output`

Any of these → the `handleTranscription` wrapper logs cleanly and falls back to raw transcription. Module host without Claude Code installed will not break the transcription pipeline.

## Test plan

- [x] Unit tests use an injectable `SpawnFn`; the real `claude` binary is not invoked
- [x] Verifies prompt + transcript are piped to stdin
- [x] Verifies proper-nouns block flows through when provided
- [x] Verifies ENOENT path produces the actionable message
- [x] Verifies non-zero exit surfaces stderr
- [x] Verifies empty-stdout guard
- [x] `bun test` — 69 / 69 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)