### PR TITLE
chore: bump scope-guard dep to 0.1.0 + correct CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0 (2026-05-04)
+## 0.4.0 (2026-05-05)
 
 First @latest release since 0.3.0. Hardens auth, adopts the shared scope-guard kernel, and ships module-protocol conformance.
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "parachute-scribe",
       "dependencies": {
-        "@openparachute/scope-guard": "^0.1.0-rc.1",
+        "@openparachute/scope-guard": "^0.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -17,7 +17,7 @@
     },
   },
   "packages": {
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0-rc.1", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-SRRzBmbbf4uWP0nKYLFg6Fasna2zl+BtADedCeQgCoHxmdwE8JaE3y5USZLLNaU5YJ9tzItXhWOsLtTFgJHgtQ=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-zPusPTeNUVzRQebjed8+vuhbdBaIQ6wpmJIwiXu31ybf8xP4+GrUrlFVkz4IhLJq00+TDFKvqVOKSFtx9s64MQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@openparachute/scope-guard": "^0.1.0-rc.1"
+    "@openparachute/scope-guard": "^0.1.0"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary

Two small touch-ups before publishing scribe@0.4.0 to npm `@latest`.

- **`package.json`**: `@openparachute/scope-guard` pin `^0.1.0-rc.1` → `^0.1.0`. Aaron published scope-guard@0.1.0 stable today; scribe now consumes the stable line. Note: `^0.1.0` does *not* match `0.1.0-rc.1` under npm semver (prereleases require explicit opt-in), so this is a real channel switch.
- **`bun.lock`**: regenerated against the live 0.1.0.
- **`CHANGELOG.md`**: `0.4.0 (2026-05-04)` → `0.4.0 (2026-05-05)` — actual publish date per Aaron.

**No version bump.** Scribe stays at 0.4.0; the pin update + date fix take effect when Aaron runs `npm publish`.

## Gates

- `bun run typecheck` — clean
- `bun test` — **107 pass / 0 fail** (225 expect calls, 10 files)
- `bun install` — resolves `@openparachute/scope-guard@0.1.0` cleanly

## Publish order (for reference)

1. ✅ scope-guard@0.1.0 — published to npm `@latest` today
2. ⏳ scribe@0.4.0 — publishes after this PR merges

## Test plan

- [ ] Reviewer confirms `^0.1.0` resolves to stable `0.1.0` (not the rc) on a fresh `bun install`
- [ ] CHANGELOG date matches publish day
- [ ] No scribe version drift (still 0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)