### PR TITLE
docs: update parachute-cli refs to parachute-hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Library (import transcribe)    ─┘
 - **`src/auth.ts`** (PR #16) — single `validateToken(token) → {valid, scopes}` seam. Today: shared-secret string compare against `SCRIBE_AUTH_TOKEN`. Tomorrow: hub-issued JWT, body swap, callers unchanged.
 - **`src/config.ts` / `src/config-schema.ts`** — file shape + loader; draft-07 JSON Schema served at `/.parachute/config/schema` (provider enums sourced from the live registry so the schema can't drift).
 - **`src/parachute-info.ts`** — `/.parachute/info` + `/.parachute/icon.svg` (hub discovery contract).
-- **`src/services-manifest.ts`** — atomic upsert into `~/.parachute/services.json` on `serve` boot so the CLI coordinator can find scribe.
+- **`src/services-manifest.ts`** — atomic upsert into `~/.parachute/services.json` on `serve` boot so the hub can find scribe.
 
 ## Key design decisions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.3.0",
+  "version": "0.3.1-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Cross-repo doc sweep for the 2026-04-26 hub rename (`parachute-cli` → `parachute-hub`, `@openparachute/cli` → `@openparachute/hub`). Scope is docs-only — no code, types, providers, or schema touched.

`git grep -E "parachute-cli|@openparachute/cli"` returned **zero hits** in this repo. The only role-name reference was a single line in `CLAUDE.md` calling the hub "the CLI coordinator". Two other "the CLI" mentions (`README.md:181`, `.env.example:48`) refer to scribe's own `parachute-scribe` binary and are out of scope.

## Per-file changes

- **`CLAUDE.md`** — line 21: "the CLI coordinator can find scribe" → "the hub can find scribe". Brings this line in line with line 20 above ("hub discovery contract").
- **`package.json`** — version `0.3.0` → `0.3.1-rc.1` per RC versioning policy.

## Test plan

- [x] `bun test` — 87 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] No biome config in repo, skipped

## Patterns check

Touches naming convention only. The hub-rename is captured in `parachute-patterns/` and the workspace `CLAUDE.md`; no new pattern established here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>