### PR TITLE
feat: context-in-payload + vault.mode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,25 @@ curl -H "Authorization: Bearer $SCRIBE_AUTH_TOKEN" \
 
 401 response shape: `{"error":"unauthorized","message":"SCRIBE_AUTH_TOKEN required"}`. CORS headers are included so browser clients can read the error.
 
-## Vault-aware cleanup (optional)
+## Proper-noun context
 
-Point scribe at a [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) and the cleanup pass will learn the proper nouns you care about — correcting mishearings ("learn by build" → "Learn Vibe Build") and wrapping matches in `[[wikilinks]]` so transcribed memos land pre-linked in your graph.
+Cleanup improves when scribe knows the proper nouns you care about — so mishearings like "learn by build" become "Learn Vibe Build". Scribe accepts context in two ways:
 
-Copy `scribe.config.example.json` to `~/.parachute/scribe/config.json` (or `$PARACHUTE_HOME/scribe/config.json`) and edit:
+### 1. Pushed in the request (preferred)
+
+Callers send a `context` multipart part alongside the audio. This is what [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) does — it queries its own notes and pushes the result with each transcription.
+
+```bash
+curl -F "file=@memo.wav" \
+  -F 'context={"entries":[{"name":"Learn Vibe Build","summary":"6-week cohort","aliases":["LVB","Learn by Build"]}]};type=application/json' \
+  http://localhost:1943/v1/audio/transcriptions
+```
+
+When `context` is present in the request, scribe uses it directly and does **not** call back into any vault.
+
+### 2. Pulled from a Parachute Vault (opt-in)
+
+If no `context` part is supplied, scribe can optionally fetch proper nouns from a configured vault. Copy `scribe.config.example.json` to `~/.parachute/scribe/config.json` (or `$PARACHUTE_HOME/scribe/config.json`) and edit:
 
 ```json
 {
@@ -176,6 +190,7 @@ Copy `scribe.config.example.json` to `~/.parachute/scribe/config.json` (or `$PAR
   "vault": {
     "url": "http://localhost:1940",
     "token": "pvt_read_only_token",
+    "mode": "fallback",
     "contexts": [
       { "tag": "person",  "exclude_tag": "archived", "include_metadata": ["summary", "aliases"] },
       { "tag": "project", "exclude_tag": "archived", "include_metadata": ["summary", "aliases"] }
@@ -184,7 +199,13 @@ Copy `scribe.config.example.json` to `~/.parachute/scribe/config.json` (or `$PAR
 }
 ```
 
-Scribe fetches the proper-noun list once per `cache_ttl_seconds` (default 300) and injects it into the cleanup prompt. If the vault is unreachable, cleanup still runs — just without the context.
+`vault.mode` controls how scribe handles the backchannel when a request lacks a `context` part:
+
+- `off` — never call vault
+- `fallback` (default) — call vault; if unreachable, continue with no proper nouns
+- `required` — call vault; if unreachable, the cleanup step fails (PR #18's wrapper still returns the raw transcription)
+
+Scribe caches the fetched list for `cache_ttl_seconds` (default 300).
 
 Default config path is `${PARACHUTE_HOME:-~/.parachute}/scribe/config.json`. Set `SCRIBE_CONFIG=/path/to/config.json` (or pass `--config <path>` on the CLI) to point somewhere else. An older `~/.parachute/scribe.config.json` is auto-migrated to the new path on first run.
 

--- a/scribe.config.example.json
+++ b/scribe.config.example.json
@@ -7,6 +7,7 @@
     "url": "http://localhost:1940",
     "token": "pvt_read_only_token",
     "cache_ttl_seconds": 300,
+    "mode": "fallback",
     "contexts": [
       {
         "tag": "person",

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -17,6 +17,7 @@ const SAMPLE: ResolvedConfig = {
     configured: true,
     url: "http://localhost:1940",
     cacheTtlSeconds: 300,
+    mode: "fallback",
   },
 };
 
@@ -76,11 +77,18 @@ describe("config-schema", () => {
   test("handleConfig reflects an unconfigured vault with nulls", async () => {
     const res = handleConfig({
       ...SAMPLE,
-      vault: { configured: false, url: null, cacheTtlSeconds: null },
+      vault: { configured: false, url: null, cacheTtlSeconds: null, mode: "fallback" },
     });
     const body = (await res.json()) as ResolvedConfig;
     expect(body.vault.configured).toBe(false);
     expect(body.vault.url).toBeNull();
     expect(body.vault.cacheTtlSeconds).toBeNull();
+  });
+
+  test("schema exposes vault.mode enum + default 'fallback'", () => {
+    const schema = buildConfigSchema();
+    const mode = schema.properties.vault.properties.mode;
+    expect(mode.enum).toEqual(["off", "fallback", "required"]);
+    expect(mode.default).toBe("fallback");
   });
 });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -78,7 +78,7 @@ export function buildConfigSchema() {
             enum: VAULT_MODES,
             default: "fallback",
             title: "Vault fetch mode",
-            description: "How scribe handles the vault backchannel when the request payload does NOT carry a `context` part. off = never call vault; fallback = call vault, ignore errors (default); required = call vault, propagate errors.",
+            description: "How scribe handles the vault backchannel when the request payload does NOT carry a `context` part. off = never call vault. fallback (default) = call vault; if unreachable, continue cleanup with no proper nouns. required = call vault; if unreachable, the cleanup step raises — the transcription pipeline's cleanup-failure wrapper catches it and the caller still gets a 200 with the raw transcription (no cleanup applied).",
           },
         },
       },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,9 +1,12 @@
 import { cleaners, transcribers } from "./providers.ts";
+import type { VaultMode } from "./config.ts";
 
 export const SCOPES = {
   "scribe:transcribe": "Submit audio for transcription (request-time, per-call).",
   "scribe:admin": "Read and write scribe configuration. Reserved — not enforced yet (scribe is loopback-trusted through launch).",
 } as const;
+
+export const VAULT_MODES: VaultMode[] = ["off", "fallback", "required"];
 
 export type ResolvedConfig = {
   transcribeProvider: string;
@@ -14,6 +17,7 @@ export type ResolvedConfig = {
     configured: boolean;
     url: string | null;
     cacheTtlSeconds: number | null;
+    mode: VaultMode;
   };
 };
 
@@ -54,7 +58,7 @@ export function buildConfigSchema() {
       vault: {
         type: "object",
         title: "Vault integration",
-        description: "Optional — point scribe at a Parachute Vault so cleanup gets proper-noun context (names, projects, aliases).",
+        description: "Optional — point scribe at a Parachute Vault so cleanup gets proper-noun context (names, projects, aliases). Callers may also supply context directly in the request payload, in which case scribe skips the vault backchannel entirely.",
         properties: {
           url: {
             type: "string",
@@ -68,6 +72,13 @@ export function buildConfigSchema() {
             title: "Cache TTL (seconds)",
             description: "How long to cache the fetched proper-noun list before refetching.",
             default: 300,
+          },
+          mode: {
+            type: "string",
+            enum: VAULT_MODES,
+            default: "fallback",
+            title: "Vault fetch mode",
+            description: "How scribe handles the vault backchannel when the request payload does NOT carry a `context` part. off = never call vault; fallback = call vault, ignore errors (default); required = call vault, propagate errors.",
           },
         },
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,9 +31,11 @@ export type ScribeConfig = {
      * NOT carry a `context` part. Defaults to "fallback" (today's behavior).
      *
      *   - "off"      — never call vault; if no context in payload, no proper nouns
-     *   - "fallback" — call vault; if unreachable, continue with no proper nouns
-     *   - "required" — call vault; if unreachable, propagate the error
-     *                  (PR #18's wrapper catches it → raw transcription survives)
+     *   - "fallback" — call vault; if unreachable, continue cleanup with no proper nouns
+     *   - "required" — call vault; if unreachable, the cleanup step raises.
+     *                  handleTranscription's cleanup-failure wrapper catches it
+     *                  and returns 200 with the raw transcription (no cleanup).
+     *                  Transcription always survives vault outages.
      */
     mode?: VaultMode;
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ export type VaultContext = {
   include_metadata?: string[];
 };
 
+export type VaultMode = "off" | "fallback" | "required";
+
+export const DEFAULT_VAULT_MODE: VaultMode = "fallback";
+
 export type ScribeConfig = {
   transcribe?: {
     provider?: string;
@@ -18,10 +22,20 @@ export type ScribeConfig = {
     default?: boolean;
   };
   vault?: {
-    url: string;
+    url?: string;
     token?: string;
     contexts?: VaultContext[];
     cache_ttl_seconds?: number;
+    /**
+     * How scribe handles the vault backchannel when the request payload does
+     * NOT carry a `context` part. Defaults to "fallback" (today's behavior).
+     *
+     *   - "off"      — never call vault; if no context in payload, no proper nouns
+     *   - "fallback" — call vault; if unreachable, continue with no proper nouns
+     *   - "required" — call vault; if unreachable, propagate the error
+     *                  (PR #18's wrapper catches it → raw transcription survives)
+     */
+    mode?: VaultMode;
   };
 };
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { buildProperNounsBlockFromEntries, parseContextPayload } from "./context.ts";
+
+describe("parseContextPayload", () => {
+  test("accepts raw JSON string and returns the payload", () => {
+    const raw = JSON.stringify({
+      entries: [{ name: "Margaret", summary: "Close friend", aliases: ["Marg"] }],
+    });
+    const payload = parseContextPayload(raw);
+    expect(payload).not.toBeNull();
+    expect(payload!.entries).toHaveLength(1);
+    expect(payload!.entries[0]!.name).toBe("Margaret");
+  });
+
+  test("accepts a pre-parsed object", () => {
+    const payload = parseContextPayload({ entries: [{ name: "Aaron" }] });
+    expect(payload!.entries).toHaveLength(1);
+  });
+
+  test("returns null for malformed JSON string", () => {
+    expect(parseContextPayload("not json")).toBeNull();
+  });
+
+  test("returns null when entries is missing or not an array", () => {
+    expect(parseContextPayload({})).toBeNull();
+    expect(parseContextPayload({ entries: "nope" })).toBeNull();
+  });
+
+  test("skips entries missing a usable name, keeps the rest", () => {
+    const payload = parseContextPayload({
+      entries: [
+        { name: "Keep", summary: "ok" },
+        { summary: "no name" },
+        { name: "" },
+        { name: "   " },
+        { name: "AlsoKeep" },
+      ],
+    });
+    expect(payload!.entries.map((e) => e.name)).toEqual(["Keep", "AlsoKeep"]);
+  });
+
+  test("returns empty entries array for empty input (valid, just no context)", () => {
+    const payload = parseContextPayload({ entries: [] });
+    expect(payload!.entries).toEqual([]);
+  });
+});
+
+describe("buildProperNounsBlockFromEntries", () => {
+  test("returns empty string when no entries", () => {
+    expect(buildProperNounsBlockFromEntries({ entries: [] })).toBe("");
+  });
+
+  test("formats name + summary + aliases on one line each", () => {
+    const block = buildProperNounsBlockFromEntries({
+      entries: [
+        { name: "Margaret", summary: "Close friend", aliases: ["Marg"] },
+        {
+          name: "Learn Vibe Build",
+          summary: "6-week cohort",
+          aliases: ["LVB", "Learn by Build"],
+        },
+        { name: "Natalie" },
+      ],
+    });
+    expect(block).toContain("## Known names in this context");
+    expect(block).toContain("- Margaret — Close friend (also: \"Marg\")");
+    expect(block).toContain("- Learn Vibe Build — 6-week cohort (also: \"LVB\", \"Learn by Build\")");
+    expect(block).toContain("- Natalie");
+    // Solo name with no summary or aliases shouldn't get a trailing dash or parens
+    expect(block).not.toContain("- Natalie —");
+    expect(block).not.toContain("- Natalie (");
+  });
+
+  test("accepts string-encoded aliases (comma-split, trimmed)", () => {
+    const block = buildProperNounsBlockFromEntries({
+      entries: [{ name: "Sam", aliases: "Samuel, Sammy" as unknown as string[] }],
+    });
+    expect(block).toContain("(also: \"Samuel\", \"Sammy\")");
+  });
+
+  test("ignores unknown metadata fields without crashing", () => {
+    const block = buildProperNounsBlockFromEntries({
+      entries: [{ name: "Weird", extraField: 42, nested: { a: 1 } }],
+    });
+    expect(block).toContain("- Weird");
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,88 @@
+/**
+ * Parse + format the `context` multipart part that callers send alongside
+ * audio in POST /v1/audio/transcriptions.
+ *
+ * Shape (matches vault's transcription-worker `appendContextPart` output):
+ *
+ *   {
+ *     "entries": [
+ *       { "name": "Margaret", "summary": "Close friend", "aliases": ["Marg"] },
+ *       { "name": "Learn Vibe Build", "summary": "6-week cohort",
+ *         "aliases": ["LVB", "Learn by Build"] }
+ *     ]
+ *   }
+ *
+ * Each entry's `name` is the canonical form (typically a note path basename
+ * from the sender's vault). Other fields are whitelisted metadata carried
+ * through unchanged. When present in the payload, scribe uses this block
+ * directly and does NOT call back into any vault — the caller has supplied
+ * everything the cleanup LLM needs.
+ */
+
+export interface ContextEntry {
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface ContextPayload {
+  entries: ContextEntry[];
+}
+
+/**
+ * Tolerant parser. Accepts either a raw JSON string or a pre-parsed object.
+ * Returns null on malformed input so the caller can fall through to vault
+ * fetch rather than 400-ing the whole transcription.
+ */
+export function parseContextPayload(raw: unknown): ContextPayload | null {
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const entries = (parsed as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return null;
+
+  const valid: ContextEntry[] = [];
+  for (const e of entries) {
+    if (!e || typeof e !== "object") continue;
+    const rec = e as Record<string, unknown>;
+    if (typeof rec.name !== "string" || !rec.name.trim()) continue;
+    valid.push(rec as ContextEntry);
+  }
+  return { entries: valid };
+}
+
+export function buildProperNounsBlockFromEntries(payload: ContextPayload): string {
+  if (!payload.entries.length) return "";
+  const lines = payload.entries.map(formatEntryLine);
+  return [
+    "## Known names in this context",
+    "",
+    "The speaker knows these names. If the transcript mentions any of them (exact match OR alias match), correct the spelling to the canonical form shown here. Do not invent names or add ones that aren't listed.",
+    "",
+    ...lines,
+  ].join("\n");
+}
+
+function formatEntryLine(entry: ContextEntry): string {
+  let line = `- ${entry.name}`;
+  const summary = typeof entry.summary === "string" ? entry.summary.trim() : "";
+  if (summary) line += ` — ${summary}`;
+  const aliases = normalizeAliases(entry.aliases);
+  if (aliases.length) line += ` (also: ${aliases.map((a) => `"${a}"`).join(", ")})`;
+  return line;
+}
+
+function normalizeAliases(aliases: unknown): string[] {
+  if (Array.isArray(aliases)) {
+    return aliases.filter((a): a is string => typeof a === "string" && a.trim().length > 0);
+  }
+  if (typeof aliases === "string") {
+    return aliases.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  return [];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,30 @@
 export { transcribers, cleaners, getProvider } from "./providers.ts";
 export { CLEANUP_PROMPT, buildCleanupPrompt } from "./cleanup/prompt.ts";
-export { loadConfig, type ScribeConfig, type VaultContext } from "./config.ts";
+export { DEFAULT_VAULT_MODE, loadConfig, type ScribeConfig, type VaultContext, type VaultMode } from "./config.ts";
 export { fetchProperNouns, clearVaultCache } from "./vault.ts";
+export {
+  buildProperNounsBlockFromEntries,
+  parseContextPayload,
+  type ContextEntry,
+  type ContextPayload,
+} from "./context.ts";
 
 import { transcribers, cleaners } from "./providers.ts";
-import { loadConfig, type ScribeConfig } from "./config.ts";
+import { DEFAULT_VAULT_MODE, loadConfig, type ScribeConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
+import { buildProperNounsBlockFromEntries, parseContextPayload, type ContextPayload } from "./context.ts";
 
 export type TranscribeOptions = {
   provider?: string;
   cleanup?: string;
   config?: ScribeConfig;
+  /**
+   * Optional pre-fetched context block. When supplied, scribe uses it directly
+   * and does NOT call the vault backchannel — the caller has already provided
+   * everything cleanup needs. Accepts the same shape vault's transcription-worker
+   * sends as the `context` multipart part.
+   */
+  context?: ContextPayload | string;
 };
 
 /**
@@ -42,11 +56,13 @@ export async function transcribe(
     throw new Error(`Unknown cleanup provider: ${cleanupProvider}. Available: ${Object.keys(cleaners).join(", ")}`);
   }
 
+  const contextPayload = opts.context !== undefined ? parseContextPayload(opts.context) : null;
+
   let text = await transcriber(audio);
 
   if (cleanupProvider !== "none") {
     try {
-      const properNouns = await fetchProperNouns(config);
+      const properNouns = await resolveProperNouns(config, contextPayload);
       text = await cleaner(text, properNouns);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -55,6 +71,16 @@ export async function transcribe(
   }
 
   return text;
+}
+
+async function resolveProperNouns(
+  config: ScribeConfig,
+  contextPayload: ContextPayload | null,
+): Promise<string> {
+  if (contextPayload) return buildProperNounsBlockFromEntries(contextPayload);
+  const mode = config.vault?.mode ?? DEFAULT_VAULT_MODE;
+  if (mode === "off") return "";
+  return fetchProperNouns(config);
 }
 
 /**

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -313,6 +313,40 @@ describe("createFetchHandler — context-in-payload + vault.mode", () => {
     }
   });
 
+  test("vault.mode='required' + vault unreachable + no context → 200 with raw transcription, cleanup skipped, error logged", async () => {
+    // Point the mocked fetch at "ECONNREFUSED" for vault calls.
+    globalThis.fetch = (async (input: Request | string | URL) => {
+      const url = typeof input === "string" ? new URL(input) : input instanceof URL ? input : new URL(input.url);
+      if (url.pathname.startsWith("/api/notes")) {
+        throw new Error("ECONNREFUSED");
+      }
+      throw new Error(`unexpected fetch: ${url.toString()}`);
+    }) as unknown as typeof fetch;
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map((a) => String(a)).join(" ")); };
+
+    try {
+      const handler = buildHandler({
+        transcribe: async () => "raw transcribed words",
+        cleanup: async (text) => `cleaned(${text})`, // should not be invoked — vault throws first
+        resolvedConfig: CLEANUP_RESOLVED,
+        scribeConfig: {
+          vault: { ...VAULT_CONFIG.vault!, mode: "required" },
+        },
+      });
+      const res = await handler(reqWithContext(null));
+
+      // The wrapper from PR #18 is the backstop — transcription always survives.
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ text: "raw transcribed words" });
+      expect(errors.some((e) => e.includes("Cleanup failed") && e.includes("ECONNREFUSED"))).toBe(true);
+    } finally {
+      console.error = origError;
+    }
+  });
+
   test("empty entries context part → vault NOT called, cleaner gets empty nouns", async () => {
     let seenNouns = "sentinel";
     const handler = buildHandler({

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2,13 +2,15 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createFetchHandler, type ServerDeps } from "./server.ts";
 import type { ResolvedConfig } from "./config-schema.ts";
 import type { Cleaner } from "./providers.ts";
+import type { ScribeConfig } from "./config.ts";
+import { clearVaultCache } from "./vault.ts";
 
 const RESOLVED: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
   cleanupProvider: "none",
   cleanupDefault: false,
   port: 1943,
-  vault: { configured: false, url: null, cacheTtlSeconds: null },
+  vault: { configured: false, url: null, cacheTtlSeconds: null, mode: "fallback" },
 };
 
 function buildHandler(overrides: Partial<ServerDeps> = {}): (req: Request) => Promise<Response> {
@@ -189,5 +191,142 @@ describe("createFetchHandler — cleanup failure behavior", () => {
     const res = await handler(transcribeReq());
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ text: "cleaned(raw)" });
+  });
+});
+
+describe("createFetchHandler — context-in-payload + vault.mode", () => {
+  const CLEANUP_RESOLVED: ResolvedConfig = {
+    ...RESOLVED,
+    cleanupProvider: "claude",
+    cleanupDefault: true,
+  };
+  const VAULT_CONFIG: ScribeConfig = {
+    vault: {
+      url: "http://localhost:1940",
+      contexts: [{ tag: "person" }],
+    },
+  };
+
+  let originalToken: string | undefined;
+  let realFetch: typeof globalThis.fetch;
+  let vaultCalls: number;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    realFetch = globalThis.fetch;
+    vaultCalls = 0;
+    globalThis.fetch = (async (input: Request | string | URL) => {
+      const url = typeof input === "string" ? new URL(input) : input instanceof URL ? input : new URL(input.url);
+      if (url.pathname.startsWith("/api/notes")) {
+        vaultCalls++;
+        return Response.json([{ path: "People/FromVault", metadata: { summary: "vault-side" } }]);
+      }
+      throw new Error(`unexpected fetch: ${url.toString()}`);
+    }) as typeof fetch;
+    clearVaultCache();
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+    globalThis.fetch = realFetch;
+  });
+
+  function reqWithContext(contextJson: string | null): Request {
+    const form = new FormData();
+    form.set("file", new File(["fake audio"], "test.wav"));
+    if (contextJson !== null) {
+      form.set("context", new Blob([contextJson], { type: "application/json" }), "context.json");
+    }
+    return new Request("http://localhost/v1/audio/transcriptions", {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  test("context part present → cleaner sees payload-derived nouns, vault is NOT called", async () => {
+    let seenNouns = "";
+    const handler = buildHandler({
+      cleanup: async (text, nouns) => {
+        seenNouns = nouns ?? "";
+        return `cleaned(${text})`;
+      },
+      resolvedConfig: CLEANUP_RESOLVED,
+      scribeConfig: VAULT_CONFIG,
+    });
+    const contextJson = JSON.stringify({
+      entries: [{ name: "Margaret", summary: "Close friend", aliases: ["Marg"] }],
+    });
+    const res = await handler(reqWithContext(contextJson));
+
+    expect(res.status).toBe(200);
+    expect(vaultCalls).toBe(0);
+    expect(seenNouns).toContain("## Known names in this context");
+    expect(seenNouns).toContain("- Margaret — Close friend (also: \"Marg\")");
+    expect(seenNouns).not.toContain("FromVault");
+  });
+
+  test("no context part + vault configured (default mode) → vault IS called", async () => {
+    const handler = buildHandler({
+      cleanup: async (text) => `cleaned(${text})`,
+      resolvedConfig: CLEANUP_RESOLVED,
+      scribeConfig: VAULT_CONFIG,
+    });
+    const res = await handler(reqWithContext(null));
+
+    expect(res.status).toBe(200);
+    expect(vaultCalls).toBeGreaterThan(0);
+  });
+
+  test("no context part + vault.mode='off' → vault is NOT called", async () => {
+    const handler = buildHandler({
+      cleanup: async (text) => `cleaned(${text})`,
+      resolvedConfig: CLEANUP_RESOLVED,
+      scribeConfig: {
+        vault: { ...VAULT_CONFIG.vault!, mode: "off" },
+      },
+    });
+    const res = await handler(reqWithContext(null));
+
+    expect(res.status).toBe(200);
+    expect(vaultCalls).toBe(0);
+  });
+
+  test("malformed context JSON → logged + falls through to vault", async () => {
+    let warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map((a) => String(a)).join(" ")); };
+    try {
+      const handler = buildHandler({
+        cleanup: async (text) => `cleaned(${text})`,
+        resolvedConfig: CLEANUP_RESOLVED,
+        scribeConfig: VAULT_CONFIG,
+      });
+      const res = await handler(reqWithContext("not valid json"));
+
+      expect(res.status).toBe(200);
+      expect(warnings.some((w) => w.includes("malformed 'context' part"))).toBe(true);
+      expect(vaultCalls).toBeGreaterThan(0);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test("empty entries context part → vault NOT called, cleaner gets empty nouns", async () => {
+    let seenNouns = "sentinel";
+    const handler = buildHandler({
+      cleanup: async (text, nouns) => {
+        seenNouns = nouns ?? "";
+        return text;
+      },
+      resolvedConfig: CLEANUP_RESOLVED,
+      scribeConfig: VAULT_CONFIG,
+    });
+    const res = await handler(reqWithContext(JSON.stringify({ entries: [] })));
+
+    expect(res.status).toBe(200);
+    expect(vaultCalls).toBe(0);
+    expect(seenNouns).toBe("");
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { cleaners, getProvider, transcribers, type Cleaner } from "./providers.ts";
-import { loadConfig, type ScribeConfig } from "./config.ts";
+import { DEFAULT_VAULT_MODE, loadConfig, type ScribeConfig } from "./config.ts";
 import { fetchProperNouns } from "./vault.ts";
+import { buildProperNounsBlockFromEntries, parseContextPayload } from "./context.ts";
 import { preflight, withCors } from "./cors.ts";
 import { upsertService } from "./services-manifest.ts";
 import {
@@ -84,6 +85,16 @@ async function handleTranscription(req: Request, deps: ServerDeps): Promise<Resp
         ? false
         : cleanupDefault);
 
+  const contextPart = form.get("context");
+  let contextPayload: ReturnType<typeof parseContextPayload> = null;
+  if (contextPart != null) {
+    const raw = contextPart instanceof Blob ? await contextPart.text() : String(contextPart);
+    contextPayload = parseContextPayload(raw);
+    if (!contextPayload) {
+      console.warn("[scribe] malformed 'context' part in transcription request — ignoring, will fall through to vault");
+    }
+  }
+
   let text: string;
   try {
     text = await deps.transcribe(file);
@@ -95,7 +106,7 @@ async function handleTranscription(req: Request, deps: ServerDeps): Promise<Resp
 
   if (doCleanup) {
     try {
-      const properNouns = await fetchProperNouns(deps.scribeConfig);
+      const properNouns = await resolveProperNouns(deps.scribeConfig, contextPayload);
       text = await deps.cleanup(text, properNouns);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -104,6 +115,16 @@ async function handleTranscription(req: Request, deps: ServerDeps): Promise<Resp
   }
 
   return Response.json({ text });
+}
+
+async function resolveProperNouns(
+  config: ScribeConfig,
+  contextPayload: ReturnType<typeof parseContextPayload>,
+): Promise<string> {
+  if (contextPayload) return buildProperNounsBlockFromEntries(contextPayload);
+  const mode = config.vault?.mode ?? DEFAULT_VAULT_MODE;
+  if (mode === "off") return "";
+  return fetchProperNouns(config);
 }
 
 export async function startServer() {
@@ -126,6 +147,7 @@ export async function startServer() {
       configured: Boolean(config.vault?.url),
       url: config.vault?.url ?? null,
       cacheTtlSeconds: config.vault?.cache_ttl_seconds ?? null,
+      mode: config.vault?.mode ?? DEFAULT_VAULT_MODE,
     },
   };
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -133,6 +133,59 @@ describe("fetchProperNouns", () => {
     await fetchProperNouns(config);
     expect(hits).toBe(1);
   });
+
+  describe("vault.mode", () => {
+    test("mode: 'off' returns empty without making any HTTP call", async () => {
+      let called = false;
+      mockFetch(() => {
+        called = true;
+        return Response.json([]);
+      });
+
+      const config: ScribeConfig = {
+        vault: {
+          url: "http://localhost:1940",
+          contexts: [{ tag: "person" }],
+          mode: "off",
+        },
+      };
+
+      expect(await fetchProperNouns(config)).toBe("");
+      expect(called).toBe(false);
+    });
+
+    test("mode: 'required' propagates fetch errors instead of swallowing them", async () => {
+      mockFetch(() => {
+        throw new Error("ECONNREFUSED");
+      });
+
+      const config: ScribeConfig = {
+        vault: {
+          url: "http://localhost:9",
+          contexts: [{ tag: "person" }],
+          mode: "required",
+        },
+      };
+
+      await expect(fetchProperNouns(config)).rejects.toThrow(/ECONNREFUSED/);
+    });
+
+    test("mode: 'fallback' (default) swallows errors and returns empty", async () => {
+      mockFetch(() => {
+        throw new Error("ECONNREFUSED");
+      });
+
+      const config: ScribeConfig = {
+        vault: {
+          url: "http://localhost:9",
+          contexts: [{ tag: "person" }],
+          mode: "fallback",
+        },
+      };
+
+      expect(await fetchProperNouns(config)).toBe("");
+    });
+  });
 });
 
 describe("buildCleanupPrompt", () => {

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1,4 +1,4 @@
-import type { ScribeConfig, VaultContext } from "./config.ts";
+import { DEFAULT_VAULT_MODE, type ScribeConfig, type VaultContext } from "./config.ts";
 
 type NoteRow = {
   path: string;
@@ -21,6 +21,8 @@ export function clearVaultCache() {
 
 export async function fetchProperNouns(config: ScribeConfig): Promise<string> {
   const vault = config.vault;
+  const mode = vault?.mode ?? DEFAULT_VAULT_MODE;
+  if (mode === "off") return "";
   if (!vault?.url || !vault.contexts?.length) return "";
 
   const ttlMs = (vault.cache_ttl_seconds ?? DEFAULT_TTL_SECONDS) * 1000;
@@ -45,6 +47,7 @@ export async function fetchProperNouns(config: ScribeConfig): Promise<string> {
     cache.set(cacheKey, { at: Date.now(), value: body });
     return body;
   } catch (err) {
+    if (mode === "required") throw err;
     const message = err instanceof Error ? err.message : String(err);
     console.warn(`[scribe] vault proper-noun fetch failed: ${message}`);
     return "";


### PR DESCRIPTION
## Summary

- Callers can now push proper-noun context to scribe in a `context` multipart part on `POST /v1/audio/transcriptions`, instead of scribe reaching back into a vault.
- Adds `vault.mode: \"off\" | \"fallback\" | \"required\"` (default `\"fallback\"`) so the backchannel is an explicit, configurable choice — not an implicit side-effect.
- Library `transcribe()` gains a symmetric `opts.context` field.
- vault.ts stays — the brief explicitly scopes its removal to a separate follow-up.

## Why

Today scribe reaches back into a configured vault on every cleanup that runs without cached nouns. That couples scribe to vault's network reachability and auth surface, and means every caller either gets *that* vault's nouns or none. The stateless-scribe direction (CLAUDE.md) is for callers to push whatever context they want cleaned-up around.

Parachute vault's `transcription-worker.ts` already constructs a `context` multipart part via `appendContextPart` — this PR lets scribe actually read it.

## Payload shape (matches vault's `appendContextPart`)

```json
{
  \"entries\": [
    { \"name\": \"Margaret\",          \"summary\": \"Close friend\",  \"aliases\": [\"Marg\"] },
    { \"name\": \"Learn Vibe Build\",  \"summary\": \"6-week cohort\", \"aliases\": [\"LVB\", \"Learn by Build\"] }
  ]
}
```

Rendered into a \"Known names in this context\" block that the cleanup prompt consumes. No wikilinks — the payload doesn't carry paths/tags, so we only correct spelling + aliases (the wikilink wrapping stays with the vault-backchannel path which does know paths).

## Precedence

1. If the request has a `context` part → use it, skip vault entirely
2. Else if `vault.mode === \"off\"` → no vault call, no proper nouns
3. Else → fetch vault; errors on \"fallback\" (default) become empty; errors on \"required\" propagate (PR #18's wrapper catches → raw transcription survives)

Malformed `context` JSON logs a warning and falls through to the vault flow rather than 400-ing the transcription — cleanup context is best-effort.

## Surface changes

- `src/context.ts` (new) — `parseContextPayload`, `buildProperNounsBlockFromEntries`
- `src/config.ts` — adds `VaultMode`, `DEFAULT_VAULT_MODE`, `vault.mode` field. `vault.url` is now optional so `{ mode: \"off\" }` can stand alone.
- `src/config-schema.ts` — exposes `mode` in the JSON Schema (with enum + default) and in the `/.parachute/config` resolved view
- `src/vault.ts` — honors `mode`: off skips entirely, required propagates errors
- `src/server.ts` — reads + parses the `context` part, short-circuits vault when present
- `src/index.ts` — library gets a symmetric `opts.context`
- `README.md` — documents both push (preferred) and pull modes

## Test plan

- [x] `src/context.test.ts` (new) — 10 tests over parse + block building, including malformed input, missing `name`, string-encoded aliases, unknown fields
- [x] `src/vault.test.ts` — 3 new tests covering each `mode` value
- [x] `src/server.test.ts` — 5 new integration tests: context present short-circuits vault; no context + default mode hits vault; `mode: \"off\"` doesn't hit vault; malformed context falls through with a warning; empty-entries context means no nouns + no vault call
- [x] `src/config-schema.test.ts` — asserts `vault.mode` schema enum + default
- [x] `bun test` — 88 / 88 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)