### PR TITLE
chore(release): 0.4.3 stable (rc chain → @latest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.3] - 2026-05-20
+
+Stable release. Cumulative changes since `0.4.2`:
+
+- **Config UI at `/scribe/admin`** (#45): static admin form for the JSON config fields (transcribe.provider, cleanup.provider, cleanup.default, cleanup.system_prompt, cleanup.context_template). New `PUT /.parachute/config` endpoint (scope-gated on `scribe:admin`) with atomic write, schema validation, restart-required signaling. `0o600` file mode for forward-compatibility with the future secrets PR. Null-as-deletion-marker semantics for clearable string fields.
+
+Secrets management (provider API keys, etc.) lands in a future scribe PR (PR-B per the design exploration).
+
 ## [0.4.3-rc.1] - 2026-05-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.3-rc.1",
+  "version": "0.4.3",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Capping the `0.4.3-rc.1` chain into `0.4.3` stable. Drops the `-rc.1` suffix in `package.json`, lifts the stable entry to the top of `CHANGELOG.md` (the rc.1 entry stays intact below it for the release-notes record).

## Major feature in this stable

- **Config UI at `/scribe/admin`** (#45) — static admin form for the JSON config fields (transcribe.provider, cleanup.provider, cleanup.default, cleanup.system_prompt, cleanup.context_template). New `PUT /.parachute/config` endpoint (scope-gated on `scribe:admin`) with atomic write, schema validation, restart-required signaling. `0o600` file mode (forward-compat with future secrets PR). Null-as-deletion-marker semantics for clearable string fields.

Secrets management (provider API keys, etc.) lands in a follow-up scribe PR (PR-B per the design exploration).

## Aaron's next action after merge

```
npm publish --tag latest
```

## Test plan

- [x] `bun test src/` — 204/204 pass
- [x] `bun run typecheck` — clean
- [ ] Aaron `npm publish --tag latest` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)