### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # output
 out
 dist
+package
 *.tgz
 
 # code coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 0.4.0 (2026-05-04)
+
+First @latest release since 0.3.0. Hardens auth, adopts the shared scope-guard kernel, and ships module-protocol conformance.
+
+### Added
+- **`@openparachute/scope-guard` adoption** — JWT validation now goes through the shared kernel (mirrors vault PR #212). `validateHubJwt`, `resetJwksCache`, `looksLikeJwt`, `HubJwtError`, `HubJwtClaims` re-exported so callers don't change. Lib's richer claim shape (`aud`, `jti`, `clientId`) is additive — available for future logging/introspection. (#33)
+- **`.parachute/module.json`** — canonical short-name (`name: scribe`, `manifestName: parachute-scribe`) per module-protocol design. (#29)
+- **DoS caps** on request handling. (#29)
+- **`installDir` preservation** across config migrations. (#29)
+
+### Changed
+- **Scope enforcement bundle** — formal scope checks at the auth boundary. Closes #25, #26, #27, #28. (#29)
+- **Timing-safe shared-secret compare** — replaced naive equality with constant-time `constantTimeStringEqual`. Closes #30, #31. (#32)
+- **Direct `jose` dep dropped** — now transitive via scope-guard. (#33)
+
+### Notes
+- 107/107 tests passing on main.
+- Targeting npm `@latest` after merge.
+
+## 0.3.1 (2026-04-23)
+
+- docs: update `parachute-cli` references to `parachute-hub`. (#23)
+
+## 0.3.0 (2026-04-23)
+
+- feat!: remove `vault.ts` backchannel — push-only context. (#22)
+- feat: user-configurable cleanup prompt. (#21)
+- feat: context-in-payload + `vault.mode` config. (#20)
+- feat: add `claude-code` cleanup provider. (#19)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.0-rc.3",
+  "version": "0.4.0",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Drop the `-rc.N` suffix to promote the cleanup + scope-guard line to npm `@latest`. Current `@latest` is `0.3.0`; this ships everything since.

## Changes since 0.3.0

- **#29** — cleanup bundle: scope enforcement at the auth boundary, `.parachute/module.json` (canonical short-name), DoS caps on request handling, `installDir` preservation across config migrations. Closes #25, #26, #27, #28.
- **#32** — auth: timing-safe shared-secret compare (`constantTimeStringEqual`). Closes #30, #31.
- **#33** — hub-jwt: adopt `@openparachute/scope-guard@^0.1.0-rc.1` shared kernel; drop direct `jose` dep (now transitive). Re-exports preserved so callers don't change. Mirrors vault PR #212.
- **#23** — docs: `parachute-cli` refs → `parachute-hub`.

Also in this PR:
- New `CHANGELOG.md` (this is the first one in the repo).
- `.gitignore` now excludes `package/` (was an unpacked `npm pack` artifact polluting `git status`).

## Gates

- `bun run typecheck` — clean
- `bun test` — **107 pass / 0 fail** (225 expect calls, 10 files)
- No lint config, no build step (Bun-native, ships TS directly per `files` whitelist)

## Publish target

`npm publish --tag latest` after merge → `@openparachute/scribe@0.4.0` on `@latest`.

## Test plan

- [ ] Reviewer confirms version bump correctness (`0.4.0-rc.3` → `0.4.0`)
- [ ] CHANGELOG accurately reflects shipped surface
- [ ] No new untracked artifacts after `git status` post-checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)