### PR TITLE
feat: user-configurable cleanup prompt

### DIFF
--- a/src/cleanup/claude-code.ts
+++ b/src/cleanup/claude-code.ts
@@ -1,4 +1,4 @@
-import { buildCleanupPrompt } from "./prompt.ts";
+import { buildCleanupPrompt, type CleanupPromptOpts } from "./prompt.ts";
 
 export type SpawnResult = { stdout: string; stderr: string; exitCode: number | null };
 
@@ -37,8 +37,12 @@ const defaultSpawn: SpawnFn = async ({ cmd, stdin, timeoutMs }) => {
 };
 
 export function makeCleaner(spawnFn: SpawnFn = defaultSpawn) {
-  return async (text: string, properNouns?: string): Promise<string> => {
-    const prompt = buildCleanupPrompt(properNouns);
+  return async (
+    text: string,
+    properNouns?: string,
+    opts?: CleanupPromptOpts,
+  ): Promise<string> => {
+    const prompt = buildCleanupPrompt(properNouns, opts);
     const stdin = `${prompt}\n\nTranscript to clean:\n\n${text}`;
 
     let result: SpawnResult;

--- a/src/cleanup/claude.ts
+++ b/src/cleanup/claude.ts
@@ -1,6 +1,10 @@
-import { buildCleanupPrompt } from "./prompt.ts";
+import { buildCleanupPrompt, type CleanupPromptOpts } from "./prompt.ts";
 
-export async function cleanup(text: string, properNouns?: string): Promise<string> {
+export async function cleanup(
+  text: string,
+  properNouns?: string,
+  opts?: CleanupPromptOpts,
+): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error("ANTHROPIC_API_KEY not set");
 
@@ -14,7 +18,7 @@ export async function cleanup(text: string, properNouns?: string): Promise<strin
     body: JSON.stringify({
       model: process.env.CLAUDE_MODEL ?? "claude-sonnet-4-20250514",
       max_tokens: 4096,
-      system: buildCleanupPrompt(properNouns),
+      system: buildCleanupPrompt(properNouns, opts),
       messages: [{ role: "user", content: text }],
     }),
   });

--- a/src/cleanup/ollama.ts
+++ b/src/cleanup/ollama.ts
@@ -1,6 +1,10 @@
-import { buildCleanupPrompt } from "./prompt.ts";
+import { buildCleanupPrompt, type CleanupPromptOpts } from "./prompt.ts";
 
-export async function cleanup(text: string, properNouns?: string): Promise<string> {
+export async function cleanup(
+  text: string,
+  properNouns?: string,
+  opts?: CleanupPromptOpts,
+): Promise<string> {
   const url = process.env.OLLAMA_URL ?? "http://localhost:11434";
   const model = process.env.OLLAMA_MODEL ?? "gemma4:e4b";
 
@@ -11,7 +15,7 @@ export async function cleanup(text: string, properNouns?: string): Promise<strin
       model,
       stream: false,
       messages: [
-        { role: "system", content: buildCleanupPrompt(properNouns) },
+        { role: "system", content: buildCleanupPrompt(properNouns, opts) },
         { role: "user", content: text },
       ],
     }),

--- a/src/cleanup/openai-compat.ts
+++ b/src/cleanup/openai-compat.ts
@@ -1,4 +1,4 @@
-import { buildCleanupPrompt } from "./prompt.ts";
+import { buildCleanupPrompt, type CleanupPromptOpts } from "./prompt.ts";
 
 type ProviderConfig = {
   baseUrl: string;
@@ -7,7 +7,11 @@ type ProviderConfig = {
 };
 
 function makeCleanup(config: ProviderConfig) {
-  return async function cleanup(text: string, properNouns?: string): Promise<string> {
+  return async function cleanup(
+    text: string,
+    properNouns?: string,
+    opts?: CleanupPromptOpts,
+  ): Promise<string> {
     const apiKey = config.apiKey;
     if (!apiKey) throw new Error(`API key not set for cleanup provider`);
 
@@ -22,7 +26,7 @@ function makeCleanup(config: ProviderConfig) {
       body: JSON.stringify({
         model,
         messages: [
-          { role: "system", content: buildCleanupPrompt(properNouns) },
+          { role: "system", content: buildCleanupPrompt(properNouns, opts) },
           { role: "user", content: text },
         ],
       }),

--- a/src/cleanup/prompt.test.ts
+++ b/src/cleanup/prompt.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { CLEANUP_PROMPT, buildCleanupPrompt } from "./prompt.ts";
+
+describe("buildCleanupPrompt", () => {
+  test("no opts, no proper nouns → returns base prompt unchanged", () => {
+    const result = buildCleanupPrompt();
+    expect(result).toBe(CLEANUP_PROMPT);
+  });
+
+  test("no opts, with proper nouns → appends block with '\\n\\n' separator", () => {
+    const result = buildCleanupPrompt("## Proper nouns\n\nPeople:\n- Sam");
+    expect(result).toBe(`${CLEANUP_PROMPT}\n\n## Proper nouns\n\nPeople:\n- Sam`);
+  });
+
+  test("systemPrompt override → uses override and default-appends proper-nouns block", () => {
+    const result = buildCleanupPrompt("NOUNS", {
+      systemPrompt: "OVERRIDE",
+    });
+    expect(result).toBe("OVERRIDE\n\nNOUNS");
+    expect(result).not.toContain("voice memo transcripts");
+  });
+
+  test("systemPrompt override with empty proper nouns → override only, no trailing separator", () => {
+    const result = buildCleanupPrompt(undefined, { systemPrompt: "OVERRIDE" });
+    expect(result).toBe("OVERRIDE");
+  });
+
+  test("both overrides → systemPrompt + rendered contextTemplate with proper nouns substituted", () => {
+    const result = buildCleanupPrompt("NOUNS", {
+      systemPrompt: "OVERRIDE",
+      contextTemplate: "\n---\n{{proper_nouns}}\n---\n",
+    });
+    expect(result).toBe("OVERRIDE\n---\nNOUNS\n---\n");
+  });
+
+  test("contextTemplate with empty proper nouns → template renders with empty substitution (no dangling newlines)", () => {
+    const result = buildCleanupPrompt("", {
+      contextTemplate: "[nouns: {{proper_nouns}}]",
+    });
+    expect(result).toBe(`${CLEANUP_PROMPT}[nouns: ]`);
+  });
+
+  test("contextTemplate overrides default '\\n\\n' separator behavior — template owns separators", () => {
+    // Without the template, default would prepend "\n\n". With template,
+    // the caller's template is the only thing appended to the base prompt.
+    const result = buildCleanupPrompt("NOUNS", {
+      contextTemplate: " — {{proper_nouns}}",
+    });
+    expect(result).toBe(`${CLEANUP_PROMPT} — NOUNS`);
+  });
+});

--- a/src/cleanup/prompt.ts
+++ b/src/cleanup/prompt.ts
@@ -10,8 +10,34 @@ Return only the cleaned text. No commentary, no preamble.`;
 
 export const CLEANUP_PROMPT = BASE_PROMPT;
 
-export function buildCleanupPrompt(properNouns?: string): string {
-  const extra = properNouns?.trim();
-  if (!extra) return BASE_PROMPT;
-  return `${BASE_PROMPT}\n\n${extra}`;
+export type CleanupPromptOpts = {
+  /**
+   * Full override of the default base prompt. When set, `BASE_PROMPT` is
+   * replaced verbatim — the user is responsible for the entire system prompt.
+   */
+  systemPrompt?: string;
+  /**
+   * Template for how the proper-nouns block is appended after the base prompt.
+   * Only variable is `{{proper_nouns}}`. When unset, the default is to append
+   * `\n\n${proper_nouns}` only if proper_nouns is non-empty (no dangling
+   * whitespace when there's nothing to append). When set, the template is
+   * always rendered, even with an empty substitution — the caller's template
+   * owns its own separators.
+   */
+  contextTemplate?: string;
+};
+
+export function buildCleanupPrompt(
+  properNouns?: string,
+  opts?: CleanupPromptOpts,
+): string {
+  const base = opts?.systemPrompt ?? BASE_PROMPT;
+  const nouns = properNouns?.trim() ?? "";
+
+  if (opts?.contextTemplate !== undefined) {
+    return base + opts.contextTemplate.replaceAll("{{proper_nouns}}", nouns);
+  }
+
+  if (!nouns) return base;
+  return `${base}\n\n${nouns}`;
 }

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -12,6 +12,8 @@ const SAMPLE: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
   cleanupProvider: "ollama",
   cleanupDefault: true,
+  cleanupSystemPrompt: null,
+  cleanupContextTemplate: null,
   port: 1943,
   vault: {
     configured: true,
@@ -90,5 +92,16 @@ describe("config-schema", () => {
     const mode = schema.properties.vault.properties.mode;
     expect(mode.enum).toEqual(["off", "fallback", "required"]);
     expect(mode.default).toBe("fallback");
+  });
+
+  test("schema exposes cleanupSystemPrompt + cleanupContextTemplate as optional strings with descriptions", () => {
+    const schema = buildConfigSchema();
+    const systemPrompt = schema.properties.cleanupSystemPrompt;
+    const template = schema.properties.cleanupContextTemplate;
+    expect(systemPrompt.type).toBe("string");
+    expect(systemPrompt.description).toBeString();
+    expect(template.type).toBe("string");
+    expect(template.description).toBeString();
+    expect(template.description).toContain("{{proper_nouns}}");
   });
 });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -12,6 +12,8 @@ export type ResolvedConfig = {
   transcribeProvider: string;
   cleanupProvider: string;
   cleanupDefault: boolean;
+  cleanupSystemPrompt: string | null;
+  cleanupContextTemplate: string | null;
   port: number;
   vault: {
     configured: boolean;
@@ -47,6 +49,16 @@ export function buildConfigSchema() {
         title: "Run cleanup by default",
         description: "When a transcription request omits an explicit cleanup flag, run the cleanup pass anyway.",
         default: true,
+      },
+      cleanupSystemPrompt: {
+        type: "string",
+        title: "Cleanup system prompt override",
+        description: "Optional full override of scribe's built-in cleanup system prompt. When set, the caller owns the entire instruction to the cleanup LLM. The proper-nouns block (from vault or request payload) is still appended after it per cleanupContextTemplate.",
+      },
+      cleanupContextTemplate: {
+        type: "string",
+        title: "Cleanup context-block template",
+        description: "Optional template for how the proper-nouns block is appended after the system prompt. Supports one variable: {{proper_nouns}}. When unset, scribe uses its default rule (append `\\n\\n{proper_nouns}` only if the block is non-empty). When set, the template is always rendered — the caller's template owns its own separators.",
       },
       port: {
         type: "integer",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,21 @@ export type ScribeConfig = {
     provider?: string;
     model?: string;
     default?: boolean;
+    /**
+     * Optional full override of the built-in cleanup system prompt. When set,
+     * the caller owns the entire instruction to the cleanup LLM. The
+     * proper-nouns block (from vault or payload) is still appended per
+     * context_template.
+     */
+    system_prompt?: string;
+    /**
+     * Optional template for how the proper-nouns block is appended after
+     * the system prompt. Supports one variable: {{proper_nouns}}. When unset,
+     * scribe uses its default rule (append `\n\n{proper_nouns}` only if the
+     * block is non-empty). When set, the template is always rendered — the
+     * caller's template owns its own separators.
+     */
+    context_template?: string;
   };
   vault?: {
     url?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,10 @@ export async function transcribe(
   if (cleanupProvider !== "none") {
     try {
       const properNouns = await resolveProperNouns(config, contextPayload);
-      text = await cleaner(text, properNouns);
+      text = await cleaner(text, properNouns, {
+        systemPrompt: config.cleanup?.system_prompt,
+        contextTemplate: config.cleanup?.context_template,
+      });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`Cleanup failed (provider=${cleanupProvider}): ${message} — returning raw transcription`);

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -16,7 +16,16 @@ export const transcribers: Record<string, (audio: File) => Promise<string>> = {
   openai,
 };
 
-export type Cleaner = (text: string, properNouns?: string) => Promise<string>;
+export type CleanerOpts = {
+  systemPrompt?: string;
+  contextTemplate?: string;
+};
+
+export type Cleaner = (
+  text: string,
+  properNouns?: string,
+  opts?: CleanerOpts,
+) => Promise<string>;
 
 export const cleaners: Record<string, Cleaner> = {
   claude,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -9,6 +9,8 @@ const RESOLVED: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
   cleanupProvider: "none",
   cleanupDefault: false,
+  cleanupSystemPrompt: null,
+  cleanupContextTemplate: null,
   port: 1943,
   vault: { configured: false, url: null, cacheTtlSeconds: null, mode: "fallback" },
 };
@@ -191,6 +193,28 @@ describe("createFetchHandler — cleanup failure behavior", () => {
     const res = await handler(transcribeReq());
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ text: "cleaned(raw)" });
+  });
+
+  test("threads cleanup.system_prompt + context_template from config into cleaner opts", async () => {
+    let seenOpts: { systemPrompt?: string; contextTemplate?: string } | undefined;
+    const handler = buildHandler({
+      transcribe: async () => "raw",
+      cleanup: async (text, _nouns, opts) => {
+        seenOpts = opts;
+        return `cleaned(${text})`;
+      },
+      resolvedConfig: CLEANUP_RESOLVED,
+      scribeConfig: {
+        cleanup: {
+          system_prompt: "OVERRIDE PROMPT",
+          context_template: "\n\nCONTEXT: {{proper_nouns}}",
+        },
+      },
+    });
+    const res = await handler(transcribeReq());
+    expect(res.status).toBe(200);
+    expect(seenOpts?.systemPrompt).toBe("OVERRIDE PROMPT");
+    expect(seenOpts?.contextTemplate).toBe("\n\nCONTEXT: {{proper_nouns}}");
   });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,7 +107,10 @@ async function handleTranscription(req: Request, deps: ServerDeps): Promise<Resp
   if (doCleanup) {
     try {
       const properNouns = await resolveProperNouns(deps.scribeConfig, contextPayload);
-      text = await deps.cleanup(text, properNouns);
+      text = await deps.cleanup(text, properNouns, {
+        systemPrompt: deps.scribeConfig.cleanup?.system_prompt,
+        contextTemplate: deps.scribeConfig.cleanup?.context_template,
+      });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`Cleanup failed (provider=${cleanupProvider}): ${message} — returning raw transcription`);
@@ -142,6 +145,8 @@ export async function startServer() {
     transcribeProvider: TRANSCRIBE,
     cleanupProvider: CLEANUP,
     cleanupDefault: CLEANUP_DEFAULT,
+    cleanupSystemPrompt: config.cleanup?.system_prompt ?? null,
+    cleanupContextTemplate: config.cleanup?.context_template ?? null,
     port: PORT,
     vault: {
       configured: Boolean(config.vault?.url),


### PR DESCRIPTION
## Summary

- Add two optional fields on `cleanup` in scribe's config — `system_prompt` (full override of the built-in base prompt) and `context_template` (how the proper-nouns block is appended; `{{proper_nouns}}` is the only variable)
- Extend `buildCleanupPrompt(properNouns, opts?)` and thread the opts through all four cleanup providers (claude, claude-code, ollama, openai-compat) plus the server + library call sites
- Surface the resolved values at `/.parachute/config` (`cleanupSystemPrompt`, `cleanupContextTemplate`, `null` when unset) and describe both fields in the draft-07 JSON Schema at `/.parachute/config/schema`

## Design notes

- **Template semantics**: when `context_template` is set, scribe always renders it — even when proper nouns are empty — and the caller's template owns its own separators. When unset, scribe keeps the existing "append `\n\n{nouns}` only if non-empty" behavior, so no dangling whitespace sneaks into the default path.
- **Substitution is `replaceAll("{{proper_nouns}}", nouns)`** — no Mustache/Handlebars, no `{{transcript}}` variable today. One variable, one substitution.
- **Config-file only** — no env-var overrides for these two fields (multi-line prompts don't round-trip through env cleanly and the "config file is the source of truth" story is simpler).
- **Default provider unchanged** — this is purely additive for people who want more control over the prompt.

## Test plan

- [x] `buildCleanupPrompt` unit tests: no opts, systemPrompt-only, both overrides, empty proper nouns + template (no dangling `\n\n`), and template-owns-separator behavior
- [x] Schema test asserts `cleanupSystemPrompt` + `cleanupContextTemplate` are exposed with descriptions and `{{proper_nouns}}` is mentioned
- [x] Server test asserts `cleanup.system_prompt` + `cleanup.context_template` from `scribeConfig` land in the cleaner's `opts` argument
- [x] `bun test` — 98 pass, 0 fail
- [x] `bunx tsc --noEmit` clean

Part of the stateless-scribe series. #18, #19, #20 preceded this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)