### PR TITLE
fix(boot): respect services.json port + use canonical 1943 default (closes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.4.1-rc.1] - 2026-05-08
+
+### Fixed
+- **Boot now respects `services.json` port + uses canonical 1943 default** — closes #40. v0.4.0's boot read `SCRIBE_PORT ?? PORT ?? DEFAULT_PORT` and ignored any existing entry in `~/.parachute/services.json`, so a stale `PORT=1944` in scribe's `.env` (written by hub's port-assigner when 1943 looked occupied) caused scribe to bind 1944 and rewrite services.json to match — silently colliding with the agent slot. New precedence: `services.json` entry → `SCRIBE_PORT` env → `PORT` env → canonical `1943`. Operator-set ports persist across restarts; the canonical default is only used when no entry exists. Bind failure now logs a named, actionable error before the throw.
+
+### Added
+- `readServiceEntry(name, path?)` in `services-manifest.ts` — pure lookup so callers can read the existing entry without instantiating the upsert path.
+- `port-resolve.ts` with `resolvePort(opts)` — pure, dependency-injected port resolver. Unit-tested across the precedence ladder + an integration suite that exercises the full read path against a real `services.json` under a tmp `PARACHUTE_HOME`.
+
+### Notes
+- 129/129 tests passing.
+- Companion bugs tracked separately: parachute-hub#195 (hub-side validation + recovery tool — defense in depth), parachute-agent#145 (agent has the same shape — port-rewrite on boot).
+
 ## 0.4.0 (2026-05-05)
 
 First @latest release since 0.3.0. Hardens auth, adopts the shared scope-guard kernel, and ships module-protocol conformance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.0",
+  "version": "0.4.1-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/port-resolve.test.ts
+++ b/src/port-resolve.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolvePort } from "./port-resolve.ts";
+import type { ServiceEntry } from "./services-manifest.ts";
+
+const SCRIBE_ENTRY: ServiceEntry = {
+  name: "parachute-scribe",
+  port: 1943,
+  paths: ["/scribe"],
+  health: "/health",
+  version: "0.4.0",
+};
+
+const noEntry = (_name: string) => undefined;
+
+describe("resolvePort", () => {
+  test("services.json entry wins over env and default (operator-set persists)", () => {
+    const result = resolvePort({
+      readEntry: () => ({ ...SCRIBE_ENTRY, port: 1947 }),
+      env: { SCRIBE_PORT: "9999", PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1947, source: "services.json" });
+  });
+
+  test("services.json with canonical 1943 → respect it (don't drift to env)", () => {
+    const result = resolvePort({
+      readEntry: () => SCRIBE_ENTRY,
+      env: { PORT: "1944" }, // hub's stale port-assigner
+    });
+    expect(result).toEqual({ port: 1943, source: "services.json" });
+  });
+
+  test("no services.json entry → SCRIBE_PORT env wins", () => {
+    const result = resolvePort({
+      readEntry: noEntry,
+      env: { SCRIBE_PORT: "5000", PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 5000, source: "SCRIBE_PORT" });
+  });
+
+  test("no entry, no SCRIBE_PORT → PORT env wins", () => {
+    const result = resolvePort({
+      readEntry: noEntry,
+      env: { PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1944, source: "PORT" });
+  });
+
+  test("no entry, no env → canonical default 1943", () => {
+    const result = resolvePort({
+      readEntry: noEntry,
+      env: {},
+    });
+    expect(result).toEqual({ port: 1943, source: "default" });
+  });
+
+  test("empty SCRIBE_PORT string → falls through to PORT", () => {
+    const result = resolvePort({
+      readEntry: noEntry,
+      env: { SCRIBE_PORT: "", PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1944, source: "PORT" });
+  });
+
+  test("malformed services.json port (string 'oops') → falls through to env", () => {
+    const result = resolvePort({
+      readEntry: () => ({ ...SCRIBE_ENTRY, port: "oops" as unknown as number }),
+      env: { PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1944, source: "PORT" });
+  });
+
+  test("malformed services.json port (zero) → falls through to env", () => {
+    const result = resolvePort({
+      readEntry: () => ({ ...SCRIBE_ENTRY, port: 0 }),
+      env: { PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1944, source: "PORT" });
+  });
+
+  test("services.json port as numeric string → accepted", () => {
+    // Defensive: hand-edited manifests sometimes quote numbers.
+    const result = resolvePort({
+      readEntry: () => ({ ...SCRIBE_ENTRY, port: "1943" as unknown as number }),
+      env: {},
+    });
+    expect(result).toEqual({ port: 1943, source: "services.json" });
+  });
+
+  test("readEntry throws (malformed manifest) → falls through to env without crashing boot", () => {
+    const result = resolvePort({
+      readEntry: () => {
+        throw new Error("manifest is malformed");
+      },
+      env: { SCRIBE_PORT: "1943" },
+    });
+    expect(result).toEqual({ port: 1943, source: "SCRIBE_PORT" });
+  });
+
+  test("port out of TCP range (70000) → rejected, falls through", () => {
+    const result = resolvePort({
+      readEntry: () => ({ ...SCRIBE_ENTRY, port: 70000 }),
+      env: { PORT: "1944" },
+    });
+    expect(result).toEqual({ port: 1944, source: "PORT" });
+  });
+
+  test("custom canonicalDefault is honored", () => {
+    const result = resolvePort({
+      readEntry: noEntry,
+      env: {},
+      canonicalDefault: 1943,
+    });
+    expect(result).toEqual({ port: 1943, source: "default" });
+  });
+
+  test("custom serviceName is forwarded to readEntry", () => {
+    let lookedUp = "";
+    const result = resolvePort({
+      readEntry: (name) => {
+        lookedUp = name;
+        return undefined;
+      },
+      env: {},
+      serviceName: "scribe-staging",
+    });
+    expect(lookedUp).toBe("scribe-staging");
+    expect(result.source).toBe("default");
+  });
+});
+
+describe("resolvePort — integration with real services.json (scribe#40)", () => {
+  // End-to-end: write a real services.json under a tmp PARACHUTE_HOME, then
+  // call `resolvePort()` with no `readEntry` injection so it goes through
+  // the real `readServiceEntry` → `readManifest` → file path.
+  let dir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-port-resolve-"));
+    originalHome = process.env.PARACHUTE_HOME;
+    process.env.PARACHUTE_HOME = dir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.PARACHUTE_HOME;
+    else process.env.PARACHUTE_HOME = originalHome;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("operator-set port=1947 in services.json wins over PORT=1944 in env", () => {
+    // Write a services.json that pins scribe to 1947 (operator-set).
+    writeFileSync(
+      join(dir, "services.json"),
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-scribe",
+            port: 1947,
+            paths: ["/scribe"],
+            health: "/health",
+            version: "0.4.0",
+          },
+        ],
+      }),
+    );
+
+    // Simulate the scribe#40 conditions: hub's port-assigner has stamped
+    // PORT=1944 into scribe's env. Without this fix, scribe would have
+    // used 1944.
+    const result = resolvePort({ env: { PORT: "1944" } });
+    expect(result).toEqual({ port: 1947, source: "services.json" });
+  });
+
+  test("no scribe entry in services.json → canonical default 1943", () => {
+    writeFileSync(
+      join(dir, "services.json"),
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/"],
+            health: "/health",
+            version: "1.0.0",
+          },
+        ],
+      }),
+    );
+    const result = resolvePort({ env: {} });
+    expect(result).toEqual({ port: 1943, source: "default" });
+  });
+
+  test("no services.json file at all → canonical default 1943", () => {
+    const result = resolvePort({ env: {} });
+    expect(result).toEqual({ port: 1943, source: "default" });
+  });
+
+  test("services.json port=1944 → respects it (operator wins, even when 'wrong')", () => {
+    // If the operator (or hub) recorded 1944 and scribe is rebooted, scribe
+    // binds 1944. The operator can correct this by editing services.json;
+    // scribe's job is to honor the contract, not second-guess it.
+    writeFileSync(
+      join(dir, "services.json"),
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-scribe",
+            port: 1944,
+            paths: ["/scribe"],
+            health: "/health",
+            version: "0.4.0",
+          },
+        ],
+      }),
+    );
+    const result = resolvePort({ env: {} });
+    expect(result).toEqual({ port: 1944, source: "services.json" });
+  });
+});

--- a/src/port-resolve.ts
+++ b/src/port-resolve.ts
@@ -1,0 +1,93 @@
+import { readServiceEntry, type ServiceEntry } from "./services-manifest.ts";
+import { DEFAULT_PORT, SERVICE_NAME } from "./parachute-info.ts";
+
+/**
+ * Resolve the port scribe should bind on boot.
+ *
+ * Precedence (services.json wins, then env, then canonical default):
+ *   1. The `port` field on scribe's existing entry in `~/.parachute/services.json`,
+ *      when it parses as a valid TCP port. This is the contract between the
+ *      operator (or hub) and the service. Scribe must respect it on boot —
+ *      otherwise services.json is write-only-by-scribe and the operator can't
+ *      pin or correct the port from outside the service.
+ *   2. `SCRIBE_PORT` env (process-scope explicit override).
+ *   3. `PORT` env (PaaS back-compat; what hub's port-assigner writes to
+ *      `~/.parachute/scribe/.env`).
+ *   4. Canonical `DEFAULT_PORT` (1943).
+ *
+ * Why services.json wins over env: scribe#40. Hub's port-assigner walked the
+ * canonical slot to 1944 once and stamped `PORT=1944` into scribe's `.env`.
+ * Scribe's old code read env-first and rewrote services.json to 1944 on
+ * every boot, ignoring whatever the operator put there. With services.json
+ * winning over env, an operator can correct the port (or hub#195's recovery
+ * tool can correct it) and scribe will respect it across restarts.
+ */
+export interface ResolvePortOpts {
+  /**
+   * Lookup for the existing entry in services.json. Pure for tests; defaults
+   * to `readServiceEntry` against the resolved manifest path.
+   */
+  readonly readEntry?: (name: string) => ServiceEntry | undefined;
+  /**
+   * Process env. Defaulted to `process.env`. Pure for tests.
+   */
+  readonly env?: Record<string, string | undefined>;
+  /**
+   * Service name to look up in the manifest. Defaults to `SERVICE_NAME`
+   * ("parachute-scribe").
+   */
+  readonly serviceName?: string;
+  /**
+   * Canonical default. Defaults to `DEFAULT_PORT` (1943).
+   */
+  readonly canonicalDefault?: number;
+}
+
+export interface ResolvedPort {
+  readonly port: number;
+  readonly source: "services.json" | "SCRIBE_PORT" | "PORT" | "default";
+}
+
+function parsePort(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isInteger(raw) && raw > 0 && raw < 65536) {
+    return raw;
+  }
+  if (typeof raw === "string" && /^[1-9]\d{0,4}$/.test(raw)) {
+    const n = Number(raw);
+    if (n > 0 && n < 65536) return n;
+  }
+  return null;
+}
+
+export function resolvePort(opts: ResolvePortOpts = {}): ResolvedPort {
+  const env = opts.env ?? process.env;
+  const serviceName = opts.serviceName ?? SERVICE_NAME;
+  const canonical = opts.canonicalDefault ?? DEFAULT_PORT;
+  const readEntry = opts.readEntry ?? ((name: string) => readServiceEntry(name));
+
+  // 1. services.json — operator-set / persisted state wins.
+  let entry: ServiceEntry | undefined;
+  try {
+    entry = readEntry(serviceName);
+  } catch {
+    // Malformed manifest: don't crash boot here. `upsertService` will throw
+    // loudly when it tries to write, which is the right surface for that
+    // error. For port resolution, treat it as "no entry".
+    entry = undefined;
+  }
+  if (entry) {
+    const port = parsePort(entry.port);
+    if (port !== null) return { port, source: "services.json" };
+  }
+
+  // 2. SCRIBE_PORT — explicit process-scope override.
+  const scribePort = parsePort(env.SCRIBE_PORT);
+  if (scribePort !== null) return { port: scribePort, source: "SCRIBE_PORT" };
+
+  // 3. PORT — PaaS back-compat / hub's port-assigner.
+  const port = parsePort(env.PORT);
+  if (port !== null) return { port, source: "PORT" };
+
+  // 4. Canonical default.
+  return { port: canonical, source: "default" };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,8 @@ import { loadConfig, type ScribeConfig } from "./config.ts";
 import { buildProperNounsBlockFromEntries, parseContextPayload } from "./context.ts";
 import { preflight, withCors } from "./cors.ts";
 import { upsertService } from "./services-manifest.ts";
+import { resolvePort } from "./port-resolve.ts";
 import {
-  DEFAULT_PORT,
   DISPLAY_NAME,
   MOUNT_PATH,
   SERVICE_NAME,
@@ -159,7 +159,10 @@ export async function startServer() {
 
   const TRANSCRIBE = config.transcribe?.provider ?? process.env.TRANSCRIBE_PROVIDER ?? "parakeet-mlx";
   const CLEANUP = config.cleanup?.provider ?? process.env.CLEANUP_PROVIDER ?? "none";
-  const PORT = Number(process.env.SCRIBE_PORT ?? process.env.PORT ?? DEFAULT_PORT);
+  // Port resolution: services.json wins, then env, then canonical default.
+  // See `port-resolve.ts` and scribe#40 for the precedence rationale.
+  const portResolution = resolvePort();
+  const PORT = portResolution.port;
   const CLEANUP_DEFAULT = config.cleanup?.default ?? true;
 
   const transcribe = getProvider(transcribers, TRANSCRIBE, "transcription");
@@ -174,7 +177,7 @@ export async function startServer() {
     port: PORT,
   };
 
-  console.log(`scribe listening on :${PORT}`);
+  console.log(`scribe listening on :${PORT} (port source: ${portResolution.source})`);
   console.log(`  transcribe: ${TRANSCRIBE}`);
   console.log(`  cleanup:    ${CLEANUP}${CLEANUP !== "none" ? ` (default: ${CLEANUP_DEFAULT})` : ""}`);
   console.log(`  auth:       ${isAuthRequired() ? "bearer (SCRIBE_AUTH_TOKEN or hub JWT)" : "open"}`);
@@ -187,11 +190,26 @@ export async function startServer() {
     scribeConfig: config,
   });
 
-  Bun.serve({
-    hostname: "0.0.0.0",
-    port: PORT,
-    fetch: handler,
-  });
+  // Fail-loud on bind: if PORT is in use we want a named, actionable error
+  // rather than a silent "address in use" deep inside Bun. The hub probes
+  // `/health` after spawn, so an unbound scribe surfaces as "service didn't
+  // come up" — which is hard to debug without this hint.
+  try {
+    Bun.serve({
+      hostname: "0.0.0.0",
+      port: PORT,
+      fetch: handler,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `scribe: failed to bind port ${PORT} (source: ${portResolution.source}): ${message}\n` +
+        `  another process is already listening on :${PORT}.\n` +
+        `  if this is unexpected, check ~/.parachute/services.json for a stale entry,\n` +
+        `  or run \`parachute status\` / \`lsof -iTCP:${PORT} -sTCP:LISTEN\` to identify the conflict.`,
+    );
+    throw err;
+  }
 
   try {
     upsertService({

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveManifestPath, upsertService, type ServiceEntry } from "./services-manifest.ts";
+import {
+  readServiceEntry,
+  resolveManifestPath,
+  upsertService,
+  type ServiceEntry,
+} from "./services-manifest.ts";
 
 const SCRIBE_ENTRY: ServiceEntry = {
   name: "parachute-scribe",
@@ -100,6 +105,51 @@ describe("services-manifest", () => {
     expect(got.services).toHaveLength(1);
     expect(got.services[0]!.version).toBe("0.5.0");
     expect(got.services[0]!.installDir).toBe("/Users/test/.parachute/scribe");
+  });
+
+  describe("readServiceEntry (scribe#40)", () => {
+    test("returns undefined when manifest does not exist", () => {
+      expect(readServiceEntry("parachute-scribe", path)).toBeUndefined();
+    });
+
+    test("returns undefined when manifest exists but lacks an entry for `name`", () => {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [
+            { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "1.0.0" },
+          ],
+        }),
+      );
+      expect(readServiceEntry("parachute-scribe", path)).toBeUndefined();
+    });
+
+    test("returns the entry when present (operator-set port survives boot)", () => {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [{ ...SCRIBE_ENTRY, port: 1947 }],
+        }),
+      );
+      const got = readServiceEntry("parachute-scribe", path);
+      expect(got?.port).toBe(1947);
+      expect(got?.name).toBe("parachute-scribe");
+    });
+
+    test("throws on malformed manifest (caller decides whether to recover)", () => {
+      writeFileSync(path, "not json at all");
+      expect(() => readServiceEntry("parachute-scribe", path)).toThrow();
+    });
+
+    test("returns undefined for a non-matching name in an otherwise valid manifest", () => {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [SCRIBE_ENTRY],
+        }),
+      );
+      expect(readServiceEntry("parachute-other", path)).toBeUndefined();
+    });
   });
 
   test("resolveManifestPath honors PARACHUTE_HOME", () => {

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -36,6 +36,24 @@ function readManifest(path: string): ServicesManifest {
   return raw as ServicesManifest;
 }
 
+/**
+ * Look up the existing entry for a service by name. Returns `undefined` when
+ * the manifest doesn't exist yet or doesn't contain an entry for `name`.
+ *
+ * Used at boot so scribe binds the port the operator (or hub) recorded in
+ * services.json, instead of overwriting it with a hardcoded default. See
+ * scribe#40 — in v0.4.0 scribe ignored services.json on boot and always
+ * stamped the env-derived `PORT`, which silently rewrote a canonical 1943
+ * entry to 1944 (the unassigned slot agent picks).
+ */
+export function readServiceEntry(
+  name: string,
+  path: string = resolveManifestPath(),
+): ServiceEntry | undefined {
+  const manifest = readManifest(path);
+  return manifest.services.find((s) => s.name === name);
+}
+
 export function upsertService(
   entry: ServiceEntry,
   path: string = resolveManifestPath(),


### PR DESCRIPTION
## Summary

Closes #40 — scribe v0.4.0 silently rewrote services.json's scribe entry to `port: 1944` on every boot, colliding with the agent slot. Operators couldn't fix it from outside scribe (editing services.json was reverted on next start).

### Symptom (from #40)

> Scribe v0.4.0 always writes `port: 1944` to `~/.parachute/services.json` on boot, regardless of what the file said before. Canonical port is 1943 (per hub's `SERVICE_SPECS` and the canonical-ports pattern doc). 1944 collides with the agent slot.
>
> - Hub's services.json is the contract between CLI/hub and every service. […] Scribe overwriting that to a non-canonical value (1944) silently collides with the agent slot.
> - Once collided, hub routes `/agent` requests to whoever's on 1944 — currently scribe — and a wrong service answers. No error, just routing the wrong way.
> - Operators have no way to fix from outside scribe: editing services.json doesn't stick.

### Diagnosed root cause

Two layers, this PR fixes the scribe-side:

1. **Hub-side (parachute-hub#195, separate):** the port-assigner in `parachute-hub/src/port-assign.ts` walked the canonical slot 1943 to 1944 (the unassigned-range fallback) once, and stamped `PORT=1944` into `~/.parachute/scribe/.env`. Verified on Aaron's box: `cat ~/.parachute/scribe/.env` → `PORT=1944`.
2. **Scribe-side (this PR):** scribe's `startServer()` did `Number(process.env.SCRIBE_PORT ?? process.env.PORT ?? DEFAULT_PORT)`. It ignored services.json entirely on boot and stamped the env-derived port back into the manifest, locking in the wrong value forever (no operator-side recovery — editing services.json was reverted by the next start).

The brief explicitly asks scribe to defend itself even given a buggy upstream:

> If services.json says 1947 and scribe was canonically 1943, scribe should bind 1947 (operator-set wins), not 1943. Only write the canonical when the entry doesn't exist.

### Fix shape

New port-resolution precedence (services.json wins over env):

1. `services.json` entry's `port` field (operator-set / persisted state).
2. `SCRIBE_PORT` env (process-scope explicit override).
3. `PORT` env (PaaS back-compat; what hub's port-assigner writes).
4. Canonical `DEFAULT_PORT` (1943).

The canonical default is only used when no services.json entry exists. Once an entry is recorded with the right port, scribe respects it across restarts — operator edits stick.

Also: bind failure now logs a named, actionable error (which port, which source, lsof hint) before the throw, rather than an opaque `address in use` deep inside Bun.

### Files changed

- **`src/port-resolve.ts`** (new) — pure, dependency-injected `resolvePort(opts)`. The `readEntry` and `env` injection points keep it unit-testable without touching disk.
- **`src/services-manifest.ts`** — adds `readServiceEntry(name, path?)` lookup so callers can read the existing entry without going through `upsertService`.
- **`src/server.ts`** — `startServer()` calls `resolvePort()`, logs the chosen port + source, wraps `Bun.serve` with a fail-loud catch.
- **`src/port-resolve.test.ts`** (new) — 14 unit tests covering the precedence ladder (services.json wins, malformed-port fallthroughs, custom canonical, throw-recovery) + 4 integration tests against a real `services.json` under a tmp `PARACHUTE_HOME`.
- **`src/services-manifest.test.ts`** — 5 new tests for `readServiceEntry`.

### Cross-references

- **parachute-hub#195** — hub-side validation + drift warning + recovery tool. Complementary defense layer; scribe-side fix is the root-cause patch, hub-side is the broader contract-enforcement work.
- **parachute-agent#145** — agent has the same shape (rewrites its own port to 1944 on boot, ignoring services.json). Same precedence model needs to land there.

### Test plan

```sh
bun test src/        # 129/129 pass
bun run typecheck    # clean
```

### Manual smoke (post-merge, on Aaron's box)

```sh
parachute stop scribe
cat ~/.parachute/services.json | grep -A 2 parachute-scribe   # observed pre-fix: port 1944
# Edit ~/.parachute/services.json → set parachute-scribe.port = 1943
parachute start scribe
sleep 2
cat ~/.parachute/services.json | grep -A 2 parachute-scribe   # expected: port 1943 (NOT rewritten)
parachute logs scribe | tail -5                               # expected: "scribe listening on :1943 (port source: services.json)"
```

Optional second smoke (operator-set non-canonical):

```sh
parachute stop scribe
# Edit ~/.parachute/services.json → set parachute-scribe.port = 1947
parachute start scribe
# expected: scribe binds 1947, services.json unchanged at 1947.
```

### Versioning

`0.4.0` → `0.4.1-rc.1` per the per-PR rc-bump rule. CHANGELOG entry at `[0.4.1-rc.1] - 2026-05-08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)