### PR TITLE
feat(hub-jwt): adopt @openparachute/scope-guard (Step 3 of 4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "parachute-scribe",
       "dependencies": {
-        "jose": "^6.2.2",
+        "@openparachute/scope-guard": "^0.1.0-rc.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -17,6 +17,8 @@
     },
   },
   "packages": {
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0-rc.1", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-SRRzBmbbf4uWP0nKYLFg6Fasna2zl+BtADedCeQgCoHxmdwE8JaE3y5USZLLNaU5YJ9tzItXhWOsLtTFgJHgtQ=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "jose": "^6.2.2"
+    "@openparachute/scope-guard": "^0.1.0-rc.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.0-rc.2",
+  "version": "0.4.0-rc.3",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -1,86 +1,73 @@
 /**
- * Hub-issued JWT validation for scribe.
+ * Hub-issued JWT validation. Scribe as resource server: trusts tokens that the
+ * hub signs against keys we fetch from the hub's `/.well-known/jwks.json`.
  *
- * Mirrors `parachute-vault/src/hub-jwt.ts` (the canonical implementation) with
- * scribe's narrower needs:
- *   - No per-resource audience binding — scribe is a single endpoint, not
- *     a multi-vault dispatcher. We accept any aud claim.
- *   - Only the `scope` claim is surfaced; downstream is `scribe:transcribe`
- *     vs `scribe:admin` exact-match enforcement.
+ * The trust kernel — JWKS fetch + verify, issuer pin, RFC 7519 string-or-array
+ * `aud` handling — lives in the shared `@openparachute/scope-guard` library
+ * so vault, scribe, and paraclaw can't silently drift on the worst place to
+ * drift. This file is the scribe-side adapter: hub-origin resolution
+ * (env-var precedence + loopback fallback), a process-wide guard instance,
+ * and re-exports preserving the public surface every existing call site
+ * already imports.
  *
- * Trust pin: `iss` MUST equal the configured hub origin. Without that check,
- * a token signed by any RSA key would pass.
+ * Scribe is a single endpoint, not a multi-resource dispatcher — we don't pass
+ * `expectedAudience`. The lib's claim shape is richer than what scribe's
+ * callers historically used (it surfaces `aud`, `jti`, `clientId` in addition
+ * to `sub`/`scopes`). That's additive — `auth.ts` only consumes `scopes`.
+ *
+ * Scope-guard adoption: Step 3 of 4 (after vault, before paraclaw).
  */
-import { type JWTPayload, createRemoteJWKSet, jwtVerify } from "jose";
+import {
+  createScopeGuard,
+  HubJwtError,
+  type HubJwtClaims,
+  looksLikeJwt,
+} from "@openparachute/scope-guard";
 
 const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
 
+/**
+ * Resolve the hub origin used to fetch JWKS and validate `iss`. Strips a
+ * trailing slash so we get a single canonical form.
+ *
+ * Order: env var → loopback fallback. We deliberately don't read
+ * `~/.parachute/services.json` — the hub is the dispatcher, not a registered
+ * service in that file. If a deployment exposes the hub on a non-default
+ * origin, the env var is the contract.
+ */
 export function getHubOrigin(): string {
   const env = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
   if (env && env.length > 0) return env;
   return DEFAULT_HUB_LOOPBACK;
 }
 
+// Process-wide guard. The resolver form lets tests flip
+// `PARACHUTE_HUB_ORIGIN` between cases — the lib re-resolves on every
+// `validateHubJwt` and `resetJwksCache` call so the env-var change picks up
+// without a server restart. JWKS cache (5min/30s defaults) lives inside the
+// guard, shared across requests.
+const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
+
 /**
- * A presented bearer token is JWT-shaped iff it begins with `eyJ` — the
- * base64url encoding of `{"` from a `{"alg":...}` JSON header. Cheap
- * pre-check so non-JWT tokens (the SCRIBE_AUTH_TOKEN shared secret) skip
- * JWKS verification entirely.
+ * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any
+ * failure (bad signature, wrong issuer, expired, missing kid, JWKS
+ * unreachable). On success returns the surfaced claims plus the parsed
+ * scope list.
+ *
+ * Trust pin: `iss` MUST equal the configured hub origin. Without that check,
+ * a token signed by any RSA key would pass verification.
  */
-export function looksLikeJwt(token: string): boolean {
-  return token.startsWith("eyJ");
-}
-
-export interface HubJwtClaims {
-  sub: string;
-  scopes: string[];
-}
-
-export class HubJwtError extends Error {
-  override name = "HubJwtError";
-}
-
-type JwksGetter = ReturnType<typeof createRemoteJWKSet>;
-let cachedGetter: JwksGetter | null = null;
-let cachedOrigin: string | null = null;
-
-function getJwksGetter(origin: string): JwksGetter {
-  if (cachedGetter && cachedOrigin === origin) return cachedGetter;
-  cachedGetter = createRemoteJWKSet(new URL(`${origin}/.well-known/jwks.json`), {
-    cacheMaxAge: 5 * 60 * 1000,
-    cooldownDuration: 30 * 1000,
-  });
-  cachedOrigin = origin;
-  return cachedGetter;
-}
-
-export function resetJwksCache(): void {
-  cachedGetter = null;
-  cachedOrigin = null;
-}
-
 export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
-  const origin = getHubOrigin();
-  const getter = getJwksGetter(origin);
-
-  let payload: JWTPayload;
-  try {
-    const verified = await jwtVerify(token, getter, { issuer: origin });
-    payload = verified.payload;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new HubJwtError(`hub JWT verification failed: ${msg}`);
-  }
-
-  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
-    throw new HubJwtError("hub JWT missing required `sub` claim");
-  }
-
-  const scopeRaw = (payload as { scope?: unknown }).scope;
-  const scopes =
-    typeof scopeRaw === "string"
-      ? scopeRaw.split(/\s+/).map((s) => s.trim()).filter(Boolean)
-      : [];
-
-  return { sub: payload.sub, scopes };
+  return guard.validateHubJwt(token);
 }
+
+/**
+ * Reset the cached JWKS getter. Tests use this to switch origins between
+ * cases; production callers shouldn't need it (origin is process-stable).
+ */
+export function resetJwksCache(): void {
+  guard.resetJwksCache();
+}
+
+export { HubJwtError, looksLikeJwt };
+export type { HubJwtClaims };


### PR DESCRIPTION
## Summary

Step 3 of 4 in the scope-guard rollout. Replaces scribe's hand-rolled JWKS getter + `jose.jwtVerify` wrapper with the shared `@openparachute/scope-guard` library (`0.1.0-rc.1`, on the npm `rc` dist-tag). Mirrors vault's adapter pattern from [parachute-vault PR #212](https://github.com/ParachuteComputer/parachute-vault/pull/212).

After this lands, only paraclaw remains on the duplicated trust kernel.

## What changes

- **`src/hub-jwt.ts`** — rewritten as a thin adapter (~75 lines, mirroring vault). Keeps `getHubOrigin` scribe-side (env-var precedence + loopback fallback); holds a process-wide `createScopeGuard({ hubOrigin: () => getHubOrigin() })`; re-exports `validateHubJwt`, `resetJwksCache`, `looksLikeJwt`, `HubJwtError`, `HubJwtClaims` so `auth.ts` and tests don't change.
- **`package.json`** — adds `@openparachute/scope-guard@^0.1.0-rc.1`, drops direct `jose` dep (now transitive through scope-guard).
- **`src/auth.ts`** — untouched. Shared-secret + JWT bifurcation stays where it is; the JWT half delegates through the unchanged `validateHubJwt` import.

## What stays scribe-side

- `getHubOrigin` resolver — `PARACHUTE_HUB_ORIGIN` → loopback fallback. Each consumer owns its origin policy.
- `SCOPE_TRANSCRIBE` / `SCOPE_ADMIN` constants and exact-match `hasScope` in `auth.ts`. Scribe's verbs are non-ladder (transcribe is not in `admin ⊇ write ⊇ read`), so the lib's inheritance-aware `hasScope` would still produce the right answer (exact-match for non-ladder names per the lib's contract), but scribe's `hasScope` has always been local — no need to swap, and keeping it local makes the auth seam self-contained.
- Shared-secret path (`SCRIBE_AUTH_TOKEN` compare) — unrelated trust axis.

## Claim shape note (additive, not breaking)

The lib's `HubJwtClaims` surfaces `aud`, `jti`, `clientId` in addition to `sub` and `scopes`. Scribe's old shape had only `sub` + `scopes`. After this swap callers see the richer object. **No code change beyond accepting it** — `auth.ts` only consumes `scopes`. Future logging / introspection paths get those fields for free.

## Spot-check: scope semantics preserved

Existing test (`auth.test.ts:111-113`) asserts no inheritance:

```ts
expect(hasScope([SCOPE_ADMIN], SCOPE_TRANSCRIBE)).toBe(false);
expect(hasScope([SCOPE_TRANSCRIBE], SCOPE_ADMIN)).toBe(false);
```

Still passes. JWT with `scope: \"scribe:transcribe\"` does NOT satisfy `scribe:admin` and vice versa — exact-match per `oauth-scopes.md`.

## Version

`0.4.0-rc.2` → `0.4.0-rc.3`. Internal refactor; auth surface and behavior unchanged.

## Gates

- `bun run typecheck` clean
- `bun test src/` — **107 / 107** (was 107 → +0; same cases pass post-swap)

## Test plan

- [x] All existing auth/hub-jwt cases pass post-swap
- [x] Malformed JWT → 401 with \"hub JWT verification failed\" message (still routes through `HubJwtError`)
- [x] Shared-secret path untouched, timing-safe compare still in place
- [x] Open mode (no `SCRIBE_AUTH_TOKEN`) still grants full scopes

## References

- Design: [parachute-hub `docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md)
- Step 2 (vault): [parachute-vault PR #212](https://github.com/ParachuteComputer/parachute-vault/pull/212)
- Lib: `@openparachute/scope-guard@0.1.0-rc.1` (npm `rc` dist-tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)