### PR TITLE
feat(scribe): config UI — JSON config form at /scribe/admin (PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@
   - `PUT /.parachute/config` accepts the same camelCase wire shape `GET /.parachute/config` returns, validates against the JSON Schema, and atomically writes the nested file shape to `~/.parachute/scribe/config.json` (tmp + rename — same pattern as `services-manifest.ts`). Scoped on `scribe:admin`.
   - Response carries `{ ok: true, restart_required: [...] }` — the array lists which fields changed in a way that needs a process restart to take effect (provider changes + port). Cleanup-prompt and cleanup-default changes take effect immediately because they're read dynamically per-request; the handler updates the in-process `scribeConfig.cleanup` block to match the new file.
   - `/scribe/admin` is a single self-contained HTML page (inline CSS + vanilla JS, no framework, no build step) that fetches schema + config on load, renders one form field per knob, and displays the restart-required list inline after save. Mirrors the "render a self-contained string from a TS function" pattern in `parachute-hub/src/oauth-ui.ts`.
-- **`src/config-write.ts`** — schema validator (tiny purpose-built draft-07; no external dep), wire→file translator, restart-required differ, atomic writer.
+- **`src/config-write.ts`** — schema validator (tiny purpose-built draft-07; no external dep), wire→file translator, **read-modify-write merger** that honors null-as-clear sentinels for the two optional string fields, restart-required differ, atomic writer.
 - **`src/admin-ui.ts`** — `renderAdminPage()` returns the static HTML.
 
+### Fixed (review folds on PR #45 before merge)
+- **Null-clear no longer silently no-ops.** Clearing the system-prompt or context-template textarea in the form and saving used to write a file that still carried the old value — `toFileShape` dropped `null` before write, and "absent in patch" was indistinguishable from "leave alone." PUT handler now reads the existing file, merges the incoming patch (treating `null` as an explicit deletion), and writes the merged result. The in-process `scribeConfig.cleanup` is replaced (not spread) on success so the next transcription request actually sees the cleared field.
+- **`config.json` is written with mode `0o600`.** Owner-only — preempts PR-B (secrets) accidentally landing world-readable provider keys on shared hosts. Rewrites preserve the mode even if someone chmod'd the file out-of-band.
+
+### Nits folded
+- Restart-required success banner now includes a footnote when `port` appears in the list: "Note: `port` is set via `services.json` or the `SCRIBE_PORT` environment variable, not `config.json`." Avoids the operator re-saving the form expecting the port change to stick.
+- Inline JS in `admin-ui.ts` renames the `setBanner(kind, html)` parameter to `trustedHtml` so the "caller must have sanitized" contract is explicit at every call site.
+- Removed a misleading "TS-friendly import shim" comment from `admin-routes.test.ts` — the import was just a plain alias.
+
 ### Notes
-- 180/180 tests passing (`bun test src/`); typecheck clean.
+- 204/204 tests passing (`bun test src/`); typecheck clean.
 - PR-A only: no secrets management (PR-B) and no hub-side "Configure" link in the admin SPA (PR-C).
 - `port` is in the schema for visibility but not written to disk — scribe's port resolution (`port-resolve.ts`) reads from services.json and env, not config.json. A port change in the form still appears in `restart_required` so the operator knows to update the env/services.json side too.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.4.3-rc.1] - 2026-05-20
+
+### Added
+- **Config UI: `PUT /.parachute/config` and a static admin form at `/scribe/admin`** — PR-A of the scribe config UI work. Operators can now read and write `~/.parachute/scribe/config.json` from a browser (through hub's reverse proxy) rather than hand-editing JSON.
+  - `PUT /.parachute/config` accepts the same camelCase wire shape `GET /.parachute/config` returns, validates against the JSON Schema, and atomically writes the nested file shape to `~/.parachute/scribe/config.json` (tmp + rename — same pattern as `services-manifest.ts`). Scoped on `scribe:admin`.
+  - Response carries `{ ok: true, restart_required: [...] }` — the array lists which fields changed in a way that needs a process restart to take effect (provider changes + port). Cleanup-prompt and cleanup-default changes take effect immediately because they're read dynamically per-request; the handler updates the in-process `scribeConfig.cleanup` block to match the new file.
+  - `/scribe/admin` is a single self-contained HTML page (inline CSS + vanilla JS, no framework, no build step) that fetches schema + config on load, renders one form field per knob, and displays the restart-required list inline after save. Mirrors the "render a self-contained string from a TS function" pattern in `parachute-hub/src/oauth-ui.ts`.
+- **`src/config-write.ts`** — schema validator (tiny purpose-built draft-07; no external dep), wire→file translator, restart-required differ, atomic writer.
+- **`src/admin-ui.ts`** — `renderAdminPage()` returns the static HTML.
+
+### Notes
+- 180/180 tests passing (`bun test src/`); typecheck clean.
+- PR-A only: no secrets management (PR-B) and no hub-side "Configure" link in the admin SPA (PR-C).
+- `port` is in the schema for visibility but not written to disk — scribe's port resolution (`port-resolve.ts`) reads from services.json and env, not config.json. A port change in the form still appears in `restart_required` so the operator knows to update the env/services.json side too.
+
 ## [0.4.2] - 2026-05-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -8,7 +8,14 @@
  * via the `configPath` dep — never touches the operator's real ~/.parachute.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFetchHandler, type ServerDeps } from "./server.ts";
@@ -132,6 +139,59 @@ describe("PUT /.parachute/config", () => {
       expect(scribeConfig.cleanup?.default).toBe(false);
     });
 
+    test("null-clear via HTTP: PUT { cleanupSystemPrompt: null } removes prompt on disk", async () => {
+      // Wire-level regression for scribe#45 must-fix 1. Seed the file with an
+      // OLD prompt, PUT with explicit null, verify the disk file no longer
+      // carries `system_prompt` AND the in-process scribeConfig no longer
+      // carries it either (otherwise the running handler would still send
+      // the old prompt to the cleanup LLM).
+      mkdirSync(configPath.replace(/\/[^/]+$/, ""), { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          cleanup: { provider: "ollama", system_prompt: "OLD PROMPT", default: true },
+        }),
+      );
+      const scribeConfig: ServerDeps["scribeConfig"] = {
+        cleanup: { provider: "ollama", system_prompt: "OLD PROMPT", default: true },
+      };
+      const handler = buildHandler(configPath, { scribeConfig });
+
+      const res = await handler(putReq({ cleanupSystemPrompt: null }));
+      expect(res.status).toBe(200);
+
+      const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+      expect(onDisk.cleanup.system_prompt).toBeUndefined();
+      // Sibling fields survive — the clear is targeted.
+      expect(onDisk.cleanup.provider).toBe("ollama");
+      expect(onDisk.cleanup.default).toBe(true);
+      // In-process config matches disk so the next transcription request
+      // doesn't keep sending the old prompt.
+      expect(scribeConfig.cleanup?.system_prompt).toBeUndefined();
+    });
+
+    test("null-clear via HTTP: PUT { cleanupContextTemplate: null } removes template on disk", async () => {
+      mkdirSync(configPath.replace(/\/[^/]+$/, ""), { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          cleanup: { provider: "ollama", context_template: "OLD {{proper_nouns}}" },
+        }),
+      );
+      const scribeConfig: ServerDeps["scribeConfig"] = {
+        cleanup: { provider: "ollama", context_template: "OLD {{proper_nouns}}" },
+      };
+      const handler = buildHandler(configPath, { scribeConfig });
+
+      const res = await handler(putReq({ cleanupContextTemplate: null }));
+      expect(res.status).toBe(200);
+
+      const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+      expect(onDisk.cleanup.context_template).toBeUndefined();
+      expect(onDisk.cleanup.provider).toBe("ollama");
+      expect(scribeConfig.cleanup?.context_template).toBeUndefined();
+    });
+
     test("bad payload — non-enum provider → 400 + error message + NO file written", async () => {
       const handler = buildHandler(configPath);
       const res = await handler(putReq({ transcribeProvider: "not-a-real-thing" }));
@@ -163,7 +223,7 @@ describe("PUT /.parachute/config", () => {
       // a 500 rather than crashing the handler.
       const blocker = join(dir, "blocker");
       // Create a file at the position we'll try to mkdir under.
-      writeFileSyncSync(blocker, "x");
+      writeFileSync(blocker, "x");
       const handler = buildHandler(join(blocker, "config.json"));
       const res = await handler(putReq({ transcribeProvider: "whisper" }));
       expect(res.status).toBe(500);
@@ -283,6 +343,27 @@ describe("GET /scribe/admin", () => {
     expect(html).toContain("Cleanup provider");
   });
 
+  test("HTML contains the port-hint footnote (services.json / SCRIBE_PORT)", async () => {
+    // scribe#45 review nit 1 — the restart-required banner needs to tell the
+    // operator that `port` is NOT writable from config.json. Pin the copy.
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    const html = await res.text();
+    expect(html).toContain("services.json");
+    expect(html).toContain("SCRIBE_PORT");
+  });
+
+  test("HTML uses trustedHtml as the setBanner parameter name (nit 2)", async () => {
+    // Light-touch pin so a future author can't silently drop the rename
+    // without thinking about the contract it documents.
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    const html = await res.text();
+    expect(html).toContain("trustedHtml");
+  });
+
   test("closed mode without bearer → 401", async () => {
     process.env.SCRIBE_AUTH_TOKEN = "s3cret";
     const handler = buildHandler("/tmp/unused");
@@ -301,9 +382,3 @@ describe("GET /scribe/admin", () => {
     expect(res.status).toBe(200);
   });
 });
-
-// `writeFileSyncSync` is just an alias for `writeFileSync` — TS-friendly
-// import shim local to this test file (some bun versions ship the binding
-// only under the node:fs name). Kept at the bottom so it doesn't crowd the
-// readable top of the file.
-import { writeFileSync as writeFileSyncSync } from "node:fs";

--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -1,0 +1,309 @@
+/**
+ * End-to-end tests for the admin surfaces:
+ *   - PUT /.parachute/config (validation, auth, atomic write, restart_required)
+ *   - GET /scribe/admin (HTML render + key form fields)
+ *
+ * The handler is constructed via `createFetchHandler` so we exercise the same
+ * auth + scope gates the live server does. Tests sandbox the on-disk write
+ * via the `configPath` dep — never touches the operator's real ~/.parachute.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFetchHandler, type ServerDeps } from "./server.ts";
+import type { ResolvedConfig } from "./config-schema.ts";
+
+const RESOLVED: ResolvedConfig = {
+  transcribeProvider: "parakeet-mlx",
+  cleanupProvider: "none",
+  cleanupDefault: true,
+  cleanupSystemPrompt: null,
+  cleanupContextTemplate: null,
+  port: 1943,
+};
+
+function buildHandler(
+  configPath: string,
+  overrides: Partial<ServerDeps> = {},
+): (req: Request) => Promise<Response> {
+  const deps: ServerDeps = {
+    transcribe: async () => "stub",
+    cleanup: async (text) => text,
+    resolvedConfig: RESOLVED,
+    scribeConfig: {},
+    configPath,
+    ...overrides,
+  };
+  return createFetchHandler(deps);
+}
+
+function putReq(body: unknown, token?: string): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token !== undefined) headers.Authorization = `Bearer ${token}`;
+  return new Request("http://localhost/.parachute/config", {
+    method: "PUT",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("PUT /.parachute/config", () => {
+  let dir: string;
+  let configPath: string;
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-put-"));
+    configPath = join(dir, "scribe", "config.json");
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  describe("open mode (SCRIBE_AUTH_TOKEN unset)", () => {
+    beforeEach(() => {
+      delete process.env.SCRIBE_AUTH_TOKEN;
+    });
+
+    test("happy path: 200 + restart_required + file written", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(
+        putReq({
+          transcribeProvider: "whisper",
+          cleanupProvider: "ollama",
+          cleanupDefault: false,
+          cleanupSystemPrompt: "PROMPT",
+          cleanupContextTemplate: "ctx {{proper_nouns}}",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown> & { errors?: { path: string; message?: string }[] };
+      expect(body.ok).toBe(true);
+      // Both provider changes require restart; prompt/default do not.
+      expect((body.restart_required as string[]).sort()).toEqual(["cleanupProvider", "transcribeProvider"]);
+      expect(existsSync(configPath)).toBe(true);
+      expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+        transcribe: { provider: "whisper" },
+        cleanup: {
+          provider: "ollama",
+          default: false,
+          system_prompt: "PROMPT",
+          context_template: "ctx {{proper_nouns}}",
+        },
+      });
+    });
+
+    test("idempotent — second identical PUT still returns 200", async () => {
+      const handler = buildHandler(configPath);
+      const body = { transcribeProvider: "whisper", cleanupProvider: "ollama" };
+      const a = await handler(putReq(body));
+      const b = await handler(putReq(body));
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200);
+      expect(existsSync(configPath)).toBe(true);
+    });
+
+    test("partial body — only the cleanup prompt changes, restart_required empty", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(putReq({ cleanupSystemPrompt: "JUST THE PROMPT" }));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown> & { errors?: { path: string; message?: string }[] };
+      expect(body.restart_required).toEqual([]);
+      expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+        cleanup: { system_prompt: "JUST THE PROMPT" },
+      });
+    });
+
+    test("dynamic field changes take effect on the in-process scribeConfig (no restart needed)", async () => {
+      const scribeConfig: ServerDeps["scribeConfig"] = {
+        cleanup: { system_prompt: "OLD", default: true },
+      };
+      const handler = buildHandler(configPath, { scribeConfig });
+      const res = await handler(
+        putReq({ cleanupSystemPrompt: "NEW", cleanupDefault: false }),
+      );
+      expect(res.status).toBe(200);
+      expect(scribeConfig.cleanup?.system_prompt).toBe("NEW");
+      expect(scribeConfig.cleanup?.default).toBe(false);
+    });
+
+    test("bad payload — non-enum provider → 400 + error message + NO file written", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(putReq({ transcribeProvider: "not-a-real-thing" }));
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown> & { errors?: { path: string; message?: string }[] };
+      expect(body.error).toBe("validation_failed");
+      expect(body.errors).toBeArray();
+      expect(body.errors?.[0]?.path).toBe("transcribeProvider");
+      expect(existsSync(configPath)).toBe(false);
+    });
+
+    test("invalid JSON body → 400, no file written", async () => {
+      const handler = buildHandler(configPath);
+      const req = new Request("http://localhost/.parachute/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown> & { errors?: { path: string; message?: string }[] };
+      expect(body.error).toBe("invalid_json");
+      expect(existsSync(configPath)).toBe(false);
+    });
+
+    test("write failure → 500, no half-written file", async () => {
+      // Pass a path whose parent exists but is a *file*, not a directory —
+      // mkdirSync will throw EEXIST/ENOTDIR. Verifies the error path returns
+      // a 500 rather than crashing the handler.
+      const blocker = join(dir, "blocker");
+      // Create a file at the position we'll try to mkdir under.
+      writeFileSyncSync(blocker, "x");
+      const handler = buildHandler(join(blocker, "config.json"));
+      const res = await handler(putReq({ transcribeProvider: "whisper" }));
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as Record<string, unknown> & { errors?: { path: string; message?: string }[] };
+      expect(body.error).toBe("write_failed");
+    });
+  });
+
+  describe("closed mode (SCRIBE_AUTH_TOKEN set)", () => {
+    beforeEach(() => {
+      process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    });
+
+    test("missing bearer → 401", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(putReq({ transcribeProvider: "whisper" }));
+      expect(res.status).toBe(401);
+      expect(existsSync(configPath)).toBe(false);
+    });
+
+    test("wrong bearer → 401", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(putReq({ transcribeProvider: "whisper" }, "wrong"));
+      expect(res.status).toBe(401);
+    });
+
+    test("matching shared-secret bearer → 200 (shared secret grants both scopes)", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(
+        putReq({ transcribeProvider: "whisper" }, "s3cret"),
+      );
+      expect(res.status).toBe(200);
+      expect(existsSync(configPath)).toBe(true);
+    });
+  });
+
+  describe("method check", () => {
+    beforeEach(() => {
+      delete process.env.SCRIBE_AUTH_TOKEN;
+    });
+
+    test("POST /.parachute/config → 405 (only GET + PUT)", async () => {
+      const handler = buildHandler(configPath);
+      const req = new Request("http://localhost/.parachute/config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(405);
+    });
+
+    test("DELETE /.parachute/config → 405", async () => {
+      const handler = buildHandler(configPath);
+      const res = await handler(
+        new Request("http://localhost/.parachute/config", { method: "DELETE" }),
+      );
+      expect(res.status).toBe(405);
+    });
+  });
+});
+
+describe("GET /scribe/admin", () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  test("returns 200 with HTML body in open mode", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  test("HTML contains the key form field names", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    const html = await res.text();
+    for (const name of [
+      "transcribeProvider",
+      "cleanupProvider",
+      "cleanupDefault",
+      "cleanupSystemPrompt",
+      "cleanupContextTemplate",
+    ]) {
+      expect(html).toContain(`name="${name}"`);
+    }
+  });
+
+  test("HTML contains JS that fetches schema + config on load", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    const html = await res.text();
+    expect(html).toContain("/.parachute/config/schema");
+    expect(html).toContain("/.parachute/config");
+    expect(html).toContain("DOMContentLoaded");
+    expect(html).toContain("PUT");
+  });
+
+  test("HTML contains the restart-required banner copy and field labels", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    const html = await res.text();
+    expect(html).toContain("Restart scribe to apply");
+    expect(html).toContain("Transcription provider");
+    expect(html).toContain("Cleanup provider");
+  });
+
+  test("closed mode without bearer → 401", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/scribe/admin"));
+    expect(res.status).toBe(401);
+  });
+
+  test("closed mode with shared-secret bearer → 200", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/scribe/admin", {
+        headers: { Authorization: "Bearer s3cret" },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+// `writeFileSyncSync` is just an alias for `writeFileSync` — TS-friendly
+// import shim local to this test file (some bun versions ship the binding
+// only under the node:fs name). Kept at the bottom so it doesn't crowd the
+// readable top of the file.
+import { writeFileSync as writeFileSyncSync } from "node:fs";

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -1,0 +1,602 @@
+/**
+ * Static HTML for `/scribe/admin` — the operator-facing config form.
+ *
+ * Single self-contained document: HTML + inline CSS + inline JS, no build
+ * step, no framework. Ships in the npm tarball as the rendered string this
+ * file exports. Same shape as hub's `oauth-ui.ts` / `admin-login-ui.ts`.
+ *
+ * The page fetches `/.parachute/config/schema` and `/.parachute/config` on
+ * load and renders one form field per schema property. On save it PUTs the
+ * collected values back to `/.parachute/config` and surfaces the
+ * `restart_required` list returned by the server.
+ *
+ * Auth posture:
+ *   - When loaded through hub's reverse proxy, the hub injects a Bearer with
+ *     `scribe:admin` scope based on the operator's hub session — the form's
+ *     fetch calls go through with that token and the operator never sees it.
+ *   - When loaded directly (no hub in front), the page has no token to send.
+ *     The schema/config fetch on load surfaces the 401 with a "no auth
+ *     detected" banner pointing the operator at the hub. Scribe doesn't try
+ *     to invent its own session system — it's stateless by design.
+ *   - In open mode (`SCRIBE_AUTH_TOKEN` unset, loopback-trusted), the page
+ *     just works without a Bearer because the auth gate is bypassed.
+ */
+
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#6A9B77",
+  accentHover: "#588163",
+  accentSoft: "rgba(106, 155, 119, 0.10)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+/**
+ * Render the admin page. Pure function — returns the HTML string. The page
+ * itself fetches live state on load (one round-trip for the schema, one for
+ * the resolved config), so the rendered HTML is the same across requests.
+ */
+export function renderAdminPage(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Scribe — Configuration</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+    <div class="card">
+      <header class="card-header">
+        <div class="brand">
+          <span class="brand-mark">S</span>
+          <span class="brand-name">Scribe</span>
+          <span class="brand-tag">configuration</span>
+        </div>
+        <h1>Configure transcription &amp; cleanup</h1>
+        <p class="subtitle">Edit values and save. Provider or port changes take effect on the next restart.</p>
+      </header>
+
+      <div id="status-banner" class="banner" hidden></div>
+
+      <form id="config-form" class="config-form" novalidate>
+        <fieldset class="loading" id="form-loading">
+          <legend>Loading current configuration…</legend>
+        </fieldset>
+
+        <fieldset class="form-body" id="form-body" hidden>
+          <label class="field">
+            <span class="field-label">Transcription provider</span>
+            <select name="transcribeProvider" id="f-transcribeProvider"></select>
+            <span class="field-hint" id="hint-transcribeProvider">Engine used to turn audio into text.</span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Cleanup provider</span>
+            <select name="cleanupProvider" id="f-cleanupProvider"></select>
+            <span class="field-hint" id="hint-cleanupProvider">Optional LLM pass — pick "none" to skip cleanup.</span>
+          </label>
+
+          <label class="field field-inline">
+            <input type="checkbox" name="cleanupDefault" id="f-cleanupDefault" />
+            <span class="field-label-inline">Run cleanup by default</span>
+            <span class="field-hint" id="hint-cleanupDefault">Applied when a transcription request omits an explicit cleanup flag.</span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Cleanup system prompt</span>
+            <textarea name="cleanupSystemPrompt" id="f-cleanupSystemPrompt" rows="10" placeholder="Leave empty to use scribe's built-in prompt."></textarea>
+            <span class="field-hint">Full override of the built-in cleanup system prompt. The proper-nouns block from the request payload is still appended after this.</span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Cleanup context template</span>
+            <textarea name="cleanupContextTemplate" id="f-cleanupContextTemplate" rows="4" placeholder="e.g. \\n\\nKnown names: {{proper_nouns}}"></textarea>
+            <span class="field-hint">Template for the proper-nouns block. Use <code>{{proper_nouns}}</code> as the placeholder. Leave empty to use scribe's default rule.</span>
+          </label>
+        </fieldset>
+
+        <div class="button-row" id="button-row" hidden>
+          <button type="submit" class="btn btn-primary" id="save-btn">Save configuration</button>
+          <button type="button" class="btn btn-secondary" id="reload-btn">Reload from server</button>
+        </div>
+      </form>
+
+      <footer class="card-footer">
+        <p class="footer-hint">
+          File on disk: <code>~/.parachute/scribe/config.json</code>.
+          Live values (resolved): <a href="/.parachute/config">/.parachute/config</a>.
+          Schema: <a href="/.parachute/config/schema">/.parachute/config/schema</a>.
+        </p>
+      </footer>
+    </div>
+  </main>
+
+  <script>${PAGE_SCRIPT}</script>
+</body>
+</html>`;
+}
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    justify-content: center;
+    padding: 2.5rem 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 44rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+    font-weight: 600;
+    font-size: 0.85rem;
+    line-height: 1;
+  }
+  .brand-name { letter-spacing: 0.01em; font-weight: 600; }
+  .brand-tag {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    color: ${PALETTE.fgDim};
+    border-left: 1px solid ${PALETTE.border};
+    padding-left: 0.55rem;
+    margin-left: 0.15rem;
+  }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.75rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  .subtitle {
+    margin: 0;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.95rem;
+  }
+
+  .banner {
+    margin: 0 0 1.25rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    border: 1px solid transparent;
+  }
+  .banner-error {
+    background: ${PALETTE.dangerSoft};
+    border-color: ${PALETTE.danger};
+    color: ${PALETTE.danger};
+  }
+  .banner-success {
+    background: ${PALETTE.successSoft};
+    border-color: ${PALETTE.success};
+    color: ${PALETTE.success};
+  }
+  .banner-warn {
+    background: ${PALETTE.bgSoft};
+    border-color: ${PALETTE.border};
+    color: ${PALETTE.fgMuted};
+  }
+  .banner ul { margin: 0.4rem 0 0; padding-left: 1.2rem; }
+  .banner code {
+    font-family: ${FONT_MONO};
+    font-size: 0.85em;
+    background: rgba(255,255,255,0.5);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+
+  .config-form { display: flex; flex-direction: column; gap: 1.25rem; }
+  fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  fieldset.loading {
+    padding: 1.25rem;
+    background: ${PALETTE.bgSoft};
+    border-radius: 6px;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.9rem;
+    text-align: center;
+  }
+  fieldset.loading legend { padding: 0; }
+
+  .field { display: flex; flex-direction: column; gap: 0.3rem; }
+  .field-inline {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .field-inline .field-hint { flex-basis: 100%; margin-left: 1.6rem; }
+  .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fgMuted};
+    letter-spacing: 0.01em;
+  }
+  .field-label-inline { font-size: 0.95rem; }
+  .field-hint {
+    font-size: 0.8rem;
+    color: ${PALETTE.fgDim};
+  }
+  .field-hint code {
+    font-family: ${FONT_MONO};
+    font-size: 0.85em;
+    background: ${PALETTE.bgSoft};
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    color: ${PALETTE.fgMuted};
+  }
+  .field-error {
+    font-size: 0.8rem;
+    color: ${PALETTE.danger};
+    font-weight: 500;
+  }
+
+  select, textarea, input[type=text], input[type=number] {
+    font: inherit;
+    width: 100%;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  textarea {
+    font-family: ${FONT_MONO};
+    font-size: 0.88rem;
+    resize: vertical;
+    min-height: 4rem;
+    line-height: 1.5;
+  }
+  select:focus, textarea:focus, input:focus {
+    outline: none;
+    border-color: ${PALETTE.accent};
+    background: ${PALETTE.cardBg};
+    box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
+  }
+  input[type=checkbox] {
+    width: 1.1rem;
+    height: 1.1rem;
+    accent-color: ${PALETTE.accent};
+    margin: 0;
+  }
+  .field-invalid select, .field-invalid textarea, .field-invalid input {
+    border-color: ${PALETTE.danger};
+  }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.6rem 1.1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  .btn-primary {
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+  }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+  .btn-primary:disabled { background: ${PALETTE.fgDim}; cursor: progress; }
+  .btn-secondary {
+    background: ${PALETTE.cardBg};
+    color: ${PALETTE.fgMuted};
+    border-color: ${PALETTE.border};
+  }
+  .btn-secondary:hover { color: ${PALETTE.fg}; border-color: ${PALETTE.fgDim}; }
+  .button-row { display: flex; gap: 0.6rem; margin-top: 0.5rem; }
+
+  .card-footer {
+    margin-top: 1.75rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+    color: ${PALETTE.fgMuted};
+    font-size: 0.82rem;
+  }
+  .footer-hint { margin: 0; }
+  .footer-hint code {
+    font-family: ${FONT_MONO};
+    font-size: 0.85em;
+    background: ${PALETTE.bgSoft};
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    color: ${PALETTE.fg};
+  }
+  .footer-hint a { color: ${PALETTE.accent}; }
+  .footer-hint a:hover { color: ${PALETTE.accentHover}; }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1 { color: #f0ece4; }
+    .subtitle, .field-label, .field-hint { color: #a8a29a; }
+    select, textarea, input[type=text], input[type=number] {
+      background: #1f1c18; border-color: #3a362f; color: #e8e4dc;
+    }
+    select:focus, textarea:focus, input:focus { background: #25221d; }
+    .btn-secondary { background: #25221d; border-color: #3a362f; color: #a8a29a; }
+    .btn-secondary:hover { color: #e8e4dc; border-color: #6b6860; }
+    .card-footer { border-color: #3a362f; }
+    fieldset.loading { background: #1f1c18; }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 1rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.45rem; }
+    .button-row { flex-direction: column; }
+    .button-row .btn { width: 100%; }
+  }
+`;
+
+// The page script is intentionally vanilla JS — no bundler, no transpile.
+// It runs on whatever the browser supports today; modern fetch + async/await
+// + DOM APIs are everywhere we care about. The string is interpolated into
+// the served HTML; do NOT use backticks inside without escaping them, since
+// this whole file is a TS template literal.
+const PAGE_SCRIPT = String.raw`
+  "use strict";
+
+  const FIELD_IDS = {
+    transcribeProvider: "f-transcribeProvider",
+    cleanupProvider: "f-cleanupProvider",
+    cleanupDefault: "f-cleanupDefault",
+    cleanupSystemPrompt: "f-cleanupSystemPrompt",
+    cleanupContextTemplate: "f-cleanupContextTemplate",
+  };
+
+  const RESTART_LABELS = {
+    transcribeProvider: "Transcription provider",
+    cleanupProvider: "Cleanup provider",
+    port: "Server port",
+  };
+
+  function el(id) { return document.getElementById(id); }
+
+  function setBanner(kind, html) {
+    const b = el("status-banner");
+    b.className = "banner banner-" + kind;
+    b.innerHTML = html;
+    b.hidden = false;
+    b.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+  function clearBanner() {
+    const b = el("status-banner");
+    b.hidden = true;
+    b.innerHTML = "";
+    b.className = "banner";
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function clearFieldErrors() {
+    document.querySelectorAll(".field-error").forEach(function (n) { n.remove(); });
+    document.querySelectorAll(".field-invalid").forEach(function (n) {
+      n.classList.remove("field-invalid");
+    });
+  }
+
+  function setFieldError(name, message) {
+    const id = FIELD_IDS[name];
+    if (!id) return;
+    const input = el(id);
+    if (!input) return;
+    const field = input.closest(".field");
+    if (!field) return;
+    field.classList.add("field-invalid");
+    const err = document.createElement("span");
+    err.className = "field-error";
+    err.textContent = message;
+    field.appendChild(err);
+  }
+
+  function populateSelect(id, options, current) {
+    const select = el(id);
+    select.innerHTML = "";
+    options.forEach(function (opt) {
+      const o = document.createElement("option");
+      o.value = opt;
+      o.textContent = opt;
+      if (opt === current) o.selected = true;
+      select.appendChild(o);
+    });
+  }
+
+  function collectForm() {
+    return {
+      transcribeProvider: el(FIELD_IDS.transcribeProvider).value,
+      cleanupProvider: el(FIELD_IDS.cleanupProvider).value,
+      cleanupDefault: el(FIELD_IDS.cleanupDefault).checked,
+      cleanupSystemPrompt: el(FIELD_IDS.cleanupSystemPrompt).value || null,
+      cleanupContextTemplate: el(FIELD_IDS.cleanupContextTemplate).value || null,
+    };
+  }
+
+  function applyConfig(schema, current) {
+    const props = schema.properties || {};
+    const transcribeEnum = (props.transcribeProvider && props.transcribeProvider.enum) || [];
+    const cleanupEnum = (props.cleanupProvider && props.cleanupProvider.enum) || [];
+    populateSelect(FIELD_IDS.transcribeProvider, transcribeEnum, current.transcribeProvider);
+    populateSelect(FIELD_IDS.cleanupProvider, cleanupEnum, current.cleanupProvider);
+    el(FIELD_IDS.cleanupDefault).checked = !!current.cleanupDefault;
+    el(FIELD_IDS.cleanupSystemPrompt).value = current.cleanupSystemPrompt || "";
+    el(FIELD_IDS.cleanupContextTemplate).value = current.cleanupContextTemplate || "";
+  }
+
+  async function loadConfig() {
+    clearBanner();
+    clearFieldErrors();
+    el("form-loading").hidden = false;
+    el("form-body").hidden = true;
+    el("button-row").hidden = true;
+
+    try {
+      const [schemaRes, configRes] = await Promise.all([
+        fetch("/.parachute/config/schema"),
+        fetch("/.parachute/config"),
+      ]);
+      if (schemaRes.status === 401 || configRes.status === 401) {
+        setBanner(
+          "warn",
+          "<strong>No auth detected.</strong> Scribe requires a bearer token with the <code>scribe:admin</code> scope, " +
+            "but this page has no way to mint one. Access the configuration through the Parachute hub (which proxies " +
+            "with the appropriate session), or set <code>SCRIBE_AUTH_TOKEN</code> empty for loopback-trusted mode."
+        );
+        el("form-loading").hidden = true;
+        return;
+      }
+      if (!schemaRes.ok) throw new Error("schema fetch failed (" + schemaRes.status + ")");
+      if (!configRes.ok) throw new Error("config fetch failed (" + configRes.status + ")");
+
+      const schema = await schemaRes.json();
+      const current = await configRes.json();
+      applyConfig(schema, current);
+      el("form-loading").hidden = true;
+      el("form-body").hidden = false;
+      el("button-row").hidden = false;
+    } catch (err) {
+      el("form-loading").hidden = true;
+      setBanner(
+        "error",
+        "<strong>Could not load configuration.</strong> " + escapeHtml(err && err.message ? err.message : String(err))
+      );
+    }
+  }
+
+  async function saveConfig(ev) {
+    ev.preventDefault();
+    clearBanner();
+    clearFieldErrors();
+    const saveBtn = el("save-btn");
+    saveBtn.disabled = true;
+    saveBtn.textContent = "Saving…";
+
+    const body = collectForm();
+    let res;
+    try {
+      res = await fetch("/.parachute/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      saveBtn.disabled = false;
+      saveBtn.textContent = "Save configuration";
+      setBanner("error", "<strong>Network error.</strong> " + escapeHtml(err && err.message ? err.message : String(err)));
+      return;
+    }
+
+    let payload = null;
+    try { payload = await res.json(); } catch (_e) { /* non-JSON */ }
+
+    if (res.status === 400 && payload && Array.isArray(payload.errors)) {
+      payload.errors.forEach(function (err) {
+        if (err && err.path) setFieldError(err.path, err.message || "invalid");
+      });
+      setBanner(
+        "error",
+        "<strong>Validation failed.</strong> Fix the highlighted fields and save again."
+      );
+    } else if (res.status === 401) {
+      setBanner(
+        "error",
+        "<strong>Unauthorized.</strong> Reload this page through the Parachute hub so it proxies with your operator session."
+      );
+    } else if (res.status === 403) {
+      setBanner(
+        "error",
+        "<strong>Forbidden.</strong> Your session is missing the <code>scribe:admin</code> scope."
+      );
+    } else if (!res.ok) {
+      const msg = payload && payload.message ? payload.message : ("HTTP " + res.status);
+      setBanner("error", "<strong>Save failed.</strong> " + escapeHtml(msg));
+    } else {
+      const restart = (payload && payload.restart_required) || [];
+      if (restart.length === 0) {
+        setBanner("success", "<strong>Configuration saved.</strong> Changes take effect immediately.");
+      } else {
+        const items = restart.map(function (f) {
+          return "<li><code>" + escapeHtml(f) + "</code> — " + escapeHtml(RESTART_LABELS[f] || f) + "</li>";
+        }).join("");
+        setBanner(
+          "success",
+          "<strong>Configuration saved.</strong> Restart scribe to apply these changes:<ul>" + items + "</ul>"
+        );
+      }
+    }
+
+    saveBtn.disabled = false;
+    saveBtn.textContent = "Save configuration";
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    el("config-form").addEventListener("submit", saveConfig);
+    el("reload-btn").addEventListener("click", loadConfig);
+    loadConfig();
+  });
+`;

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -228,6 +228,13 @@ const STYLES = `
     color: ${PALETTE.fgMuted};
   }
   .banner ul { margin: 0.4rem 0 0; padding-left: 1.2rem; }
+  .banner-footnote {
+    margin: 0.6rem 0 0;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba(0,0,0,0.08);
+    font-size: 0.85rem;
+    opacity: 0.85;
+  }
   .banner code {
     font-family: ${FONT_MONO};
     font-size: 0.85em;
@@ -411,10 +418,15 @@ const PAGE_SCRIPT = String.raw`
 
   function el(id) { return document.getElementById(id); }
 
-  function setBanner(kind, html) {
+  // The second arg is named trustedHtml as a signal that callers MUST have
+  // sanitized any untrusted content (escapeHtml() etc.) before passing it
+  // in. innerHTML is the right primitive here because the success banner
+  // composes its own HTML <ul>; renaming makes the contract explicit at
+  // every call site.
+  function setBanner(kind, trustedHtml) {
     const b = el("status-banner");
     b.className = "banner banner-" + kind;
-    b.innerHTML = html;
+    b.innerHTML = trustedHtml;
     b.hidden = false;
     b.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
@@ -583,9 +595,18 @@ const PAGE_SCRIPT = String.raw`
         const items = restart.map(function (f) {
           return "<li><code>" + escapeHtml(f) + "</code> — " + escapeHtml(RESTART_LABELS[f] || f) + "</li>";
         }).join("");
+        // Surface the port-is-not-in-config.json gotcha: when 'port' shows
+        // up in restart_required, an unwary operator will edit config.json
+        // (or re-save the form) and find scribe still binds the same port.
+        // Port resolution reads services.json + SCRIBE_PORT env, not
+        // config.json -- call that out inline so the operator knows where
+        // to actually change it.
+        const portNote = restart.indexOf("port") !== -1
+          ? "<p class=\"banner-footnote\">Note: <code>port</code> is set via <code>services.json</code> or the <code>SCRIBE_PORT</code> environment variable, not <code>config.json</code>.</p>"
+          : "";
         setBanner(
           "success",
-          "<strong>Configuration saved.</strong> Restart scribe to apply these changes:<ul>" + items + "</ul>"
+          "<strong>Configuration saved.</strong> Restart scribe to apply these changes:<ul>" + items + "</ul>" + portNote
         );
       }
     }

--- a/src/config-write.test.ts
+++ b/src/config-write.test.ts
@@ -1,10 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ResolvedConfig } from "./config-schema.ts";
 import {
   detectRestartRequired,
+  mergeIntoFileShape,
+  readExistingConfig,
   toFileShape,
   validateConfig,
   writeConfigFileAtomic,
@@ -143,13 +153,23 @@ describe("toFileShape", () => {
     expect((file as Record<string, unknown>).port).toBeUndefined();
   });
 
-  test("explicit null on a clearable field skips writing it (don't pin an empty string)", () => {
+  test("explicit null on a clearable field is preserved as a deletion sentinel", () => {
+    // `null` now flows through `toFileShape` so `mergeIntoFileShape` can act
+    // on it. The merger drops null-valued keys from the merged-on-disk
+    // shape; `toFileShape` alone no longer makes that decision (scribe#45
+    // must-fix 1 — the prior behavior silently no-op'd a textarea clear).
     const file = toFileShape({
       cleanupProvider: "ollama",
       cleanupSystemPrompt: null,
       cleanupContextTemplate: null,
     });
-    expect(file).toEqual({ cleanup: { provider: "ollama" } });
+    expect(file).toEqual({
+      cleanup: {
+        provider: "ollama",
+        system_prompt: null,
+        context_template: null,
+      },
+    });
   });
 });
 
@@ -260,5 +280,223 @@ describe("writeConfigFileAtomic", () => {
     writeConfigFileAtomic(target, { cleanup: { provider: "none" } });
     const leftovers = readdirSync(join(dir, "scribe")).filter((n) => n.includes(".tmp-"));
     expect(leftovers).toEqual([]);
+  });
+
+  test("written file has 0o600 mode (owner-only — scribe#45 must-fix 2)", () => {
+    const path = join(dir, "scribe", "config.json");
+    writeConfigFileAtomic(path, { cleanup: { provider: "none" } });
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("rewrite preserves 0o600 — even if someone chmod'd to 644 between writes", () => {
+    const path = join(dir, "scribe", "config.json");
+    writeConfigFileAtomic(path, { cleanup: { provider: "none" } });
+    // Simulate an out-of-band chmod that loosened the perms.
+    require("node:fs").chmodSync(path, 0o644);
+    writeConfigFileAtomic(path, { cleanup: { provider: "ollama" } });
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("readExistingConfig", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-read-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns {} when the file does not exist", () => {
+    expect(readExistingConfig(join(dir, "nope.json"))).toEqual({});
+  });
+
+  test("returns {} when the file exists but is empty", () => {
+    const path = join(dir, "empty.json");
+    writeFileSync(path, "");
+    expect(readExistingConfig(path)).toEqual({});
+  });
+
+  test("parses a valid file and returns its contents", () => {
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ cleanup: { provider: "ollama", system_prompt: "X" } }),
+    );
+    expect(readExistingConfig(path)).toEqual({
+      cleanup: { provider: "ollama", system_prompt: "X" },
+    });
+  });
+
+  test("throws on malformed JSON (fail-loud, matches loadConfig posture)", () => {
+    const path = join(dir, "bad.json");
+    writeFileSync(path, "{not json");
+    expect(() => readExistingConfig(path)).toThrow(/Failed to parse config/);
+  });
+});
+
+describe("mergeIntoFileShape", () => {
+  test("empty patch on empty existing → empty merged", () => {
+    expect(mergeIntoFileShape({}, {})).toEqual({});
+  });
+
+  test("patch with no cleanup keys carries existing cleanup forward verbatim", () => {
+    const existing = {
+      cleanup: { provider: "ollama", system_prompt: "OLD", default: true },
+    };
+    expect(mergeIntoFileShape(existing, { transcribe: { provider: "whisper" } })).toEqual({
+      transcribe: { provider: "whisper" },
+      cleanup: { provider: "ollama", system_prompt: "OLD", default: true },
+    });
+  });
+
+  test("patch with system_prompt: null DROPS system_prompt from merged result", () => {
+    const existing = {
+      cleanup: { provider: "ollama", system_prompt: "OLD PROMPT", default: true },
+    };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { system_prompt: null },
+    });
+    expect(merged).toEqual({
+      cleanup: { provider: "ollama", default: true },
+    });
+    expect(merged.cleanup).not.toHaveProperty("system_prompt");
+  });
+
+  test("patch with context_template: null DROPS context_template from merged result", () => {
+    const existing = {
+      cleanup: { provider: "ollama", context_template: "OLD {{proper_nouns}}" },
+    };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { context_template: null },
+    });
+    expect(merged).toEqual({ cleanup: { provider: "ollama" } });
+    expect(merged.cleanup).not.toHaveProperty("context_template");
+  });
+
+  test("patch overwrites existing string field with new string", () => {
+    const existing = { cleanup: { system_prompt: "OLD" } };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { system_prompt: "NEW" },
+    });
+    expect(merged.cleanup?.system_prompt).toBe("NEW");
+  });
+
+  test("patch boolean field replaces existing boolean", () => {
+    const existing = { cleanup: { default: true } };
+    const merged = mergeIntoFileShape(existing, { cleanup: { default: false } });
+    expect(merged.cleanup?.default).toBe(false);
+  });
+
+  test("absent patch boolean leaves existing boolean alone (not falsey-coerced)", () => {
+    const existing = { cleanup: { default: false } };
+    const merged = mergeIntoFileShape(existing, { cleanup: { provider: "ollama" } });
+    expect(merged.cleanup?.default).toBe(false);
+  });
+
+  test("operator-set `model` survives a patch that does not mention it", () => {
+    // Wire shape doesn't expose `model` today, so a SPA-driven patch never
+    // sets it. Don't strip the operator's hand-set value.
+    const existing = { cleanup: { provider: "ollama", model: "llama3.2:3b" } };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { system_prompt: "X" },
+    });
+    expect(merged.cleanup?.model).toBe("llama3.2:3b");
+  });
+
+  test("clearing one prompt does not touch the other prompt", () => {
+    const existing = {
+      cleanup: { system_prompt: "KEEP_SYS", context_template: "KEEP_TPL" },
+    };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { system_prompt: null },
+    });
+    expect(merged.cleanup).toEqual({ context_template: "KEEP_TPL" });
+  });
+
+  test("cleanup block disappears entirely when every key is cleared or absent", () => {
+    const existing = { cleanup: { system_prompt: "OLD" } };
+    const merged = mergeIntoFileShape(existing, {
+      cleanup: { system_prompt: null },
+    });
+    expect(merged.cleanup).toBeUndefined();
+  });
+});
+
+describe("write-through null-clear (regression — scribe#45 must-fix 1)", () => {
+  // These tests pin the load-bearing UX behavior: the user clears a textarea
+  // in the admin form, hits Save, and expects the field to actually be
+  // cleared on disk. Before the read-modify-write fix, `toFileShape` dropped
+  // null-valued keys before write, so the disk file still carried the OLD
+  // value — and the SPA's 200 banner said "Saved." End-to-end test through
+  // toFileShape → mergeIntoFileShape → writeConfigFileAtomic → readback.
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-clear-"));
+    path = join(dir, "scribe", "config.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFull(): void {
+    writeConfigFileAtomic(path, {
+      transcribe: { provider: "whisper" },
+      cleanup: {
+        provider: "ollama",
+        system_prompt: "OLD PROMPT",
+        context_template: "OLD TEMPLATE",
+        default: true,
+      },
+    });
+  }
+
+  function applyWirePatch(wire: Parameters<typeof toFileShape>[0]): void {
+    const existing = readExistingConfig(path);
+    const patch = toFileShape(wire);
+    const merged = mergeIntoFileShape(existing, patch);
+    writeConfigFileAtomic(path, merged);
+  }
+
+  test("PUT with cleanupSystemPrompt: null clears existing prompt on disk", () => {
+    writeFull();
+    applyWirePatch({ cleanupSystemPrompt: null });
+    const onDisk = JSON.parse(readFileSync(path, "utf8"));
+    expect(onDisk.cleanup.system_prompt).toBeUndefined();
+    // Other cleanup fields survive.
+    expect(onDisk.cleanup.context_template).toBe("OLD TEMPLATE");
+    expect(onDisk.cleanup.provider).toBe("ollama");
+    expect(onDisk.cleanup.default).toBe(true);
+  });
+
+  test("PUT with cleanupContextTemplate: null clears existing template on disk", () => {
+    writeFull();
+    applyWirePatch({ cleanupContextTemplate: null });
+    const onDisk = JSON.parse(readFileSync(path, "utf8"));
+    expect(onDisk.cleanup.context_template).toBeUndefined();
+    expect(onDisk.cleanup.system_prompt).toBe("OLD PROMPT");
+  });
+
+  test("PUT with both null clears both — provider survives", () => {
+    writeFull();
+    applyWirePatch({ cleanupSystemPrompt: null, cleanupContextTemplate: null });
+    const onDisk = JSON.parse(readFileSync(path, "utf8"));
+    expect(onDisk.cleanup.system_prompt).toBeUndefined();
+    expect(onDisk.cleanup.context_template).toBeUndefined();
+    expect(onDisk.cleanup.provider).toBe("ollama");
+  });
+
+  test("PUT that replaces the prompt overwrites cleanly (not a null-clear path)", () => {
+    writeFull();
+    applyWirePatch({ cleanupSystemPrompt: "NEW PROMPT" });
+    const onDisk = JSON.parse(readFileSync(path, "utf8"));
+    expect(onDisk.cleanup.system_prompt).toBe("NEW PROMPT");
   });
 });

--- a/src/config-write.test.ts
+++ b/src/config-write.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedConfig } from "./config-schema.ts";
+import {
+  detectRestartRequired,
+  toFileShape,
+  validateConfig,
+  writeConfigFileAtomic,
+} from "./config-write.ts";
+
+const BASE_RESOLVED: ResolvedConfig = {
+  transcribeProvider: "parakeet-mlx",
+  cleanupProvider: "none",
+  cleanupDefault: true,
+  cleanupSystemPrompt: null,
+  cleanupContextTemplate: null,
+  port: 1943,
+};
+
+describe("validateConfig", () => {
+  test("accepts a complete, well-typed body and returns it verbatim", () => {
+    const body = {
+      transcribeProvider: "parakeet-mlx",
+      cleanupProvider: "ollama",
+      cleanupDefault: false,
+      cleanupSystemPrompt: "PROMPT",
+      cleanupContextTemplate: "ctx {{proper_nouns}}",
+      port: 1943,
+    };
+    const result = validateConfig(body);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(body);
+  });
+
+  test("accepts an empty object (partial PUT)", () => {
+    const result = validateConfig({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object bodies", () => {
+    for (const v of [null, undefined, "string", 5, true, []]) {
+      const r = validateConfig(v as unknown);
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  test("rejects unknown top-level keys", () => {
+    const r = validateConfig({ frobnicator: "x", transcribeProvider: "parakeet-mlx" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.some((e) => e.path === "frobnicator")).toBe(true);
+  });
+
+  test("rejects transcribeProvider not in enum", () => {
+    const r = validateConfig({ transcribeProvider: "not-a-real-provider" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]?.path).toBe("transcribeProvider");
+  });
+
+  test("rejects cleanupProvider not in enum (case-sensitive)", () => {
+    const r = validateConfig({ cleanupProvider: "Claude" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]?.path).toBe("cleanupProvider");
+  });
+
+  test("rejects port outside 1..65535", () => {
+    const high = validateConfig({ port: 70000 });
+    expect(high.ok).toBe(false);
+    if (!high.ok) expect(high.errors[0]?.path).toBe("port");
+    const low = validateConfig({ port: 0 });
+    expect(low.ok).toBe(false);
+    const float = validateConfig({ port: 19.43 });
+    expect(float.ok).toBe(false);
+  });
+
+  test("rejects cleanupDefault that is not a boolean", () => {
+    const r = validateConfig({ cleanupDefault: "true" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]?.path).toBe("cleanupDefault");
+  });
+
+  test("accepts explicit null for the two clearable string fields", () => {
+    const r = validateConfig({
+      cleanupSystemPrompt: null,
+      cleanupContextTemplate: null,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test("rejects null for non-clearable fields", () => {
+    const r = validateConfig({ transcribeProvider: null });
+    expect(r.ok).toBe(false);
+  });
+
+  test("collects multiple errors in one pass", () => {
+    const r = validateConfig({
+      transcribeProvider: "nope",
+      cleanupProvider: "nope",
+      port: -1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.length).toBe(3);
+  });
+});
+
+describe("toFileShape", () => {
+  test("translates flat camelCase wire shape to nested file shape", () => {
+    expect(
+      toFileShape({
+        transcribeProvider: "whisper",
+        cleanupProvider: "ollama",
+        cleanupDefault: false,
+        cleanupSystemPrompt: "PROMPT",
+        cleanupContextTemplate: "CTX",
+      }),
+    ).toEqual({
+      transcribe: { provider: "whisper" },
+      cleanup: {
+        provider: "ollama",
+        default: false,
+        system_prompt: "PROMPT",
+        context_template: "CTX",
+      },
+    });
+  });
+
+  test("omits the transcribe block when transcribeProvider absent", () => {
+    expect(toFileShape({ cleanupProvider: "none" })).toEqual({
+      cleanup: { provider: "none" },
+    });
+  });
+
+  test("omits cleanup block entirely when no cleanup-* fields are present", () => {
+    expect(toFileShape({ transcribeProvider: "whisper" })).toEqual({
+      transcribe: { provider: "whisper" },
+    });
+  });
+
+  test("does NOT write port to disk (port is resolved from services.json / env)", () => {
+    const file = toFileShape({ transcribeProvider: "whisper", port: 1944 });
+    expect(file).toEqual({ transcribe: { provider: "whisper" } });
+    expect((file as Record<string, unknown>).port).toBeUndefined();
+  });
+
+  test("explicit null on a clearable field skips writing it (don't pin an empty string)", () => {
+    const file = toFileShape({
+      cleanupProvider: "ollama",
+      cleanupSystemPrompt: null,
+      cleanupContextTemplate: null,
+    });
+    expect(file).toEqual({ cleanup: { provider: "ollama" } });
+  });
+});
+
+describe("detectRestartRequired", () => {
+  test("empty diff when incoming matches resolved", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, {
+      transcribeProvider: "parakeet-mlx",
+      cleanupProvider: "none",
+      cleanupDefault: true,
+      port: 1943,
+    });
+    expect(list).toEqual([]);
+  });
+
+  test("transcribeProvider change is restart-required", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, { transcribeProvider: "whisper" });
+    expect(list).toEqual(["transcribeProvider"]);
+  });
+
+  test("cleanupProvider change is restart-required", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, { cleanupProvider: "ollama" });
+    expect(list).toEqual(["cleanupProvider"]);
+  });
+
+  test("port change is restart-required", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, { port: 1944 });
+    expect(list).toEqual(["port"]);
+  });
+
+  test("system_prompt change alone is NOT restart-required (read dynamically)", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, {
+      cleanupSystemPrompt: "NEW PROMPT",
+    });
+    expect(list).toEqual([]);
+  });
+
+  test("cleanupDefault toggle alone is NOT restart-required (read dynamically)", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, { cleanupDefault: false });
+    expect(list).toEqual([]);
+  });
+
+  test("context_template change alone is NOT restart-required", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, {
+      cleanupContextTemplate: "X {{proper_nouns}}",
+    });
+    expect(list).toEqual([]);
+  });
+
+  test("absent field never counts even if resolved differs (no-change-requested)", () => {
+    // resolved.transcribeProvider is "parakeet-mlx"; absent in incoming.
+    // No change requested → not listed.
+    const list = detectRestartRequired(BASE_RESOLVED, { cleanupSystemPrompt: "x" });
+    expect(list).toEqual([]);
+  });
+
+  test("combined provider + prompt change lists only the provider", () => {
+    const list = detectRestartRequired(BASE_RESOLVED, {
+      transcribeProvider: "whisper",
+      cleanupSystemPrompt: "NEW",
+    });
+    expect(list).toEqual(["transcribeProvider"]);
+  });
+});
+
+describe("writeConfigFileAtomic", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-write-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("writes the config to disk and trailing-newlines", () => {
+    const path = join(dir, "scribe", "config.json");
+    writeConfigFileAtomic(path, {
+      transcribe: { provider: "whisper" },
+      cleanup: { provider: "ollama", default: false },
+    });
+    expect(existsSync(path)).toBe(true);
+    const text = readFileSync(path, "utf8");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(JSON.parse(text)).toEqual({
+      transcribe: { provider: "whisper" },
+      cleanup: { provider: "ollama", default: false },
+    });
+  });
+
+  test("is idempotent — repeated writes produce the same content", () => {
+    const path = join(dir, "scribe", "config.json");
+    writeConfigFileAtomic(path, { transcribe: { provider: "whisper" } });
+    writeConfigFileAtomic(path, { transcribe: { provider: "whisper" } });
+    expect(readFileSync(path, "utf8")).toBe(
+      `${JSON.stringify({ transcribe: { provider: "whisper" } }, null, 2)}\n`,
+    );
+  });
+
+  test("creates intermediate directories if missing", () => {
+    const path = join(dir, "nested", "deeper", "scribe", "config.json");
+    writeConfigFileAtomic(path, { cleanup: { provider: "none" } });
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("does not leave a partial tmp file behind on success", () => {
+    const target = join(dir, "scribe", "config.json");
+    writeConfigFileAtomic(target, { cleanup: { provider: "none" } });
+    const leftovers = readdirSync(join(dir, "scribe")).filter((n) => n.includes(".tmp-"));
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/src/config-write.ts
+++ b/src/config-write.ts
@@ -1,0 +1,243 @@
+/**
+ * PUT /.parachute/config support — JSON-Schema validation, atomic write of
+ * `~/.parachute/scribe/config.json`, and a small restart-required diff.
+ *
+ * Wire shape:
+ *   - PUT body is the camelCase shape that GET /.parachute/config returns
+ *     (`transcribeProvider`, `cleanupProvider`, `cleanupDefault`,
+ *     `cleanupSystemPrompt`, `cleanupContextTemplate`, optional `port`).
+ *     It mirrors the JSON Schema served at `/.parachute/config/schema`.
+ *   - File shape on disk is the nested `ScribeConfig` (`transcribe.provider`,
+ *     `cleanup.provider`, …) — `toFileShape` translates wire→file before write.
+ *
+ * Validation: a tiny purpose-built draft-07 validator that handles the schema
+ * shapes we actually emit (`type: object` + `properties` of `string/integer/
+ * boolean` with optional `enum` + `minimum`/`maximum`). No external dep — the
+ * schema is internal and stable, and pulling ajv in would 10x the deps for one
+ * endpoint.
+ *
+ * Restart-required diff: provider changes (`transcribeProvider`,
+ * `cleanupProvider`) and `port` require a restart because they're resolved
+ * once at boot in `startServer()`. `cleanupDefault`, `cleanupSystemPrompt`,
+ * and `cleanupContextTemplate` are read dynamically per-request in
+ * `handleTranscription`, so they take effect on the next call.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { buildConfigSchema } from "./config-schema.ts";
+import type { ResolvedConfig } from "./config-schema.ts";
+import type { ScribeConfig } from "./config.ts";
+
+/**
+ * Fields whose change forces a restart. Resolved once at boot in
+ * `startServer()`; the running handler closes over the resolved values, so a
+ * mid-life write to `config.json` doesn't repoint the provider in-process.
+ */
+export const RESTART_REQUIRED_FIELDS = [
+  "transcribeProvider",
+  "cleanupProvider",
+  "port",
+] as const;
+
+export type RestartRequiredField = (typeof RESTART_REQUIRED_FIELDS)[number];
+
+export type ValidationError = {
+  path: string;
+  message: string;
+};
+
+export type ValidationResult =
+  | { ok: true; value: ConfigWire }
+  | { ok: false; errors: ValidationError[] };
+
+/**
+ * Wire-shape config. Matches the JSON Schema + GET /.parachute/config output.
+ * Fields are optional on PUT — caller can post a partial object and unspecified
+ * fields keep the resolved-default for that knob. (Explicit `null` for the
+ * two string-or-null fields clears them; absent = keep current.)
+ */
+export type ConfigWire = {
+  transcribeProvider?: string;
+  cleanupProvider?: string;
+  cleanupDefault?: boolean;
+  cleanupSystemPrompt?: string | null;
+  cleanupContextTemplate?: string | null;
+  port?: number;
+};
+
+/**
+ * Tiny draft-07 validator covering only the shapes the scribe schema emits.
+ * Returns a flat list of errors so the wire response can surface them inline.
+ */
+export function validateConfig(input: unknown): ValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: [{ path: "", message: "body must be a JSON object" }],
+    };
+  }
+  const schema = buildConfigSchema();
+  const props = schema.properties as Record<string, SchemaProperty>;
+  const errors: ValidationError[] = [];
+  const out: ConfigWire = {};
+
+  const obj = input as Record<string, unknown>;
+  // Reject unknown top-level keys so a typo on the wire fails loud rather
+  // than silently no-ops. (additionalProperties:false equivalent.)
+  for (const key of Object.keys(obj)) {
+    if (!(key in props)) {
+      errors.push({ path: key, message: `unknown field "${key}"` });
+    }
+  }
+  for (const [key, spec] of Object.entries(props)) {
+    if (!(key in obj)) continue;
+    const value = obj[key];
+    const fieldErrors = validateField(key, value, spec);
+    if (fieldErrors.length > 0) {
+      errors.push(...fieldErrors);
+      continue;
+    }
+    (out as Record<string, unknown>)[key] = value;
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value: out };
+}
+
+type SchemaProperty = {
+  type: "string" | "integer" | "boolean";
+  enum?: string[];
+  minimum?: number;
+  maximum?: number;
+};
+
+function validateField(
+  path: string,
+  value: unknown,
+  spec: SchemaProperty,
+): ValidationError[] {
+  // `cleanupSystemPrompt` and `cleanupContextTemplate` accept explicit `null`
+  // as "clear this field" — that's the natural shape for an optional string
+  // toggled off in the form. The schema itself only declares `type: string`,
+  // but null-as-clear is the inherited contract from the resolved-config
+  // type (which is `string | null`), so we honor it here.
+  if (value === null && (path === "cleanupSystemPrompt" || path === "cleanupContextTemplate")) {
+    return [];
+  }
+  if (spec.type === "string") {
+    if (typeof value !== "string") {
+      return [{ path, message: `${path} must be a string` }];
+    }
+    if (spec.enum && !spec.enum.includes(value)) {
+      return [
+        {
+          path,
+          message: `${path} must be one of: ${spec.enum.join(", ")}`,
+        },
+      ];
+    }
+    return [];
+  }
+  if (spec.type === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      return [{ path, message: `${path} must be an integer` }];
+    }
+    if (spec.minimum !== undefined && value < spec.minimum) {
+      return [{ path, message: `${path} must be ≥ ${spec.minimum}` }];
+    }
+    if (spec.maximum !== undefined && value > spec.maximum) {
+      return [{ path, message: `${path} must be ≤ ${spec.maximum}` }];
+    }
+    return [];
+  }
+  if (spec.type === "boolean") {
+    if (typeof value !== "boolean") {
+      return [{ path, message: `${path} must be a boolean` }];
+    }
+    return [];
+  }
+  return [];
+}
+
+/**
+ * Translate wire-shape (camelCase, flat) → file-shape (nested `transcribe.*`,
+ * `cleanup.*`). The file shape stays the source of truth on disk; the wire
+ * shape mirrors the resolved-config / schema surface.
+ *
+ * `port` is intentionally NOT written into the file: scribe's port resolution
+ * (port-resolve.ts) reads from `services.json` and env, not config.json. The
+ * schema lists it for visibility / documentation in the SPA but writing it
+ * here would just create a dead-letter knob.
+ */
+export function toFileShape(wire: ConfigWire): ScribeConfig {
+  const file: ScribeConfig = {};
+  if (wire.transcribeProvider !== undefined) {
+    file.transcribe = { provider: wire.transcribeProvider };
+  }
+  const cleanup: NonNullable<ScribeConfig["cleanup"]> = {};
+  let cleanupTouched = false;
+  if (wire.cleanupProvider !== undefined) {
+    cleanup.provider = wire.cleanupProvider;
+    cleanupTouched = true;
+  }
+  if (wire.cleanupDefault !== undefined) {
+    cleanup.default = wire.cleanupDefault;
+    cleanupTouched = true;
+  }
+  if (wire.cleanupSystemPrompt !== undefined && wire.cleanupSystemPrompt !== null) {
+    cleanup.system_prompt = wire.cleanupSystemPrompt;
+    cleanupTouched = true;
+  }
+  if (wire.cleanupContextTemplate !== undefined && wire.cleanupContextTemplate !== null) {
+    cleanup.context_template = wire.cleanupContextTemplate;
+    cleanupTouched = true;
+  }
+  if (cleanupTouched) file.cleanup = cleanup;
+  return file;
+}
+
+/**
+ * Diff resolved-current against incoming wire-shape; return the fields whose
+ * change requires a restart to take effect.
+ *
+ * Only fields actually present in the incoming wire are considered — a
+ * partial PUT that omits `transcribeProvider` can't be a transcribe-provider
+ * change, even if the resolved value differs (the absent field is "no change
+ * requested").
+ */
+export function detectRestartRequired(
+  current: ResolvedConfig,
+  incoming: ConfigWire,
+): RestartRequiredField[] {
+  const out: RestartRequiredField[] = [];
+  if (
+    incoming.transcribeProvider !== undefined &&
+    incoming.transcribeProvider !== current.transcribeProvider
+  ) {
+    out.push("transcribeProvider");
+  }
+  if (
+    incoming.cleanupProvider !== undefined &&
+    incoming.cleanupProvider !== current.cleanupProvider
+  ) {
+    out.push("cleanupProvider");
+  }
+  if (incoming.port !== undefined && incoming.port !== current.port) {
+    out.push("port");
+  }
+  return out;
+}
+
+/**
+ * Atomic write of `~/.parachute/scribe/config.json`. Writes a tmp file in the
+ * same directory, then renames — POSIX rename is atomic on the same fs, so a
+ * crash mid-write leaves either the old file intact or the new file complete,
+ * never a half-written file. Same pattern as `services-manifest.ts`.
+ */
+export function writeConfigFileAtomic(path: string, config: ScribeConfig): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`);
+  renameSync(tmp, path);
+}

--- a/src/config-write.ts
+++ b/src/config-write.ts
@@ -1,6 +1,7 @@
 /**
- * PUT /.parachute/config support — JSON-Schema validation, atomic write of
- * `~/.parachute/scribe/config.json`, and a small restart-required diff.
+ * PUT /.parachute/config support — JSON-Schema validation, read-modify-write
+ * merge into `~/.parachute/scribe/config.json`, and a small restart-required
+ * diff.
  *
  * Wire shape:
  *   - PUT body is the camelCase shape that GET /.parachute/config returns
@@ -9,6 +10,16 @@
  *     It mirrors the JSON Schema served at `/.parachute/config/schema`.
  *   - File shape on disk is the nested `ScribeConfig` (`transcribe.provider`,
  *     `cleanup.provider`, …) — `toFileShape` translates wire→file before write.
+ *
+ * Null-as-clear semantics (scribe#45 review must-fix 1):
+ *   - For the two optional string fields (`cleanupSystemPrompt`,
+ *     `cleanupContextTemplate`) an explicit `null` on the wire means "clear
+ *     this field" — the user emptied the form textarea. We surface that to
+ *     the merger as a sentinel and the merger drops the key from the
+ *     merged-on-disk shape. Without this read-modify-write step, an
+ *     "absent in `toFileShape` output" key was silently treated as
+ *     "leave it alone," which meant the operator could "save" an empty
+ *     textarea and the old value would persist unchanged on disk.
  *
  * Validation: a tiny purpose-built draft-07 validator that handles the schema
  * shapes we actually emit (`type: object` + `properties` of `string/integer/
@@ -23,7 +34,7 @@
  * `handleTranscription`, so they take effect on the next call.
  */
 
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { buildConfigSchema } from "./config-schema.ts";
 import type { ResolvedConfig } from "./config-schema.ts";
@@ -161,21 +172,26 @@ function validateField(
 }
 
 /**
- * Translate wire-shape (camelCase, flat) → file-shape (nested `transcribe.*`,
- * `cleanup.*`). The file shape stays the source of truth on disk; the wire
- * shape mirrors the resolved-config / schema surface.
+ * Translate wire-shape (camelCase, flat) → file-shape patch (nested
+ * `transcribe.*`, `cleanup.*`).
+ *
+ * Output is a *patch*, not a replacement: only fields explicitly present in
+ * `wire` appear in the result. Absent fields are absent from the patch and
+ * survive whatever's already on disk. Explicit `null` for the two clearable
+ * string fields is preserved as a sentinel so `mergeIntoFileShape` can drop
+ * the key during the read-modify-write step.
  *
  * `port` is intentionally NOT written into the file: scribe's port resolution
  * (port-resolve.ts) reads from `services.json` and env, not config.json. The
  * schema lists it for visibility / documentation in the SPA but writing it
  * here would just create a dead-letter knob.
  */
-export function toFileShape(wire: ConfigWire): ScribeConfig {
-  const file: ScribeConfig = {};
+export function toFileShape(wire: ConfigWire): FileShapePatch {
+  const file: FileShapePatch = {};
   if (wire.transcribeProvider !== undefined) {
     file.transcribe = { provider: wire.transcribeProvider };
   }
-  const cleanup: NonNullable<ScribeConfig["cleanup"]> = {};
+  const cleanup: CleanupPatch = {};
   let cleanupTouched = false;
   if (wire.cleanupProvider !== undefined) {
     cleanup.provider = wire.cleanupProvider;
@@ -185,16 +201,122 @@ export function toFileShape(wire: ConfigWire): ScribeConfig {
     cleanup.default = wire.cleanupDefault;
     cleanupTouched = true;
   }
-  if (wire.cleanupSystemPrompt !== undefined && wire.cleanupSystemPrompt !== null) {
+  if (wire.cleanupSystemPrompt !== undefined) {
+    // Preserve explicit null — it's the "clear this field" sentinel.
     cleanup.system_prompt = wire.cleanupSystemPrompt;
     cleanupTouched = true;
   }
-  if (wire.cleanupContextTemplate !== undefined && wire.cleanupContextTemplate !== null) {
+  if (wire.cleanupContextTemplate !== undefined) {
     cleanup.context_template = wire.cleanupContextTemplate;
     cleanupTouched = true;
   }
   if (cleanupTouched) file.cleanup = cleanup;
   return file;
+}
+
+/**
+ * Patch shape produced by `toFileShape`. Same nested structure as
+ * `ScribeConfig` but each cleanup field is optional + nullable: presence
+ * means "set this", `null` means "clear this", absence means "leave alone".
+ */
+export type CleanupPatch = {
+  provider?: string;
+  model?: string;
+  default?: boolean;
+  system_prompt?: string | null;
+  context_template?: string | null;
+};
+
+export type FileShapePatch = {
+  transcribe?: { provider?: string };
+  cleanup?: CleanupPatch;
+};
+
+/**
+ * Read the existing config file (if any) and apply the patch produced by
+ * `toFileShape`. Returns the merged result that should be written back to
+ * disk. Null patch values for the clearable string fields drop the key
+ * entirely; absent patch keys leave the on-disk value untouched.
+ *
+ * This is the load-bearing function for the "user clears textarea, hits
+ * Save, expects it cleared" UX — see the module-level docstring.
+ */
+export function mergeIntoFileShape(
+  existing: ScribeConfig,
+  patch: FileShapePatch,
+): ScribeConfig {
+  const merged: ScribeConfig = {};
+  // transcribe block: full replace when present in patch; otherwise carry
+  // forward the existing block as-is.
+  if (patch.transcribe !== undefined) {
+    if (patch.transcribe.provider !== undefined) {
+      merged.transcribe = { provider: patch.transcribe.provider };
+    }
+  } else if (existing.transcribe !== undefined) {
+    merged.transcribe = { ...existing.transcribe };
+  }
+
+  // cleanup block: field-by-field merge. Null in patch deletes the key;
+  // undefined in patch carries forward the existing value.
+  const existingCleanup = existing.cleanup ?? {};
+  const patchCleanup = patch.cleanup ?? {};
+  const cleanup: NonNullable<ScribeConfig["cleanup"]> = {};
+  if (patchCleanup.provider !== undefined) cleanup.provider = patchCleanup.provider;
+  else if (existingCleanup.provider !== undefined) cleanup.provider = existingCleanup.provider;
+
+  if (patchCleanup.default !== undefined) cleanup.default = patchCleanup.default;
+  else if (existingCleanup.default !== undefined) cleanup.default = existingCleanup.default;
+
+  if (patchCleanup.system_prompt === null) {
+    // Explicit clear — leave the key out of the merged cleanup block.
+  } else if (patchCleanup.system_prompt !== undefined) {
+    cleanup.system_prompt = patchCleanup.system_prompt;
+  } else if (existingCleanup.system_prompt !== undefined) {
+    cleanup.system_prompt = existingCleanup.system_prompt;
+  }
+
+  if (patchCleanup.context_template === null) {
+    // Explicit clear — leave the key out of the merged cleanup block.
+  } else if (patchCleanup.context_template !== undefined) {
+    cleanup.context_template = patchCleanup.context_template;
+  } else if (existingCleanup.context_template !== undefined) {
+    cleanup.context_template = existingCleanup.context_template;
+  }
+
+  // Carry over `model` if it's already on disk — we don't expose it in the
+  // wire shape today, but the file format allows it and we shouldn't
+  // silently strip operator-set values.
+  if (existingCleanup.model !== undefined && patchCleanup.model === undefined) {
+    cleanup.model = existingCleanup.model;
+  } else if (patchCleanup.model !== undefined) {
+    cleanup.model = patchCleanup.model;
+  }
+
+  if (Object.keys(cleanup).length > 0) merged.cleanup = cleanup;
+  return merged;
+}
+
+/**
+ * Read the existing on-disk config (if any). Returns `{}` when the file is
+ * missing or empty. Throws when the file is present but malformed — same
+ * fail-loud posture as `loadConfig` in `config.ts`.
+ */
+export function readExistingConfig(path: string): ScribeConfig {
+  if (!existsSync(path)) return {};
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read config ${path}: ${message}`);
+  }
+  if (raw.trim() === "") return {};
+  try {
+    return JSON.parse(raw) as ScribeConfig;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse config ${path}: ${message}`);
+  }
 }
 
 /**
@@ -234,10 +356,16 @@ export function detectRestartRequired(
  * same directory, then renames — POSIX rename is atomic on the same fs, so a
  * crash mid-write leaves either the old file intact or the new file complete,
  * never a half-written file. Same pattern as `services-manifest.ts`.
+ *
+ * Mode 0o600 (scribe#45 review must-fix 2): PR-B will add provider API keys
+ * to this same file. Default umask would produce 0o644 (world-readable) on
+ * shared hosts. Setting the mode at create time means a fresh file is owner-
+ * read/write only from the first byte; subsequent atomic rewrites pass the
+ * same mode so a chmod-out-of-band can't silently revert.
  */
 export function writeConfigFileAtomic(path: string, config: ScribeConfig): void {
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`);
+  writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
   renameSync(tmp, path);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,8 @@ import {
 } from "./config-schema.ts";
 import {
   detectRestartRequired,
+  mergeIntoFileShape,
+  readExistingConfig,
   toFileShape,
   validateConfig,
   writeConfigFileAtomic,
@@ -182,10 +184,27 @@ async function handleConfigPut(req: Request, deps: ServerDeps): Promise<Response
     );
   }
   const incoming = result.value;
-  const file = toFileShape(incoming);
+  const patch = toFileShape(incoming);
   const path = deps.configPath ?? resolveDefaultConfigPath();
+
+  // Read-modify-write so null-clear semantics actually clear (scribe#45
+  // must-fix 1). Without this, an absent key in `patch` was indistinguishable
+  // from "leave alone", and clearing a textarea silently no-op'd.
+  let existing: ScribeConfig;
   try {
-    writeConfigFileAtomic(path, file);
+    existing = readExistingConfig(path);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[scribe] config read failed (${path}): ${message}`);
+    return Response.json(
+      { error: "read_failed", message: `failed to read ${path}: ${message}` },
+      { status: 500 },
+    );
+  }
+  const merged = mergeIntoFileShape(existing, patch);
+
+  try {
+    writeConfigFileAtomic(path, merged);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[scribe] config write failed (${path}): ${message}`);
@@ -194,12 +213,12 @@ async function handleConfigPut(req: Request, deps: ServerDeps): Promise<Response
       { status: 500 },
     );
   }
-  // Mutate the in-process scribe config so the dynamically-read fields
-  // (cleanup default + prompts) take effect without restart. The provider
-  // closures from boot still hold for the restart-required fields.
-  if (file.cleanup) {
-    deps.scribeConfig.cleanup = { ...deps.scribeConfig.cleanup, ...file.cleanup };
-  }
+  // Mirror the merged-on-disk cleanup block onto the in-process scribeConfig
+  // so dynamically-read fields take effect without restart. Replace the
+  // whole `cleanup` reference rather than spreading: a null-clear (e.g.
+  // `system_prompt`) must remove the key from the live config too, and a
+  // spread would carry the old value forward.
+  deps.scribeConfig.cleanup = merged.cleanup;
   const restartRequired = detectRestartRequired(deps.resolvedConfig, incoming);
   return Response.json({ ok: true, restart_required: restartRequired });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { cleaners, getProvider, transcribers, type Cleaner } from "./providers.ts";
-import { loadConfig, type ScribeConfig } from "./config.ts";
+import { loadConfig, resolveDefaultConfigPath, type ScribeConfig } from "./config.ts";
 import { buildProperNounsBlockFromEntries, parseContextPayload } from "./context.ts";
 import { preflight, withCors } from "./cors.ts";
 import { upsertService } from "./services-manifest.ts";
@@ -18,6 +18,13 @@ import {
   handleConfigSchema,
 } from "./config-schema.ts";
 import {
+  detectRestartRequired,
+  toFileShape,
+  validateConfig,
+  writeConfigFileAtomic,
+} from "./config-write.ts";
+import { renderAdminPage } from "./admin-ui.ts";
+import {
   SCOPE_ADMIN,
   SCOPE_TRANSCRIBE,
   enforceAuth,
@@ -33,6 +40,14 @@ export type ServerDeps = {
   cleanup: Cleaner;
   resolvedConfig: ResolvedConfig;
   scribeConfig: ScribeConfig;
+  /**
+   * Path to the on-disk config file the admin PUT writes through. Defaults
+   * to `resolveDefaultConfigPath()` so production code never specifies it;
+   * tests inject a tmp path. Pulled out as a dep rather than re-resolved at
+   * request time so the test can sandbox the write target without touching
+   * the operator's real `~/.parachute`.
+   */
+  configPath?: string;
 };
 
 export function createFetchHandler(deps: ServerDeps) {
@@ -56,6 +71,11 @@ export function createFetchHandler(deps: ServerDeps) {
 function requiredScopeFor(pathname: string, method: string): string | null {
   if (pathname === "/v1/audio/transcriptions" && method === "POST") return SCOPE_TRANSCRIBE;
   if (pathname.startsWith("/.parachute/config")) return SCOPE_ADMIN;
+  // `/scribe/admin` is the static admin SPA. The page itself is just HTML
+  // and (open mode aside) can't do anything without a Bearer to call back
+  // with — but we still scope-gate the HTML response so an unauthorized
+  // operator gets a clean 403 rather than a page that 401s on every fetch.
+  if (pathname === "/scribe/admin") return SCOPE_ADMIN;
   if (pathname === "/v1/models") return SCOPE_TRANSCRIBE;
   return null;
 }
@@ -72,6 +92,9 @@ async function route(
   }
 
   if (url.pathname.startsWith("/.parachute/")) {
+    if (url.pathname === "/.parachute/config" && req.method === "PUT") {
+      return handleConfigPut(req, deps);
+    }
     if (req.method !== "GET") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
@@ -80,6 +103,19 @@ async function route(
     if (url.pathname === "/.parachute/config/schema") return handleConfigSchema();
     if (url.pathname === "/.parachute/config") return handleConfig(deps.resolvedConfig);
     return new Response("Not found", { status: 404 });
+  }
+
+  if (url.pathname === "/scribe/admin" && req.method === "GET") {
+    return new Response(renderAdminPage(), {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        // The page is per-instance branded but otherwise static and small.
+        // Short cache so a `bun link`-updated scribe serves the new HTML on
+        // reload without manual cache-busts.
+        "Cache-Control": "no-cache",
+      },
+    });
   }
 
   if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
@@ -97,6 +133,75 @@ async function route(
   }
 
   return new Response("Not found", { status: 404 });
+}
+
+/**
+ * PUT /.parachute/config — schema-validate the incoming body, atomically
+ * persist it to `~/.parachute/scribe/config.json`, return the list of fields
+ * whose change requires a restart to take effect.
+ *
+ * The in-process resolved config is NOT mutated here. Provider/port values
+ * are bound to the running handler at boot in `startServer()`; an in-place
+ * swap would skip provider-init invariants. Operators see the new config on
+ * the next process boot. `restart_required` makes that explicit.
+ *
+ * Fields that ARE read dynamically per-request (the cleanup default flag, the
+ * cleanup prompt overrides) take effect on the next call without restart
+ * because `handleTranscription` re-reads `deps.scribeConfig.cleanup.*` each
+ * time. To keep that working we mutate the existing `scribeConfig` object's
+ * `cleanup` block in place after a successful write — the running handler's
+ * closure already holds the reference, so the new prompts apply immediately.
+ *
+ * `transcribeProvider` / `cleanupProvider` / `port` changes still require
+ * restart because the provider *functions* (`deps.transcribe`, `deps.cleanup`)
+ * were closed over at boot. We don't repoint them mid-life — too easy to
+ * misconfigure a provider with no boot-time validation.
+ */
+async function handleConfigPut(req: Request, deps: ServerDeps): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    return Response.json(
+      {
+        error: "invalid_json",
+        message: err instanceof Error ? err.message : "request body was not valid JSON",
+      },
+      { status: 400 },
+    );
+  }
+  const result = validateConfig(body);
+  if (!result.ok) {
+    return Response.json(
+      {
+        error: "validation_failed",
+        message: result.errors.map((e) => `${e.path}: ${e.message}`).join("; "),
+        errors: result.errors,
+      },
+      { status: 400 },
+    );
+  }
+  const incoming = result.value;
+  const file = toFileShape(incoming);
+  const path = deps.configPath ?? resolveDefaultConfigPath();
+  try {
+    writeConfigFileAtomic(path, file);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[scribe] config write failed (${path}): ${message}`);
+    return Response.json(
+      { error: "write_failed", message: `failed to write ${path}: ${message}` },
+      { status: 500 },
+    );
+  }
+  // Mutate the in-process scribe config so the dynamically-read fields
+  // (cleanup default + prompts) take effect without restart. The provider
+  // closures from boot still hold for the restart-required fields.
+  if (file.cleanup) {
+    deps.scribeConfig.cleanup = { ...deps.scribeConfig.cleanup, ...file.cleanup };
+  }
+  const restartRequired = detectRestartRequired(deps.resolvedConfig, incoming);
+  return Response.json({ ok: true, restart_required: restartRequired });
 }
 
 async function handleTranscription(req: Request, deps: ServerDeps): Promise<Response> {


### PR DESCRIPTION
## Summary

PR-A of the scribe config UI work — operators can now read and write `~/.parachute/scribe/config.json` from a browser instead of hand-editing JSON.

**In:**
- `PUT /.parachute/config` — schema-validated, atomic write (`tmp` + `rename`), returns `{ ok: true, restart_required: [...] }`. Scoped on `scribe:admin`.
- Static `/scribe/admin` HTML form (inline CSS + vanilla JS, no build step, no framework). Fetches schema + config on load, renders one field per knob, surfaces restart-required + validation errors inline after save.
- Restart-required helper: provider changes (`transcribeProvider`, `cleanupProvider`) and `port` need a restart (resolved once at boot); `cleanupDefault`, `cleanupSystemPrompt`, `cleanupContextTemplate` apply on the next call because `handleTranscription` re-reads them per-request — the PUT handler mutates the in-process `scribeConfig.cleanup` block on success so the new prompts take effect immediately.

**Not in (out of scope for PR-A):**
- Secrets management (provider API keys / Ollama URL / etc.) — PR-B
- Hub-side "Configure" link surfacing /scribe/admin in the admin SPA — PR-C

**Auth posture:**
- Proxied through hub → hub injects the operator's bearer based on session.
- Loaded direct in closed mode → page surfaces "no auth detected" banner pointing at hub. Scribe doesn't invent its own session system (stays stateless by design).
- Open mode (`SCRIBE_AUTH_TOKEN` unset) → loopback-trusted, just works.

**File-vs-schema mismatch by design:** `port` is in the schema and the form for visibility, but `toFileShape` deliberately does NOT write it — scribe reads its port from `services.json` and env (`port-resolve.ts`), not `config.json`. Listing port in the response's `restart_required` still surfaces "you wanted to change the port" to the operator; writing a dead-letter knob to `config.json` would silently confuse the next restart.

## What changed

```
 CHANGELOG.md                |  17 ++
 package.json                |   2 +-
 src/admin-routes.test.ts    | new
 src/admin-ui.ts             | new
 src/config-write.test.ts    | new
 src/config-write.ts         | new
 src/server.ts               | +107 / -1
```

Three commits:
1. `config-write` helpers: validator, file-shape translator, atomic writer, restart-required diff, 26 tests.
2. Server wiring: `PUT /.parachute/config`, `/scribe/admin`, in-process dynamic-field mutation on save, 22 tests.
3. `0.4.3-rc.1` bump + CHANGELOG.

## Smoke

```
SCRIBE_AUTH_TOKEN=test123 SCRIBE_PORT=11943 PARACHUTE_HOME=/tmp/scribe-pra-smoke bun run src/cli.ts serve
```

- `GET /.parachute/info` → 200, version `0.4.3-rc.1`.
- `GET /.parachute/config` with bearer → 200, current resolved values.
- `PUT /.parachute/config` with bearer + valid body → `{"ok":true,"restart_required":["transcribeProvider","cleanupProvider"]}`; file on disk matches the nested file shape.
- `PUT /.parachute/config` with bearer + `{"transcribeProvider":"not-a-thing"}` → 400 with per-field error array.
- `PUT /.parachute/config` no bearer in closed mode → 401.
- `GET /scribe/admin` with bearer → 200 HTML with the form.

## Versioning

`0.4.2` stable → `0.4.3-rc.1`. Same `0.4.3` patch will carry forward across the rc chain; promotes to stable once Aaron says ready-for-release.

## Test plan

- [x] `bun test src/` — 180/180 passing locally
- [x] `bun run typecheck` — clean
- [x] Manual smoke against a sandboxed `PARACHUTE_HOME` (see above)
- [ ] Reviewer dispatch (team-lead)
- [ ] Browser-side smoke against `/scribe/admin` through hub's reverse proxy (operator)

## UX decisions on the form

- **Placement:** Single full-width card on the page, ~44rem max-width. One label-above-field row per knob; the two textareas are large enough to actually compose prompts in.
- **Validation feedback:** Top-of-page banner ("Validation failed. Fix the highlighted fields and save again.") + per-field red border + inline error message under the offending field. Errors clear on next save attempt.
- **Restart-required banner:** Green success banner ("Configuration saved.") with a bulleted list of restart-required fields underneath (code-formatted name + human label). Empty list → "Changes take effect immediately."
- **Reload button:** Secondary button next to Save, re-fetches schema + config so the operator can discard edits without reloading the page.
- **Auth absence:** Loaded direct with `SCRIBE_AUTH_TOKEN` set, the schema/config fetch 401s → page renders a top warning banner pointing the operator at the hub instead of an empty/broken form.
- **No SPA framework, no build:** Mirrors hub's `oauth-ui.ts` pattern — render-from-TS-function, vanilla DOM + `fetch`. Ships in the tarball as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)