### PR TITLE
release: 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.3.1-rc.1",
+  "version": "0.3.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Promotes the cli→hub doc-sweep change (#23) to a stable release. Drops the `-rc.1` suffix from `0.3.1-rc.1` so `npm publish --access public` (no `--tag`) lands on `latest`.

After merge: `npm publish --access public` moves `@openparachute/scribe@latest` to `0.3.1`.

## Test plan

- [x] `bun test` — 87 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>