### PR TITLE
feat(scribe): accept --mount flag for prefix-stripping (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.4-rc.3] - 2026-05-21
+
+### feat(scribe): accept --mount flag for prefix-stripping uniform with notes-serve (#39)
+
+Closes [#39](https://github.com/ParachuteComputer/parachute-scribe/issues/39). Adds a `--mount <prefix>` flag to `parachute-scribe serve`, mirroring the shape `notes-serve.ts` (and `parachute-agent`) already use. Scribe now strips the configured mount from inbound pathnames before the route table fires, so external `/scribe/v1/audio/transcriptions` reaches the same internal handler as bare `/v1/audio/transcriptions`.
+
+**Flag semantics.** Default is empty (`--mount ""` or omitting the flag) — bare routes at the origin root, identical to pre-#39 behavior. `--mount /` is equivalent. `--mount /scribe` means every external URL must be prefixed with `/scribe`; bare requests return 404. `--mount scribe` (no leading slash) and `--mount /scribe/` (trailing slash) are auto-normalized to `/scribe`.
+
+**Hub coordination.** No breaking change today. Hub continues to set `stripPrefix: true` on the SCRIBE_FALLBACK entry, so the existing reverse-proxy path still strips the prefix before forwarding. The follow-up — flip hub's `stripPrefix` to `false` and pass `--mount /scribe` in the start command — is tracked on hub's side and lands when there's bandwidth.
+
+**Admin SPA back-compat.** The `/scribe/admin` URL keeps working at the default mount as a legacy alias; the canonical post-mount route is `/admin`. Same back-compat applies to `/scribe/mcp` → `/mcp`. When scribe is launched with `--mount /scribe`, the admin page bakes the mount prefix into its in-page fetch URLs so the `fetch('/.parachute/config')` calls become `fetch('/scribe/.parachute/config')`.
+
+**New files.** `src/mount.ts` (`normalizeMount` + `stripMount` helpers), `src/mount.test.ts` (30 new tests covering the matrix of mount values and route shapes).
+
 ## [0.4.4-rc.2] - 2026-05-21
 
 ### feat(scribe): POST /transcribe-url + MCP server (#34, #35)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4-rc.2",
+  "version": "0.4.4-rc.3",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -47,9 +47,22 @@ const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", mono
 /**
  * Render the admin page. Pure function — returns the HTML string. The page
  * itself fetches live state on load (one round-trip for the schema, one for
- * the resolved config), so the rendered HTML is the same across requests.
+ * the resolved config), so the rendered HTML is the same across requests
+ * for a given mount.
+ *
+ * `mount` is the path prefix the in-page fetches must use to reach scribe's
+ * `/.parachute/config` and `/.parachute/config/schema` endpoints. When
+ * scribe is launched with `--mount /scribe`, the canonical URL of those
+ * endpoints externally is `/scribe/.parachute/config`; the page can't
+ * assume bare-root URLs. Default `""` (no mount) preserves the existing
+ * shape for direct-loopback callers. Issue #39.
  */
-export function renderAdminPage(): string {
+export function renderAdminPage(mount = ""): string {
+  // Build the mount-aware URLs server-side so the page script is a
+  // pure no-state interpolation. `mount` is already normalized by the
+  // server boot path (see `src/mount.ts`).
+  const configUrl = `${mount}/.parachute/config`;
+  const schemaUrl = `${mount}/.parachute/config/schema`;
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -120,13 +133,20 @@ export function renderAdminPage(): string {
       <footer class="card-footer">
         <p class="footer-hint">
           File on disk: <code>~/.parachute/scribe/config.json</code>.
-          Live values (resolved): <a href="/.parachute/config">/.parachute/config</a>.
-          Schema: <a href="/.parachute/config/schema">/.parachute/config/schema</a>.
+          Live values (resolved): <a href="${configUrl}">${configUrl}</a>.
+          Schema: <a href="${schemaUrl}">${schemaUrl}</a>.
         </p>
       </footer>
     </div>
   </main>
 
+  <script>
+    // Mount-prefix the page-script's fetch URLs see. Server-rendered so
+    // the script body can stay a plain string literal (no per-request
+    // template interpolation inside the script itself). Issue #39.
+    window.__SCRIBE_CONFIG_URL__ = ${JSON.stringify(configUrl)};
+    window.__SCRIBE_SCHEMA_URL__ = ${JSON.stringify(schemaUrl)};
+  </script>
   <script>${PAGE_SCRIPT}</script>
 </body>
 </html>`;
@@ -509,8 +529,8 @@ const PAGE_SCRIPT = String.raw`
 
     try {
       const [schemaRes, configRes] = await Promise.all([
-        fetch("/.parachute/config/schema"),
-        fetch("/.parachute/config"),
+        fetch(window.__SCRIBE_SCHEMA_URL__ || "/.parachute/config/schema"),
+        fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config"),
       ]);
       if (schemaRes.status === 401 || configRes.status === 401) {
         setBanner(
@@ -551,7 +571,7 @@ const PAGE_SCRIPT = String.raw`
     const body = collectForm();
     let res;
     try {
-      res = await fetch("/.parachute/config", {
+      res = await fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,12 @@ Options:
   --config <path>                     Path to scribe.config.json
   --json                              Output JSON instead of plain text
 
+Serve-only options:
+  --mount <prefix>                    Path prefix scribe answers under
+                                      (e.g. --mount /scribe → routes at
+                                      /scribe/health, /scribe/v1/...).
+                                      Default "" = bare routes at root.
+
 Environment:
   TRANSCRIBE_PROVIDER                 Default transcription provider
   CLEANUP_PROVIDER                    Default cleanup provider
@@ -50,12 +56,13 @@ Examples:
   parachute-scribe note.wav --cleanup claude-code    # uses your Claude Code auth
   parachute-scribe https://example.com/podcast.mp3   # transcribe from URL
   parachute-scribe serve
+  parachute-scribe serve --mount /scribe             # behind a reverse proxy
 `);
 }
 
 switch (command) {
   case "serve":
-    await startServer();
+    await startServer({ mount: getFlag("--mount") });
     break;
 
   case "providers":

--- a/src/mount.test.ts
+++ b/src/mount.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeMount, stripMount } from "./mount.ts";
+import { createFetchHandler, type ServerDeps } from "./server.ts";
+import type { ResolvedConfig } from "./config-schema.ts";
+
+describe("normalizeMount", () => {
+  test("empty string normalizes to ''", () => {
+    expect(normalizeMount("")).toBe("");
+  });
+
+  test("'/' normalizes to '' (no prefix)", () => {
+    expect(normalizeMount("/")).toBe("");
+  });
+
+  test("'/scribe' stays '/scribe'", () => {
+    expect(normalizeMount("/scribe")).toBe("/scribe");
+  });
+
+  test("'/scribe/' strips trailing slash → '/scribe'", () => {
+    expect(normalizeMount("/scribe/")).toBe("/scribe");
+  });
+
+  test("'scribe' (no leading slash) auto-prepends → '/scribe'", () => {
+    expect(normalizeMount("scribe")).toBe("/scribe");
+  });
+
+  test("'/scribe/v2' multi-segment stays as-is", () => {
+    expect(normalizeMount("/scribe/v2")).toBe("/scribe/v2");
+  });
+
+  test("'/scribe///' multiple trailing slashes all stripped", () => {
+    expect(normalizeMount("/scribe///")).toBe("/scribe");
+  });
+});
+
+describe("stripMount", () => {
+  test("empty mount returns pathname unchanged", () => {
+    expect(stripMount("/health", "")).toBe("/health");
+    expect(stripMount("/v1/audio/transcriptions", "")).toBe("/v1/audio/transcriptions");
+    expect(stripMount("/", "")).toBe("/");
+  });
+
+  test("mount = pathname exactly returns '/'", () => {
+    expect(stripMount("/scribe", "/scribe")).toBe("/");
+  });
+
+  test("mount + trailing strips correctly", () => {
+    expect(stripMount("/scribe/health", "/scribe")).toBe("/health");
+    expect(stripMount("/scribe/v1/audio/transcriptions", "/scribe")).toBe(
+      "/v1/audio/transcriptions",
+    );
+    expect(stripMount("/scribe/.parachute/info", "/scribe")).toBe("/.parachute/info");
+  });
+
+  test("nested mount works", () => {
+    expect(stripMount("/scribe/v2/health", "/scribe/v2")).toBe("/health");
+  });
+
+  test("non-matching pathname returns null", () => {
+    // `--mount /scribe` deployed scribe should NOT serve `/health` — only
+    // `/scribe/health`. Returning null surfaces that as 404 in the handler.
+    expect(stripMount("/health", "/scribe")).toBeNull();
+    expect(stripMount("/", "/scribe")).toBeNull();
+    expect(stripMount("/scribed/health", "/scribe")).toBeNull();
+    // Partial-prefix match is NOT a match — `/scribe-old/...` doesn't
+    // belong to `--mount /scribe`.
+    expect(stripMount("/scribe-old/health", "/scribe")).toBeNull();
+  });
+});
+
+describe("createFetchHandler — mount-aware routing (issue #39)", () => {
+  const RESOLVED: ResolvedConfig = {
+    transcribeProvider: "parakeet-mlx",
+    transcribeProviders: {},
+    cleanupProvider: "none",
+    cleanupDefault: false,
+    cleanupProviders: {},
+    cleanupSystemPrompt: null,
+    cleanupContextTemplate: null,
+    port: 1943,
+  };
+
+  function buildHandler(mount: string | undefined): (req: Request) => Promise<Response> {
+    const deps: ServerDeps = {
+      transcribe: async () => "stub text",
+      cleanup: async (text) => text,
+      resolvedConfig: RESOLVED,
+      scribeConfig: {},
+      mount,
+    };
+    return createFetchHandler(deps);
+  }
+
+  describe("default mount (no prefix)", () => {
+    test("undefined mount → routes at root, identical to pre-#39", async () => {
+      const handler = buildHandler(undefined);
+      const res = await handler(new Request("http://localhost/health"));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
+
+    test("empty-string mount → routes at root", async () => {
+      const handler = buildHandler("");
+      const res = await handler(new Request("http://localhost/health"));
+      expect(res.status).toBe(200);
+    });
+
+    test("'/' mount → equivalent to empty (no prefix)", async () => {
+      const handler = buildHandler("/");
+      const res = await handler(new Request("http://localhost/health"));
+      expect(res.status).toBe(200);
+    });
+
+    test("`/scribe/admin` legacy SPA URL still serves the admin page", async () => {
+      const handler = buildHandler("");
+      const res = await handler(new Request("http://localhost/scribe/admin"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/html");
+    });
+
+    test("`/admin` canonical SPA URL also serves the admin page", async () => {
+      const handler = buildHandler("");
+      const res = await handler(new Request("http://localhost/admin"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/html");
+    });
+
+    test("admin page bakes empty-string mount into fetch URLs", async () => {
+      const handler = buildHandler("");
+      const res = await handler(new Request("http://localhost/admin"));
+      const html = await res.text();
+      // No prefix when mount is empty — fetches go to root.
+      expect(html).toContain('"/.parachute/config"');
+      expect(html).toContain('"/.parachute/config/schema"');
+    });
+  });
+
+  describe("`--mount /scribe`", () => {
+    test("`/scribe/health` reaches /health route", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/scribe/health"));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
+
+    test("`/scribe/.parachute/info` reaches info handler", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/scribe/.parachute/info"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string };
+      expect(body.name).toBe("parachute-scribe");
+    });
+
+    test("`/scribe/.parachute/config` reaches config-get", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/scribe/.parachute/config"));
+      expect(res.status).toBe(200);
+    });
+
+    test("`/scribe/v1/audio/transcriptions` reaches transcribe handler", async () => {
+      const handler = buildHandler("/scribe");
+      const form = new FormData();
+      form.set("file", new File(["fake audio"], "test.wav"));
+      const res = await handler(
+        new Request("http://localhost/scribe/v1/audio/transcriptions", {
+          method: "POST",
+          body: form,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ text: "stub text" });
+    });
+
+    test("`/scribe/admin` reaches admin SPA", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/scribe/admin"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/html");
+    });
+
+    test("admin page bakes mount prefix into fetch URLs", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/scribe/admin"));
+      const html = await res.text();
+      // Mount-prefixed URLs so in-page fetches resolve back through the
+      // proxy that handed us /scribe/admin.
+      expect(html).toContain('"/scribe/.parachute/config"');
+      expect(html).toContain('"/scribe/.parachute/config/schema"');
+    });
+
+    test("bare `/health` (no mount prefix) returns 404", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(new Request("http://localhost/health"));
+      expect(res.status).toBe(404);
+    });
+
+    test("bare `/v1/audio/transcriptions` (no mount prefix) returns 404", async () => {
+      const handler = buildHandler("/scribe");
+      const form = new FormData();
+      form.set("file", new File(["fake audio"], "test.wav"));
+      const res = await handler(
+        new Request("http://localhost/v1/audio/transcriptions", {
+          method: "POST",
+          body: form,
+        }),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    test("OPTIONS preflight still passes through without mount-strip (CORS)", async () => {
+      const handler = buildHandler("/scribe");
+      const res = await handler(
+        new Request("http://localhost/scribe/v1/audio/transcriptions", { method: "OPTIONS" }),
+      );
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+  });
+
+  describe("normalization edge cases", () => {
+    test("`--mount scribe` (no leading slash) is auto-normalized", async () => {
+      const handler = buildHandler("scribe");
+      const res = await handler(new Request("http://localhost/scribe/health"));
+      expect(res.status).toBe(200);
+    });
+
+    test("`--mount /scribe/` (trailing slash) is auto-normalized", async () => {
+      const handler = buildHandler("/scribe/");
+      const res = await handler(new Request("http://localhost/scribe/health"));
+      expect(res.status).toBe(200);
+    });
+
+    test("multi-segment mount `/scribe/v2` works end-to-end", async () => {
+      const handler = buildHandler("/scribe/v2");
+      const res = await handler(new Request("http://localhost/scribe/v2/health"));
+      expect(res.status).toBe(200);
+      const miss = await handler(new Request("http://localhost/scribe/health"));
+      expect(miss.status).toBe(404);
+    });
+  });
+});

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,0 +1,58 @@
+/**
+ * Mount-prefix normalization + stripping.
+ *
+ * Mirrors the convention notes-serve / parachute-agent already use: the
+ * service accepts a `--mount <prefix>` flag, normalizes it once at boot,
+ * and strips it from every inbound request's pathname before the route
+ * table fires. This way the route table is canonically defined at root
+ * (e.g. `/health`, `/v1/audio/transcriptions`) regardless of where the
+ * reverse proxy mounts the service externally.
+ *
+ * Default `""` (empty) preserves the legacy "bare routes at the origin
+ * root" shape — scribe v0.4.4-rc.2 and earlier never accepted a mount
+ * flag, so this is the back-compat path. Passing `--mount /` is
+ * equivalent.
+ *
+ * Issue #39 — accept --mount flag for prefix-stripping (uniform with
+ * notes-serve / agent).
+ */
+
+/**
+ * Canonicalize a `--mount <raw>` argument. Empty string and `"/"` both
+ * collapse to `""` (no prefix). Otherwise:
+ *
+ *   - Trailing slashes are stripped (so `/scribe/` → `/scribe`).
+ *   - A missing leading slash is auto-prepended (so `scribe` → `/scribe`).
+ *
+ * The trailing-slash and missing-leading-slash fixups mirror notes-serve's
+ * `normalizeMount` semantics; consistent normalization across the
+ * ecosystem means operators don't need to memorize per-module shape rules.
+ */
+export function normalizeMount(raw: string): string {
+  if (raw === "" || raw === "/") return "";
+  const withLeading = raw.startsWith("/") ? raw : `/${raw}`;
+  return withLeading.replace(/\/+$/, "");
+}
+
+/**
+ * Strip `mount` from the front of `pathname`.
+ *
+ *   - When `mount` is `""` (no prefix configured), returns `pathname`
+ *     unchanged. This is the default — every existing scribe deployment
+ *     hits this branch.
+ *   - When `mount` is non-empty and `pathname` matches it exactly OR is
+ *     followed by `/`, returns the un-prefixed remainder (always at least
+ *     `"/"`).
+ *   - When `mount` is non-empty and `pathname` does NOT have the mount as
+ *     a prefix, returns `null` — the caller should respond 404. This
+ *     prevents `--mount /scribe`-deployed scribe from serving requests
+ *     for `/health` that bypass the configured mount.
+ */
+export function stripMount(pathname: string, mount: string): string | null {
+  if (mount === "") return pathname;
+  if (pathname === mount) return "/";
+  if (pathname.startsWith(`${mount}/`)) {
+    return pathname.slice(mount.length) || "/";
+  }
+  return null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   type ContextPayload,
 } from "./context.ts";
 import { preflight, withCors } from "./cors.ts";
+import { normalizeMount, stripMount } from "./mount.ts";
 import {
   UrlFetchError,
   fetchAudioFromUrl,
@@ -69,25 +70,52 @@ export type ServerDeps = {
    * this instead of reading `~/.claude.json`. Production never passes it.
    */
   setupTokenStatusFn?: () => ReturnType<typeof readSetupTokenStatus>;
+  /**
+   * Mount prefix this scribe instance answers under. Default `""` means
+   * "bare routes at the origin root" — legacy behavior, unchanged for
+   * every deployment that didn't pass `--mount`. Set to e.g. `"/scribe"`
+   * and external requests to `/scribe/v1/audio/transcriptions` are
+   * stripped to `/v1/audio/transcriptions` before the route table fires.
+   * Requests that fall outside the mount return 404. Issue #39.
+   */
+  mount?: string;
 };
 
 export function createFetchHandler(deps: ServerDeps) {
+  const mount = normalizeMount(deps.mount ?? "");
+  // Re-bind the deps with the normalized mount so route handlers (e.g. the
+  // admin SPA renderer) read the canonical value, not a raw `--mount foo`
+  // that hasn't been through `normalizeMount` yet.
+  const boundDeps: ServerDeps = { ...deps, mount };
   return async (req: Request): Promise<Response> => {
     if (req.method === "OPTIONS") return preflight();
     const url = new URL(req.url);
-    const auth = await enforceAuth(req, url.pathname);
+    const internalPath = stripMount(url.pathname, mount);
+    if (internalPath === null) {
+      // The mount is configured but the request fell outside it. Don't
+      // leak which routes exist — a flat 404 is the right signal that
+      // this scribe instance doesn't serve the bare path.
+      return withCors(new Response("Not found", { status: 404 }));
+    }
+    const auth = await enforceAuth(req, internalPath);
     if (auth instanceof Response) return withCors(auth);
-    return withCors(await route(req, url, auth.scopes, deps));
+    return withCors(await route(req, url, internalPath, auth.scopes, boundDeps));
   };
 }
 
 /**
- * Per-route required scope.
+ * Per-route required scope. Paths here are **post-mount-strip** — see
+ * `createFetchHandler`. The route table is canonically defined at root
+ * regardless of where the reverse proxy mounts scribe externally.
  *
  *   - `/v1/audio/transcriptions` → `scribe:transcribe`
  *   - `/.parachute/config*`      → `scribe:admin`
  *   - `/admin/*`                 → `scribe:admin` (refresh / clear endpoints)
- *   - `/scribe/admin`            → `scribe:admin` (the SPA page itself)
+ *   - `/scribe/admin`            → `scribe:admin` (SPA page — legacy alias
+ *                                  for back-compat with direct-loopback
+ *                                  callers using the `/scribe/admin` URL
+ *                                  pre-#39; the canonical post-mount
+ *                                  match is just `/admin`)
  *   - `/v1/models`               → `scribe:transcribe`
  */
 function requiredScopeFor(pathname: string, method: string): string | null {
@@ -95,9 +123,14 @@ function requiredScopeFor(pathname: string, method: string): string | null {
   if (pathname === "/v1/audio/transcriptions-url" && method === "POST") return SCOPE_TRANSCRIBE;
   if (pathname.startsWith("/.parachute/config")) return SCOPE_ADMIN;
   if (pathname.startsWith("/admin/")) return SCOPE_ADMIN;
-  if (pathname === "/scribe/admin") return SCOPE_ADMIN;
+  if (pathname === "/admin" || pathname === "/scribe/admin") return SCOPE_ADMIN;
   if (pathname === "/v1/models") return SCOPE_TRANSCRIBE;
-  if (pathname === "/scribe/mcp" || pathname.startsWith("/scribe/mcp/")) {
+  if (
+    pathname === "/mcp" ||
+    pathname.startsWith("/mcp/") ||
+    pathname === "/scribe/mcp" ||
+    pathname.startsWith("/scribe/mcp/")
+  ) {
     // MCP transport — the SDK negotiates capabilities on the first call;
     // per-tool scope enforcement happens inside the handler so a caller
     // with only `scribe:transcribe` can list/call tools without needing
@@ -110,39 +143,44 @@ function requiredScopeFor(pathname: string, method: string): string | null {
 async function route(
   req: Request,
   url: URL,
+  internalPath: string,
   scopes: readonly string[],
   deps: ServerDeps,
 ): Promise<Response> {
-  const required = requiredScopeFor(url.pathname, req.method);
+  const required = requiredScopeFor(internalPath, req.method);
   if (required && !hasScope(scopes, required)) {
     return insufficientScopeResponse(required, scopes);
   }
 
-  if (url.pathname.startsWith("/.parachute/")) {
-    if (url.pathname === "/.parachute/config" && req.method === "PUT") {
+  if (internalPath.startsWith("/.parachute/")) {
+    if (internalPath === "/.parachute/config" && req.method === "PUT") {
       return handleConfigPut(req, deps);
     }
     if (req.method !== "GET") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
-    if (url.pathname === "/.parachute/info") return handleParachuteInfo();
-    if (url.pathname === "/.parachute/icon.svg") return handleParachuteIcon();
-    if (url.pathname === "/.parachute/config/schema") return handleConfigSchema();
-    if (url.pathname === "/.parachute/config") return handleConfigGet(deps);
+    if (internalPath === "/.parachute/info") return handleParachuteInfo();
+    if (internalPath === "/.parachute/icon.svg") return handleParachuteIcon();
+    if (internalPath === "/.parachute/config/schema") return handleConfigSchema();
+    if (internalPath === "/.parachute/config") return handleConfigGet(deps);
     return new Response("Not found", { status: 404 });
   }
 
   // Admin actions live under /admin/* — refresh-claude-token-status is the
   // only one shipped in 0.4.4-rc.1; clear-credential follows in Phase 2.
-  if (url.pathname === "/admin/refresh-claude-token-status" && req.method === "POST") {
+  if (internalPath === "/admin/refresh-claude-token-status" && req.method === "POST") {
     return handleRefreshSetupTokenStatus(deps);
   }
-  if (url.pathname.startsWith("/admin/") && req.method !== "GET") {
+  if (internalPath.startsWith("/admin/") && req.method !== "GET") {
     return Response.json({ error: "Not found" }, { status: 404 });
   }
 
-  if (url.pathname === "/scribe/admin" && req.method === "GET") {
-    return new Response(renderAdminPage(), {
+  // SPA page: canonical at `/admin` (post-mount), with `/scribe/admin` kept
+  // as a legacy alias for direct-loopback callers using the pre-#39 URL
+  // unchanged. Both serve the same HTML; the mount value baked into the
+  // page determines what URLs the in-page fetches use.
+  if ((internalPath === "/admin" || internalPath === "/scribe/admin") && req.method === "GET") {
+    return new Response(renderAdminPage(deps.mount ?? ""), {
       status: 200,
       headers: {
         "Content-Type": "text/html; charset=utf-8",
@@ -151,23 +189,28 @@ async function route(
     });
   }
 
-  if (url.pathname === "/v1/audio/transcriptions" && req.method === "POST") {
+  if (internalPath === "/v1/audio/transcriptions" && req.method === "POST") {
     return handleTranscription(req, deps);
   }
 
-  if (url.pathname === "/v1/audio/transcriptions-url" && req.method === "POST") {
+  if (internalPath === "/v1/audio/transcriptions-url" && req.method === "POST") {
     return handleTranscriptionUrl(req, deps);
   }
 
-  if (url.pathname === "/scribe/mcp" || url.pathname.startsWith("/scribe/mcp/")) {
+  if (
+    internalPath === "/mcp" ||
+    internalPath.startsWith("/mcp/") ||
+    internalPath === "/scribe/mcp" ||
+    internalPath.startsWith("/scribe/mcp/")
+  ) {
     return handleScribeMcp(req, scopes, deps);
   }
 
-  if (url.pathname === "/health") {
+  if (internalPath === "/health") {
     return Response.json({ ok: true });
   }
 
-  if (url.pathname === "/v1/models") {
+  if (internalPath === "/v1/models") {
     return Response.json({
       data: [{ id: deps.resolvedConfig.transcribeProvider, object: "model" }],
     });
@@ -471,8 +514,18 @@ function missingProviderResponse(): Response {
   );
 }
 
-export async function startServer() {
+export type StartServerOptions = {
+  /**
+   * Mount-prefix this scribe instance answers under. Forwarded from
+   * `parachute-scribe serve --mount <prefix>`. Default `""` keeps
+   * routes bare at the origin root (legacy behavior). Issue #39.
+   */
+  mount?: string;
+};
+
+export async function startServer(opts: StartServerOptions = {}) {
   const config = await loadConfig();
+  const mount = normalizeMount(opts.mount ?? "");
 
   // Transcribe provider: config > env > built-in `parakeet-mlx` default.
   // When even the default isn't viable on the host (e.g. Render container
@@ -511,6 +564,7 @@ export async function startServer() {
   console.log(`  transcribe: ${transcribeProviderName}`);
   console.log(`  cleanup:    ${CLEANUP}${CLEANUP !== "none" ? ` (default: ${CLEANUP_DEFAULT})` : ""}`);
   console.log(`  auth:       ${isAuthRequired() ? "bearer (SCRIBE_AUTH_TOKEN or hub JWT)" : "open"}`);
+  console.log(`  mount:      ${mount === "" ? "(none — bare routes at origin root)" : mount}`);
   warnIfTokenLooksJwt();
 
   const handler = createFetchHandler({
@@ -518,6 +572,7 @@ export async function startServer() {
     cleanup,
     resolvedConfig,
     scribeConfig: config,
+    mount,
   });
 
   try {


### PR DESCRIPTION
## Summary

Closes [#39](https://github.com/ParachuteComputer/parachute-scribe/issues/39). Adds `--mount <prefix>` to `parachute-scribe serve`, mirroring the shape `notes-serve.ts` / `parachute-agent` already use. Scribe now strips the configured mount from inbound pathnames before its route table fires, so a reverse proxy can hand off `/scribe/v1/audio/transcriptions` and scribe answers it on the same internal handler as bare `/v1/audio/transcriptions`.

## Flag semantics

- Default empty (`--mount ""`, omitted, or `--mount /`) — bare routes at origin root. **Unchanged from rc.2.**
- `--mount /scribe` — every external URL must be prefixed with `/scribe`; bare requests return 404.
- `--mount scribe` (no leading slash) and `--mount /scribe/` (trailing slash) are auto-normalized to `/scribe`.
- `--mount /scribe/v2` — multi-segment prefixes work too.

## Hub coordination — no breaking change today

Hub continues `stripPrefix: true` on the SCRIBE_FALLBACK entry. Both paths (hub-side strip OR scribe-side `--mount` strip) work simultaneously. The follow-up — flip hub to `stripPrefix: false` and pass `--mount /scribe` in scribe's start command — is the hub-side coordinated change tracked on hub's roadmap. **Did not fold that hub change here**, per the brief's recommendation.

## Files

- `src/mount.ts` — `normalizeMount` + `stripMount` helpers (semantics mirror `parachute-hub/src/notes-serve.ts` `normalizeMount`).
- `src/server.ts` — `ServerDeps.mount`, normalized in `createFetchHandler`, stripped from `url.pathname` once before route matching. Out-of-mount → 404. `StartServerOptions.mount` forwarded from CLI.
- `src/cli.ts` — `parachute-scribe serve --mount <prefix>`.
- `src/admin-ui.ts` — `renderAdminPage(mount)` bakes the prefix into in-page fetch URLs via `window.__SCRIBE_{CONFIG,SCHEMA}_URL__`. Without this, the admin SPA under `--mount /scribe` would `fetch('/.parachute/config')` and hit nothing.
- Existing `/scribe/admin` and `/scribe/mcp` direct-loopback URLs are kept as back-compat aliases at the default mount; the canonical post-mount routes are `/admin` and `/mcp`.
- `src/mount.test.ts` — 30 new tests.
- `CHANGELOG.md`, `package.json` — `0.4.4-rc.2` → `0.4.4-rc.3`.

## Representative diff (route registration)

```ts
// Before — server.ts:
if (url.pathname === "/health") return Response.json({ ok: true });
if (url.pathname === "/scribe/admin" && req.method === "GET") { ... }

// After — server.ts:
const internalPath = stripMount(url.pathname, mount);
if (internalPath === null) return 404;       // out-of-mount
if (internalPath === "/health") return Response.json({ ok: true });
if ((internalPath === "/admin" || internalPath === "/scribe/admin") &&
    req.method === "GET") { ... }            // /scribe/admin = legacy alias
```

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test ./src` — **344 pass / 0 fail** (was 314 at rc.2; +30 mount tests)
- [x] `parachute-scribe help` — `--mount` documented under "Serve-only options"
- [ ] Manual smoke: `parachute-scribe serve --mount /scribe`, hit `/scribe/health` (200), `/health` (404), `/scribe/admin` (HTML)
- [ ] Manual smoke: `parachute-scribe serve` (no mount), hit `/health` (200), `/scribe/admin` (HTML, legacy alias still works)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)