### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.1-rc.1] - 2026-05-08
+## [0.4.1] - 2026-05-09
 
 ### Fixed
 - **Boot now respects `services.json` port + uses canonical 1943 default** — closes #40. v0.4.0's boot read `SCRIBE_PORT ?? PORT ?? DEFAULT_PORT` and ignored any existing entry in `~/.parachute/services.json`, so a stale `PORT=1944` in scribe's `.env` (written by hub's port-assigner when 1943 looked occupied) caused scribe to bind 1944 and rewrite services.json to match — silently colliding with the agent slot. New precedence: `services.json` entry → `SCRIBE_PORT` env → `PORT` env → canonical `1943`. Operator-set ports persist across restarts; the canonical default is only used when no entry exists. Bind failure now logs a named, actionable error before the throw.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.1-rc.1",
+  "version": "0.4.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Promote `0.4.1-rc.1` → `0.4.1` stable. No code changes — drops the `-rc.1` suffix in `package.json` and renames the CHANGELOG section header to its release date.

## What's in 0.4.1

- **#41** — fix(boot): respect `services.json` port + use canonical `1943` default. Closes #40.

## Why it shipped

`0.4.0`'s boot read `SCRIBE_PORT ?? PORT ?? DEFAULT_PORT` and ignored any existing entry in `~/.parachute/services.json`, so a stale `PORT=1944` in scribe's `.env` (written by hub's port-assigner when 1943 looked occupied) caused scribe to bind 1944 and silently rewrite services.json to match — colliding with the agent slot.

`0.4.1` introduces a 4-tier port-resolve ladder: `services.json` entry → `SCRIBE_PORT` env → `PORT` env → canonical `1943`. Operator-set ports persist across restarts; the canonical default only fires when no entry exists. Companion bugs (same regression class) tracked separately at `parachute-hub#195` and `parachute-agent#145`.

## Tests

`bun test src/` — 129/129 passing (same count as #41 — no code change here).

## Post-merge

Promotion to `@latest` is a deliberate `npm dist-tag add` step after Aaron publishes `--tag rc` and validates.