### PR TITLE
auth: timing-safe shared-secret compare + close #30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -3,6 +3,7 @@ import {
   AUTH_EXEMPT_PATHS,
   SCOPE_ADMIN,
   SCOPE_TRANSCRIBE,
+  constantTimeStringEqual,
   enforceAuth,
   extractBearer,
   hasScope,
@@ -202,6 +203,31 @@ describe("auth", () => {
       expect(res.status).toBe(401);
       const body = (await res.json()) as { message: string };
       expect(body.message).toContain("hub JWT verification failed");
+    });
+  });
+
+  describe("constantTimeStringEqual", () => {
+    test("returns true for equal strings", () => {
+      expect(constantTimeStringEqual("s3cret", "s3cret")).toBe(true);
+    });
+
+    test("returns false for different same-length strings", () => {
+      expect(constantTimeStringEqual("abcdef", "abcxyz")).toBe(false);
+    });
+
+    test("returns false for different-length strings (no throw)", () => {
+      expect(constantTimeStringEqual("short", "much-longer-secret")).toBe(false);
+      expect(constantTimeStringEqual("much-longer-secret", "short")).toBe(false);
+    });
+
+    test("handles empty strings", () => {
+      expect(constantTimeStringEqual("", "")).toBe(true);
+      expect(constantTimeStringEqual("", "x")).toBe(false);
+    });
+
+    test("handles multibyte utf-8 (compares bytes, not codepoints)", () => {
+      expect(constantTimeStringEqual("café", "café")).toBe(true);
+      expect(constantTimeStringEqual("café", "cafe")).toBe(false);
     });
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,6 +18,8 @@
  * "valid? what scopes?", not "does this scope satisfy this route?".
  */
 
+import { Buffer } from "node:buffer";
+import { timingSafeEqual } from "node:crypto";
 import { HubJwtError, looksLikeJwt, validateHubJwt } from "./hub-jwt.ts";
 
 export const SCOPE_TRANSCRIBE = "scribe:transcribe" as const;
@@ -64,8 +66,25 @@ export async function validateToken(token: string | undefined): Promise<AuthResu
     }
   }
 
-  if (token !== required) return { valid: false, reason: "token-mismatch" };
+  if (!constantTimeStringEqual(token, required)) {
+    return { valid: false, reason: "token-mismatch" };
+  }
   return { valid: true, scopes: FULL_SCOPES, mode: "shared-secret" };
+}
+
+/**
+ * Constant-time string compare for the shared-secret path. The risk on a
+ * loopback-only deployment is negligible (an attacker with same-host access
+ * has bigger problems), but timing-safe is the standard hygiene for any
+ * secret compare. `timingSafeEqual` requires equal-length buffers; the
+ * length pre-check leaks length only — the secret length is fixed per
+ * deployment, not the secret itself, so this is fine.
+ */
+export function constantTimeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
 }
 
 export function isAuthRequired(): boolean {


### PR DESCRIPTION
## Summary

Two tiny cleanup items off scribe's backlog.

### #30 — JWT-shape footgun warning — **already shipped in #29**
Verified `warnIfTokenLooksJwt()` is in main (auth.ts:75-93, called from server.ts:181). Closes #30 as already-done.

### #31 — Timing-safe shared-secret compare
Flip `validateToken`'s `token !== required` to `constantTimeStringEqual` — a `Buffer.from(s, 'utf8')` + `crypto.timingSafeEqual` helper.

- Length pre-check returns false on length mismatch (avoids the throw `timingSafeEqual` does on unequal-length buffers). Leaks length only; the secret length is a per-deployment constant, so no content leak.
- 5 new tests: equal, same-length-different, different-length, empty, multibyte UTF-8.

Risk on a loopback-only deployment is negligible (an attacker with same-host access has bigger problems), but timing-safe is the standard hygiene for any secret compare.

## Version

`0.4.0-rc.1` → `0.4.0-rc.2` — additive change to existing auth seam, no surface-shape impact.

## Gates

- `bun run typecheck` clean
- `bun test src/` — **107/107** (was 102 → +5 for `constantTimeStringEqual`)

## Test plan

- [x] Existing shared-secret accept/reject tests still pass
- [x] New `constantTimeStringEqual` cases (equal, same-length-mismatch, different-length, empty, multibyte) pass
- [x] No throw on length mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)