### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.2-rc.1] - 2026-05-10
+## [0.4.2] - 2026-05-10
 
 ### Added
 - **`@openparachute/scope-guard` 0.2.0 adoption — hub revocation list now enforced (hub#212 Phase 4).** Hub-issued JWTs are consulted against the hub's `/.well-known/parachute-revocation.json` after sig/iss/aud/expiry pass; revoked jtis surface as `HubJwtError(code: "revoked")` and are rejected at `validateToken` with a 401. Without this bump, operator revocation via the hub mint API was a no-op against scribe.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.2-rc.1",
+  "version": "0.4.2",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Promote scribe Phase 4 (revocation-list adoption) from `0.4.2-rc.1` to stable `0.4.2`.

- Phase 4 scribe-side adoption shipped in scribe#43 (merged at `c4524d2`): `@openparachute/scope-guard` `^0.1.0` → `^0.2.0`; hub-issued JWTs now consult `/.well-known/parachute-revocation.json` after sig/iss/aud/expiry pass; revoked jtis rejected with sanitized client 401s while full diagnostics route to `console.warn` for the operator audit trail.
- No code changes since rc.1 — version bump + CHANGELOG heading rename only.

After merge, Aaron publishes `@openparachute/scribe@0.4.2` to npm at `latest`.

## Test plan

- [x] `bun test src/` — 133/133 pass (unchanged from rc.1)
- [x] `bun run typecheck` — clean (unchanged from rc.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)