### PR TITLE
feat(auth): consume hub revocation list — scope-guard 0.2.0 (hub#212 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.4.2-rc.1] - 2026-05-10
+
+### Added
+- **`@openparachute/scope-guard` 0.2.0 adoption — hub revocation list now enforced (hub#212 Phase 4).** Hub-issued JWTs are consulted against the hub's `/.well-known/parachute-revocation.json` after sig/iss/aud/expiry pass; revoked jtis surface as `HubJwtError(code: "revoked")` and are rejected at `validateToken` with a 401. Without this bump, operator revocation via the hub mint API was a no-op against scribe.
+- **`resetRevocationCache`** re-export from `src/hub-jwt.ts` (mirrors `resetJwksCache`) so tests can start cases from a clean fail-closed state.
+- **`src/auth-hub-jwt.test.ts`** — integration suite for the hub-JWT path. Pins: happy-path acceptance with active revocations on unrelated jtis, sanitized 401 + jti-bearing audit log on revoked rejection, sanitized 401 + implementation-detail-bearing audit log on cold-start revocation-endpoint outage. scope-guard's own unit suite covers cache mechanics; this file pins scribe-side wire-up.
+
+### Changed
+- **Sanitized client-facing 401 messages on revocation outcomes.** `code: "revoked"` returns `"token has been revoked"` (no jti); `code: "revocation_unavailable"` returns `"token cannot be validated: revocation list unavailable"` (no "no last-good cache" implementation detail). Full diagnostics — including the jti and the cache-state phrasing — route to `console.warn` for the operator audit trail. Inheritable pattern from vault PR #281; agent inherits next.
+
+### Notes
+- 133/133 tests passing (`bun test src/`); typecheck clean.
+- Behavior summary from scope-guard 0.2.0: 60s TTL on the revocation cache (matches hub's published `Cache-Control: max-age=60`); fail-open with last-good cache during a hub outage; fail-closed only on first-fetch-failure (cold start, no last-good).
+- Shared-secret + open-mode paths untouched. Existing JWT-shape rejection tests in `auth.test.ts` continue to pass — non-revocation `HubJwtError` codes (signature, audience, expired, etc.) still forward their messages verbatim.
+
 ## [0.4.1] - 2026-05-09
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "parachute-scribe",
       "dependencies": {
-        "@openparachute/scope-guard": "^0.1.0",
+        "@openparachute/scope-guard": "^0.2.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -17,7 +17,7 @@
     },
   },
   "packages": {
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-zPusPTeNUVzRQebjed8+vuhbdBaIQ6wpmJIwiXu31ybf8xP4+GrUrlFVkz4IhLJq00+TDFKvqVOKSFtx9s64MQ=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.2.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HbL1ZFBD0Kl/IiEXbEVLEGSQXGKL9sjRltye5RtqVLdwkR7Y9qOM9SSYmxa9np7nqzbRXrwDjEbRRQubKju9xg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.1",
+  "version": "0.4.2-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@openparachute/scope-guard": "^0.1.0"
+    "@openparachute/scope-guard": "^0.2.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for the hub-JWT path through scribe's auth boundary.
+ *
+ * Scope:
+ *   - signed valid JWT (not in revocation list) → accepted with hub-jwt mode
+ *   - revoked jti rejected (revocation list integration; client-facing
+ *     message is sanitized so the jti doesn't leak)
+ *   - revocation list unavailable on cold start → fail-closed 401 sanitized
+ *
+ * Each test owns a fake hub fixture that serves BOTH `/.well-known/jwks.json`
+ * and `/.well-known/parachute-revocation.json`. scope-guard's own unit suite
+ * covers the cache mechanics (TTL refresh, fail-open with last-good,
+ * single-flight); this file pins the scribe-side wiring and the response-shape
+ * contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { enforceAuth, validateToken } from "./auth.ts";
+import { resetJwksCache, resetRevocationCache } from "./hub-jwt.ts";
+
+interface Keypair {
+  privateKey: CryptoKey;
+  publicJwk: Record<string, unknown>;
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: { ...jwk, kid, alg: "RS256", use: "sig" },
+    kid,
+  };
+}
+
+interface HubFixture {
+  origin: string;
+  /** Drive the revocation list contents; cleared by default. */
+  setRevoked(jtis: string[]): void;
+  /** When true, the revocation endpoint returns 503 — exercises fail-closed. */
+  setRevocationFails(fails: boolean): void;
+  stop: () => void;
+}
+
+function startHubFixture(keys: Keypair[]): HubFixture {
+  let revokedJtis: string[] = [];
+  let revocationFails = false;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/.well-known/jwks.json") {
+        return Response.json({ keys: keys.map((k) => k.publicJwk) });
+      }
+      if (url.pathname === "/.well-known/parachute-revocation.json") {
+        if (revocationFails) {
+          return new Response("hub down", { status: 503 });
+        }
+        return Response.json({
+          generated_at: new Date().toISOString(),
+          jtis: revokedJtis,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    setRevoked: (jtis) => {
+      revokedJtis = jtis;
+    },
+    setRevocationFails: (fails) => {
+      revocationFails = fails;
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+interface SignOpts {
+  iss: string;
+  aud: string;
+  scope: string;
+  sub?: string;
+  ttlSeconds?: number;
+  /** Override the random jti — needed when a test wants to revoke this exact token. */
+  jti?: string;
+}
+
+async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + (opts.ttlSeconds ?? 60);
+  return new SignJWT({ scope: opts.scope })
+    .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+    .setIssuer(opts.iss)
+    .setSubject(opts.sub ?? "operator-test")
+    .setAudience(opts.aud)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setJti(opts.jti ?? `jti-${Math.random().toString(36).slice(2)}`)
+    .sign(kp.privateKey);
+}
+
+function bearerReq(token: string): Request {
+  return new Request("http://localhost/v1/audio/transcriptions", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+let prevHubOrigin: string | undefined;
+let prevAuthToken: string | undefined;
+let fixture: HubFixture;
+let kp: Keypair;
+
+beforeEach(async () => {
+  prevAuthToken = process.env.SCRIBE_AUTH_TOKEN;
+  // SCRIBE_AUTH_TOKEN must be set to engage the auth path; the value itself
+  // is irrelevant for hub-JWT cases (JWT-shaped tokens skip the shared-secret
+  // compare entirely).
+  process.env.SCRIBE_AUTH_TOKEN = "shared-secret-not-used-for-jwt-cases";
+
+  kp = await makeKeypair("k1");
+  fixture = startHubFixture([kp]);
+  prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  resetJwksCache();
+  resetRevocationCache();
+});
+
+afterEach(() => {
+  fixture.stop();
+  if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  if (prevAuthToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+  else process.env.SCRIBE_AUTH_TOKEN = prevAuthToken;
+  resetJwksCache();
+  resetRevocationCache();
+});
+
+describe("hub JWT integration — revocation enforcement", () => {
+  test("happy path: signed valid JWT not in revocation list → accepted with hub-jwt mode", async () => {
+    fixture.setRevoked([]);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+    const result = await validateToken(token);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.mode).toBe("hub-jwt");
+      expect(result.scopes).toEqual(["scribe:transcribe"]);
+    }
+  });
+
+  test("non-revoked jti against populated list → still honored (active revocations don't poison unrelated tokens)", async () => {
+    fixture.setRevoked(["some-other-revoked-jti"]);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+      jti: "jti-still-good",
+    });
+    const result = await validateToken(token);
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.mode).toBe("hub-jwt");
+  });
+
+  test("revoked jti → 401 sanitized; full diagnostic (with jti) routed to console.warn audit log", async () => {
+    const revokedJti = "jti-revoked-by-operator";
+    fixture.setRevoked([revokedJti]);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+      jti: revokedJti,
+    });
+
+    // Spy + suppress so the assertion is the audit-trail invariant for this
+    // scenario, not a stderr inspection. Pattern carries from vault PR #281
+    // and propagates to agent.
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await enforceAuth(bearerReq(token), "/v1/audio/transcriptions");
+      expect(result).toBeInstanceOf(Response);
+      const res = result as Response;
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string; message: string };
+      // Client-facing message must NOT carry the jti — that's a server-side
+      // audit-log concern only. See the `code === "revoked"` branch in
+      // auth.ts:validateToken for the sanitization.
+      expect(body.message).toBe("token has been revoked");
+      expect(body.message).not.toContain(revokedJti);
+
+      // Audit-log invariant: console.warn fires exactly once with a message
+      // that carries the jti, so an operator chasing a 401 in production logs
+      // can correlate to which token was retired.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArg = warnSpy.mock.calls[0]![0] as string;
+      expect(warnArg).toContain(revokedJti);
+      expect(warnArg).toContain("revoked");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("revocation list unreachable on cold start → fail-closed 401 sanitized; full diagnostic routed to console.warn", async () => {
+    // Hub is reachable for JWKS but the revocation endpoint 503s. Cold cache
+    // + first-fetch-fail = "unknown" outcome, surfaced as
+    // HubJwtError(code: "revocation_unavailable"). Client gets a code-shaped
+    // sentence; the implementation-detail phrasing ("no last-good cache")
+    // stays in the server-side audit log.
+    fixture.setRevocationFails(true);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await enforceAuth(bearerReq(token), "/v1/audio/transcriptions");
+      expect(result).toBeInstanceOf(Response);
+      const res = result as Response;
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string; message: string };
+      // Client message: code-shaped, no internals.
+      expect(body.message).toBe("token cannot be validated: revocation list unavailable");
+      // The internal phrase "no last-good cache" is a scope-guard
+      // implementation detail and must not leak into the public response.
+      expect(body.message).not.toContain("last-good cache");
+
+      // Audit-log invariant: full diagnostic routed to console.warn so
+      // operators can distinguish cold-start from sustained outage.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArg = warnSpy.mock.calls[0]![0] as string;
+      expect(warnArg).toContain("no last-good cache");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -61,6 +61,26 @@ export async function validateToken(token: string | undefined): Promise<AuthResu
       const claims = await validateHubJwt(token);
       return { valid: true, scopes: claims.scopes, mode: "hub-jwt" };
     } catch (err) {
+      // Revocation-related codes get sanitized client messages: server-side
+      // audit log carries the full diagnostic (jti for `revoked`,
+      // implementation-detail phrasing for `revocation_unavailable`); the
+      // unauthenticated caller gets a code-shaped sentence with no internals.
+      // Inheritable pattern across vault/scribe/agent — all revocation-related
+      // codes get sanitized client messages, full detail lives in server-side
+      // audit logs. Other HubJwtError codes (signature, audience, expired,
+      // etc.) carry generic messages and are forwarded as-is.
+      if (err instanceof HubJwtError && err.code === "revoked") {
+        console.warn(`[scribe-auth] hub JWT rejected: ${err.message}`);
+        return { valid: false, reason: "jwt-invalid", message: "token has been revoked" };
+      }
+      if (err instanceof HubJwtError && err.code === "revocation_unavailable") {
+        console.warn(`[scribe-auth] hub JWT rejected: ${err.message}`);
+        return {
+          valid: false,
+          reason: "jwt-invalid",
+          message: "token cannot be validated: revocation list unavailable",
+        };
+      }
       const message = err instanceof HubJwtError ? err.message : err instanceof Error ? err.message : "JWT validation failed";
       return { valid: false, reason: "jwt-invalid", message };
     }

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -69,5 +69,14 @@ export function resetJwksCache(): void {
   guard.resetJwksCache();
 }
 
+/**
+ * Reset the cached revocation list. Tests use this to start from a clean
+ * fail-closed state between cases; production callers shouldn't need it
+ * (the cache refreshes itself on TTL expiry).
+ */
+export function resetRevocationCache(): void {
+  guard.resetRevocationCache();
+}
+
 export { HubJwtError, looksLikeJwt };
 export type { HubJwtClaims };

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -14,8 +14,6 @@
  * `expectedAudience`. The lib's claim shape is richer than what scribe's
  * callers historically used (it surfaces `aud`, `jti`, `clientId` in addition
  * to `sub`/`scopes`). That's additive — `auth.ts` only consumes `scopes`.
- *
- * Scope-guard adoption: Step 3 of 4 (after vault, before paraclaw).
  */
 import {
   createScopeGuard,


### PR DESCRIPTION
## Summary

Phase 4 scribe-side adoption of the hub revocation list, mirroring vault PR #281. Bumps `@openparachute/scope-guard` `^0.1.0` → `^0.2.0` so hub-issued JWTs are now consulted against `/.well-known/parachute-revocation.json` after sig/iss/aud/expiry pass. Without this bump, operator revocation via the hub mint API was a no-op against scribe.

- Sanitized client 401s on `code: "revoked"` and `code: "revocation_unavailable"` — full diagnostics (jti, cache state) route to `console.warn` for the operator audit trail.
- New `src/auth-hub-jwt.test.ts` integration suite pins the wire-up + the audit-log invariant via `spyOn(console, "warn")`.
- `resetRevocationCache` re-exported from `src/hub-jwt.ts` for test cleanup.
- Inheritable pattern from vault PR #281: all revocation-related diagnostics stay server-side, client gets a code-shaped sentence with no internals. Agent inherits next.

Behavior summary (from scope-guard 0.2.0): 60s revocation-cache TTL matching the hub's published `Cache-Control: max-age=60`; fail-open with last-good cache on hub outage; fail-closed only on first-fetch-failure.

Shared-secret + open-mode paths untouched. No `pvt_*` analog in scribe (Phase 6 N/A).

Version: `0.4.1` → `0.4.2-rc.1` (post-stable, new chain per pre-1.0 RC rule).

## Test plan

- [x] `bun test src/` — 133/133 pass
- [x] `bun run typecheck` — clean
- [x] `src/auth-hub-jwt.test.ts` — 4/4 pass (happy path, non-revoked-against-populated-list, revoked rejection, cold-start unavailable)
- [ ] Hand-off to reviewer dispatch (team-lead)

## Pattern check

- **Auth boundary sanitization** — copies vault PR #281's `code === "revoked"` / `code === "revocation_unavailable"` branches into scribe's `validateToken`. No new pattern; this is the second adopter of the inheritable shape, agent will be the third.
- **Test fixture** — `startHubFixture` mirrors vault's `startHubFixture` (jwks + revocation served from one Bun.serve). No fixture-shape drift across vault/scribe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)