### PR TITLE
feat(scribe): self-register manifest + installDir at startup (#38)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,6 +7,7 @@
   "port": 1943,
   "paths": ["/scribe"],
   "health": "/health",
+  "stripPrefix": true,
   "startCmd": ["parachute-scribe", "serve"],
   "scopes": {
     "defines": ["scribe:transcribe", "scribe:admin"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.4-rc.4] - 2026-05-21
+
+### feat(scribe): self-register manifest + installDir at startup (#38)
+
+Closes [#38](https://github.com/ParachuteComputer/parachute-scribe/issues/38). On `parachute-scribe serve` boot, scribe now reads its own `.parachute/module.json` and atomically upserts its row in `~/.parachute/services.json` — stamping `installDir`, paths/health/displayName/tagline/stripPrefix from the manifest, version from `package.json`. Mirrors the pattern already shipped in [vault#266](https://github.com/ParachuteComputer/parachute-vault/pull/266) and [runner#3](https://github.com/ParachuteComputer/parachute-runner/pull/3).
+
+**Why this exists.** Hub-as-supervisor (v0.6) reads `~/.parachute/services.json` to know which modules exist on the host. Before this PR, scribe relied on the `bun link` install path (or hub's vendored `SCRIBE_FALLBACK` manifest) to stamp `installDir`. A `bun link`-mode dev tree that never went through `parachute install scribe` was missing the field, leaving `parachute restart scribe` unable to resolve back to the checkout. Self-registration closes that gap — scribe's manifest is now the single source of truth.
+
+**Operator-override discipline preserved.** Per [scribe#40](https://github.com/ParachuteComputer/parachute-scribe/issues/40) / [paraclaw#145](https://github.com/ParachuteComputer/parachute-agent/issues/145): if services.json already has a row for `parachute-scribe`, the existing `port` survives the write — operator (or hub) overrides are not silently restamped. First-boot writes the bound port; subsequent boots preserve.
+
+**Hub-stamped fields ride through.** `upsertService` merges rather than replaces, so any field hub stamps onto the row (`installDir` from [parachute-hub#84](https://github.com/ParachuteComputer/parachute-hub/issues/84), future `uiUrl` / `managementUrl`) survives every self-registration pass. We do re-stamp our own `installDir` so it follows the live checkout after a `git pull` moves the package root.
+
+**Graceful failure.** All four read/write boundaries (missing module.json, malformed module.json, malformed services.json, unwritable target) return `{ok: false}` with a `[scribe]` warn log rather than throwing. The daemon serves locally even when the discoverability bookkeeping fails — the symptom is "scribe doesn't appear in `parachute status` until the underlying issue clears."
+
+**`SCRIBE_FALLBACK` retirement deferred.** Hub's `FIRST_PARTY_FALLBACKS[scribe]` stays in place this release; it retires in a future hub PR after all four committed-core modules (vault/notes/scribe/runner) are confirmed self-registering reliably across the install matrix. Additive change — no hub coordination required for this PR to ship.
+
+**New files.** `src/self-register.ts` (helper + `resolveProjectRoot`), `src/self-register.test.ts` (14 new tests covering first-boot, subsequent-boot port preservation, hub-stamped field merge, idempotency, sibling preservation, and the four graceful-failure modes). `src/services-manifest.ts` refactored to mirror runner's env-injection shape on `resolveManifestPath(env?)`. `.parachute/module.json` gained explicit `stripPrefix: true` (was implicit via hub's `SCRIBE_FALLBACK`).
+
+**Test gate.** `bun test src/` — 360 pass (was 344 on rc.3), 749 expect() calls. `bun run typecheck` clean.
+
 ## [0.4.4-rc.3] - 2026-05-21
 
 ### feat(scribe): accept --mount flag for prefix-stripping uniform with notes-serve (#39)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4-rc.3",
+  "version": "0.4.4-rc.4",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/self-register.test.ts
+++ b/src/self-register.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for `src/self-register.ts` — services.json self-registration on
+ * `parachute-scribe serve` boot. Mirrors `parachute-runner/src/__tests__/
+ * self-register.test.ts` (same scenarios, same shape).
+ *
+ * Coverage:
+ *   - First boot: stamps the resolved port + installDir + version +
+ *     paths/health/displayName/tagline/stripPrefix from .parachute/module.json
+ *   - Subsequent boot: preserves the existing port (operator-override
+ *     discipline — paraclaw#145 / scribe#40 shape)
+ *   - Hub-stamped fields on a prior row survive the merge (installDir from
+ *     parachute-hub#84)
+ *   - Idempotent: re-running with the same opts doesn't drift the file
+ *   - Sibling entries (vault, runner, etc.) survive
+ *   - Best-effort: missing .parachute/module.json yields {ok:false} + warn
+ *   - Best-effort: malformed module.json yields {ok:false} + warn
+ *   - Best-effort: malformed services.json yields {ok:false} + warn
+ *   - Best-effort: unwritable target yields {ok:false} + warn
+ *   - resolveProjectRoot points at the package root (contains module.json)
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveProjectRoot, selfRegister } from "./self-register.ts";
+
+interface CapturedLogger {
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  warnings: string[];
+  logs: string[];
+  errors: string[];
+}
+
+function makeLogger(): CapturedLogger {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  return {
+    log: (msg: string) => logs.push(msg),
+    warn: (msg: string) => warnings.push(msg),
+    error: (msg: string) => errors.push(msg),
+    logs,
+    warnings,
+    errors,
+  };
+}
+
+/**
+ * Build a tmp fake installDir tree with `.parachute/module.json` so
+ * `selfRegister` reads its manifest from a fixture rather than the
+ * live repo. Mirrors scribe's real `.parachute/module.json` shape.
+ */
+function makeFakeInstall(root: string, overrides: Record<string, unknown> = {}): string {
+  fs.mkdirSync(path.join(root, ".parachute"), { recursive: true });
+  const manifest = {
+    name: "scribe",
+    manifestName: "parachute-scribe",
+    displayName: "Scribe",
+    tagline: "Audio transcription (Whisper-compatible API + LLM cleanup)",
+    kind: "api",
+    port: 1943,
+    paths: ["/scribe"],
+    health: "/health",
+    stripPrefix: true,
+    startCmd: ["parachute-scribe", "serve"],
+    ...overrides,
+  };
+  fs.writeFileSync(
+    path.join(root, ".parachute", "module.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  return root;
+}
+
+let tmpDir: string;
+let installDir: string;
+let manifestPath: string;
+let logger: CapturedLogger;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scribe-self-register-"));
+  installDir = path.join(tmpDir, "install");
+  makeFakeInstall(installDir);
+  manifestPath = path.join(tmpDir, "services.json");
+  logger = makeLogger();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("selfRegister — first boot", () => {
+  test("writes a fresh services.json with our entry", () => {
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.hadExistingEntry).toBe(false);
+    expect(result.portWritten).toBe(1943);
+
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<Record<string, unknown>>;
+    };
+    expect(raw.services).toHaveLength(1);
+    const entry = raw.services[0]!;
+    expect(entry.name).toBe("parachute-scribe");
+    expect(entry.port).toBe(1943);
+    expect(entry.paths).toEqual(["/scribe"]);
+    expect(entry.health).toBe("/health");
+    expect(entry.installDir).toBe(installDir);
+    expect(entry.displayName).toBe("Scribe");
+    expect(entry.tagline).toBe(
+      "Audio transcription (Whisper-compatible API + LLM cleanup)",
+    );
+    expect(entry.stripPrefix).toBe(true);
+    expect(typeof entry.version).toBe("string");
+  });
+
+  test("logs a single info-level line on success", () => {
+    selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    expect(logger.logs).toHaveLength(1);
+    expect(logger.logs[0]).toContain("self-registered");
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  test("manifest fields without optional fields still register correctly", () => {
+    // Stripped-down module.json missing the optional fields — verifies the
+    // helper degrades gracefully and doesn't stamp `undefined` keys.
+    const minimal = path.join(tmpDir, "minimal-install");
+    fs.mkdirSync(path.join(minimal, ".parachute"), { recursive: true });
+    fs.writeFileSync(
+      path.join(minimal, ".parachute", "module.json"),
+      JSON.stringify({
+        name: "scribe",
+        manifestName: "parachute-scribe",
+      }),
+    );
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir: minimal,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(true);
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<Record<string, unknown>>;
+    };
+    // Defaults from selfRegister apply when module.json omits them.
+    expect(raw.services[0]?.paths).toEqual(["/scribe"]);
+    expect(raw.services[0]?.health).toBe("/health");
+    // Optional fields stay absent rather than stamped as undefined.
+    expect("displayName" in (raw.services[0] ?? {})).toBe(false);
+    expect("tagline" in (raw.services[0] ?? {})).toBe(false);
+    expect("stripPrefix" in (raw.services[0] ?? {})).toBe(false);
+  });
+});
+
+describe("selfRegister — subsequent boot (existing entry)", () => {
+  test("preserves an operator-set port from services.json", () => {
+    // Seed with a port the operator chose by hand.
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-scribe",
+            port: 1947, // operator override, not the default
+            paths: ["/scribe"],
+            health: "/health",
+            version: "0.4.3",
+            installDir: "/old/checkout",
+          },
+        ],
+      }),
+    );
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.hadExistingEntry).toBe(true);
+    // The result.portWritten should be the operator-override port, NOT
+    // boundPort — that's the load-bearing invariant for restart-stability.
+    expect(result.portWritten).toBe(1947);
+
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<Record<string, unknown>>;
+    };
+    expect(raw.services[0]?.port).toBe(1947);
+    expect(raw.services[0]?.installDir).toBe(installDir); // we re-stamp this
+  });
+
+  test("hub-stamped fields on prior row survive the merge", () => {
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-scribe",
+            port: 1943,
+            paths: ["/scribe"],
+            health: "/health",
+            version: "0.4.3",
+            // Hub-stamped fields (parachute-hub#84 stamps installDir; a
+            // future hub may stamp uiUrl / managementUrl). The merge
+            // invariant: we re-stamp `installDir` ourselves, but any
+            // field scribe doesn't author rides through.
+            hubStampedField: "preserve-me",
+            uiUrl: "/scribe/admin",
+          },
+        ],
+      }),
+    );
+    selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<Record<string, unknown>>;
+    };
+    expect(raw.services[0]?.hubStampedField).toBe("preserve-me");
+    expect(raw.services[0]?.uiUrl).toBe("/scribe/admin");
+    expect(raw.services[0]?.installDir).toBe(installDir);
+  });
+
+  test("idempotent — calling twice doesn't drift the file", () => {
+    const opts = {
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    };
+    selfRegister(opts);
+    const first = fs.readFileSync(manifestPath, "utf8");
+    selfRegister(opts);
+    const second = fs.readFileSync(manifestPath, "utf8");
+    expect(second).toBe(first);
+  });
+
+  test("preserves sibling entries", () => {
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        services: [
+          { name: "parachute-vault", port: 1940, paths: ["/vault"], health: "/h", version: "1" },
+          { name: "runner", port: 1945, paths: ["/runner"], health: "/h", version: "1" },
+        ],
+      }),
+    );
+    selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<{ name: string }>;
+    };
+    expect(raw.services.map((s) => s.name).sort()).toEqual([
+      "parachute-scribe",
+      "parachute-vault",
+      "runner",
+    ]);
+  });
+});
+
+describe("selfRegister — best-effort failure modes", () => {
+  test("missing .parachute/module.json yields {ok:false} + warn log, doesn't throw", () => {
+    const empty = path.join(tmpDir, "no-manifest");
+    fs.mkdirSync(empty, { recursive: true });
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir: empty,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(logger.warnings.length).toBeGreaterThan(0);
+    expect(logger.warnings[0]).toContain("module.json not found");
+    // services.json must remain untouched on the manifest-missing path.
+    expect(fs.existsSync(manifestPath)).toBe(false);
+  });
+
+  test("malformed module.json yields {ok:false} + warn log, doesn't throw", () => {
+    const bad = path.join(tmpDir, "bad-manifest");
+    fs.mkdirSync(path.join(bad, ".parachute"), { recursive: true });
+    fs.writeFileSync(path.join(bad, ".parachute", "module.json"), "{not json");
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir: bad,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(logger.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("module.json missing manifestName yields {ok:false} + warn log", () => {
+    const bad = path.join(tmpDir, "no-manifestName");
+    fs.mkdirSync(path.join(bad, ".parachute"), { recursive: true });
+    fs.writeFileSync(
+      path.join(bad, ".parachute", "module.json"),
+      JSON.stringify({ name: "scribe" }), // manifestName missing
+    );
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir: bad,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("manifestName");
+  });
+
+  test("malformed services.json yields {ok:false} + warn log, doesn't throw", () => {
+    fs.writeFileSync(manifestPath, "{not json");
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      logger,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(logger.warnings.length).toBeGreaterThan(0);
+    expect(logger.warnings[0]).toContain("skipped self-register");
+  });
+
+  test("unwritable manifest path yields {ok:false} + warn log, doesn't throw", () => {
+    // Point at a path under a file (not a dir) — mkdir will fail.
+    const blocker = path.join(tmpDir, "im-a-file-not-a-dir");
+    fs.writeFileSync(blocker, "");
+    const unwritable = path.join(blocker, "services.json");
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath: unwritable,
+      logger,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(logger.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("selfRegister — moduleManifestPath override", () => {
+  test("tests can point at an arbitrary manifest path", () => {
+    // Verifies the test seam — wire installDir at one location, manifest
+    // at another, useful for fixtures that don't want to fake an install
+    // tree.
+    const customManifest = path.join(tmpDir, "custom-module.json");
+    fs.writeFileSync(
+      customManifest,
+      JSON.stringify({
+        name: "scribe",
+        manifestName: "parachute-scribe-custom",
+        paths: ["/custom"],
+        health: "/custom-health",
+      }),
+    );
+    const result = selfRegister({
+      boundPort: 1943,
+      installDir,
+      manifestPath,
+      moduleManifestPath: customManifest,
+      logger,
+    });
+    expect(result.ok).toBe(true);
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      services: Array<Record<string, unknown>>;
+    };
+    expect(raw.services[0]?.name).toBe("parachute-scribe-custom");
+    expect(raw.services[0]?.paths).toEqual(["/custom"]);
+    expect(raw.services[0]?.health).toBe("/custom-health");
+  });
+});
+
+describe("resolveProjectRoot", () => {
+  test("points at a directory containing .parachute/module.json", () => {
+    const root = resolveProjectRoot();
+    const manifestFile = path.join(root, ".parachute", "module.json");
+    expect(fs.existsSync(manifestFile)).toBe(true);
+    const m = JSON.parse(fs.readFileSync(manifestFile, "utf8")) as {
+      name: string;
+      manifestName: string;
+    };
+    expect(m.name).toBe("scribe");
+    expect(m.manifestName).toBe("parachute-scribe");
+  });
+});

--- a/src/self-register.ts
+++ b/src/self-register.ts
@@ -1,0 +1,221 @@
+/**
+ * `selfRegister()` — stamp scribe's entry into `~/.parachute/services.json`
+ * on `parachute-scribe serve` boot.
+ *
+ * Why this exists, in one sentence: hub-as-supervisor (v0.6) reads
+ * `~/.parachute/services.json` to know which modules exist on the host; a
+ * module that doesn't self-register is invisible to `parachute status`,
+ * `parachute restart`, the admin SPA module catalog, and the live
+ * `/.well-known/parachute.json` builder.
+ *
+ * Mirrors `parachute-runner/src/self-register.ts` (canonical going
+ * forward) and `parachute-vault/src/self-register.ts` (the original POC
+ * for retiring hub's `FIRST_PARTY_FALLBACKS`).
+ *
+ * Two reads from the file before we write:
+ *   1. The existing row's `port` is preserved on subsequent boots so an
+ *      operator (or hub) who set `scribe.port = 1947` in services.json
+ *      stays at 1947 across restarts — even if the env var that pointed
+ *      scribe at 1947 is later unset. Same first-boot-vs-subsequent-boot
+ *      rule scribe + agent settled (scribe#40, paraclaw#145). When this
+ *      is a first run, stamp the resolved port (cli arg, env, or
+ *      default 1943).
+ *   2. The existing row's hub-stamped fields (`installDir` from
+ *      parachute-hub#84, future `uiUrl` / `managementUrl`) merge through
+ *      because `upsertService` spreads `entry` last. We re-stamp our own
+ *      `installDir = resolveProjectRoot()` regardless — hub#293/#302 made
+ *      the runtime install path stamp installDir, and we want services.json
+ *      to keep that resolution after a `git pull` moves the checkout.
+ *
+ * Manifest is the source of truth: paths, health, displayName, tagline,
+ * stripPrefix are read from `.parachute/module.json` rather than hardcoded
+ * in the call site. This is the load-bearing piece of scribe#38 — once all
+ * four committed-core modules self-register from their own manifest, hub's
+ * `FIRST_PARTY_FALLBACKS[scribe]` retires.
+ *
+ * Failure mode: any error during the read or write is logged + returned
+ * as `{ok: false}`. The daemon still serves locally if module.json is
+ * missing, services.json is unwritable, malformed, or fights with a
+ * concurrent writer — the operator just won't see scribe in
+ * `parachute status` until the underlying issue clears.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+
+import pkg from "../package.json" with { type: "json" };
+import { type ServiceEntry, readServiceEntry, upsertService } from "./services-manifest.ts";
+
+/**
+ * Subset of `.parachute/module.json` we care about for self-registration.
+ * `manifestName` is the row's `name` field in services.json (e.g.
+ * `"parachute-scribe"`). The bare `name` ("scribe") is the short slug hub
+ * uses for `SERVICE_SPECS`.
+ */
+interface ModuleManifest {
+  name: string;
+  manifestName: string;
+  displayName?: string;
+  tagline?: string;
+  paths?: string[];
+  health?: string;
+  stripPrefix?: boolean;
+}
+
+export type SelfRegisterOpts = {
+  /**
+   * The port scribe just bound. Used only as the first-run fallback —
+   * if services.json already has an entry, we re-stamp the existing port
+   * unchanged to preserve operator/hub overrides.
+   */
+  boundPort: number;
+  /**
+   * Absolute path to the scribe package root (where `.parachute/` and
+   * `package.json` live). Stamped as `installDir` so hub can resolve
+   * `parachute restart scribe` back to this checkout.
+   */
+  installDir: string;
+  /**
+   * Override the services.json location (tests). Defaults to
+   * `$PARACHUTE_HOME/services.json`.
+   */
+  manifestPath?: string;
+  /**
+   * Override the `.parachute/module.json` location (tests). Defaults to
+   * `<installDir>/.parachute/module.json`.
+   */
+  moduleManifestPath?: string;
+  /** Logger override; default console. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+};
+
+export type SelfRegisterResult = {
+  ok: boolean;
+  /** The path we wrote to (or attempted to write to). */
+  manifestPath: string;
+  /** True when services.json already had a row for scribe before we wrote. */
+  hadExistingEntry: boolean;
+  /** The port we ended up stamping (existing-entry port or boundPort). */
+  portWritten: number;
+  /** Set when ok=false — the error swallowed by the caller. */
+  error?: Error;
+};
+
+function readModuleManifest(p: string): ModuleManifest {
+  const raw = JSON.parse(readFileSync(p, "utf8"));
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`module manifest at ${p} is not an object`);
+  }
+  const m = raw as Record<string, unknown>;
+  if (typeof m.manifestName !== "string" || m.manifestName.length === 0) {
+    throw new Error(`module manifest at ${p} is missing "manifestName"`);
+  }
+  return raw as ModuleManifest;
+}
+
+/**
+ * Self-register scribe's services.json entry. Best-effort: returns
+ * `{ok: false, error}` on any failure rather than throwing, so the caller's
+ * "log + continue" branch is one shape regardless of failure mode.
+ *
+ * Idempotent against repeated calls — the canonical case is `serve()`
+ * invoking this once per boot, but if the daemon restarts in-process (PUT
+ * config triggering a reload, etc.) repeated calls converge to the same
+ * disk state.
+ */
+export function selfRegister(opts: SelfRegisterOpts): SelfRegisterResult {
+  const logger = opts.logger ?? console;
+  const manifestPath = opts.manifestPath; // undefined → resolveManifestPath() default
+  const moduleManifestPath =
+    opts.moduleManifestPath ?? path.join(opts.installDir, ".parachute", "module.json");
+
+  let module: ModuleManifest;
+  try {
+    if (!existsSync(moduleManifestPath)) {
+      logger.warn(
+        `[scribe] skipped self-register: .parachute/module.json not found at ${moduleManifestPath}`,
+      );
+      return {
+        ok: false,
+        manifestPath: manifestPath ?? "~/.parachute/services.json",
+        hadExistingEntry: false,
+        portWritten: opts.boundPort,
+        error: new Error(`module.json not found at ${moduleManifestPath}`),
+      };
+    }
+    module = readModuleManifest(moduleManifestPath);
+  } catch (e) {
+    const err = e as Error;
+    logger.warn(`[scribe] skipped self-register: ${err.message}`);
+    return {
+      ok: false,
+      manifestPath: manifestPath ?? "~/.parachute/services.json",
+      hadExistingEntry: false,
+      portWritten: opts.boundPort,
+      error: err,
+    };
+  }
+
+  let existing: ServiceEntry | undefined;
+  try {
+    existing = readServiceEntry(module.manifestName, manifestPath);
+  } catch (e) {
+    // Malformed services.json — don't blow up boot. The first write below
+    // would also throw; we trade an early bail for a noisy log so the
+    // operator sees what's wrong.
+    const err = e as Error;
+    logger.warn(`[scribe] skipped self-register: ${err.message}`);
+    return {
+      ok: false,
+      manifestPath: manifestPath ?? "~/.parachute/services.json",
+      hadExistingEntry: false,
+      portWritten: opts.boundPort,
+      error: err,
+    };
+  }
+
+  const portToWrite = existing?.port ?? opts.boundPort;
+  const entry: ServiceEntry = {
+    name: module.manifestName,
+    port: portToWrite,
+    paths: module.paths ?? ["/scribe"],
+    health: module.health ?? "/health",
+    version: pkg.version,
+    installDir: opts.installDir,
+  };
+  if (module.displayName !== undefined) entry.displayName = module.displayName;
+  if (module.tagline !== undefined) entry.tagline = module.tagline;
+  if (module.stripPrefix !== undefined) entry.stripPrefix = module.stripPrefix;
+
+  try {
+    upsertService(entry, manifestPath);
+  } catch (e) {
+    const err = e as Error;
+    logger.warn(`[scribe] skipped self-register: ${err.message}`);
+    return {
+      ok: false,
+      manifestPath: manifestPath ?? "~/.parachute/services.json",
+      hadExistingEntry: existing !== undefined,
+      portWritten: portToWrite,
+      error: err,
+    };
+  }
+
+  logger.log(
+    `[scribe] self-registered services.json entry (port=${portToWrite}, installDir=${opts.installDir}${existing ? ", existing entry merged" : ", first boot"})`,
+  );
+  return {
+    ok: true,
+    manifestPath: manifestPath ?? "~/.parachute/services.json",
+    hadExistingEntry: existing !== undefined,
+    portWritten: portToWrite,
+  };
+}
+
+/**
+ * Resolve the scribe package root — the directory containing
+ * `.parachute/module.json` + `package.json`. `import.meta.dir` points at
+ * `src/`; walk up one level.
+ */
+export function resolveProjectRoot(): string {
+  return path.resolve(import.meta.dir, "..");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,13 +13,9 @@ import {
   type FetchedAudio,
 } from "./url-fetch.ts";
 import { handleScribeMcp } from "./mcp/http.ts";
-import { upsertService } from "./services-manifest.ts";
+import { resolveProjectRoot, selfRegister } from "./self-register.ts";
 import { resolvePort } from "./port-resolve.ts";
 import {
-  DISPLAY_NAME,
-  MOUNT_PATH,
-  SERVICE_NAME,
-  TAGLINE,
   handleParachuteIcon,
   handleParachuteInfo,
 } from "./parachute-info.ts";
@@ -47,8 +43,6 @@ import {
   isAuthRequired,
   warnIfTokenLooksJwt,
 } from "./auth.ts";
-import pkg from "../package.json" with { type: "json" };
-
 export type ServerDeps = {
   transcribe: ((file: File) => Promise<string>) | null;
   cleanup: Cleaner;
@@ -592,19 +586,17 @@ export async function startServer(opts: StartServerOptions = {}) {
     throw err;
   }
 
-  try {
-    upsertService({
-      name: SERVICE_NAME,
-      port: PORT,
-      paths: [MOUNT_PATH],
-      health: "/health",
-      version: pkg.version,
-      displayName: DISPLAY_NAME,
-      tagline: TAGLINE,
-    });
-  } catch (err) {
-    console.warn(
-      `scribe: skipped services manifest update: ${err instanceof Error ? err.message : err}`,
-    );
-  }
+  // Self-register into `~/.parachute/services.json` so `parachute status`,
+  // `parachute restart scribe`, hub's admin SPA module catalog, and the
+  // live `/.well-known/parachute.json` builder see scribe without an
+  // operator step. Best-effort: a failure here doesn't block the daemon
+  // from serving locally — `selfRegister` swallows the error and logs.
+  // The helper reads `.parachute/module.json` for the canonical paths /
+  // health / displayName / tagline / stripPrefix shape (scribe#38), and
+  // honors a pre-existing services.json port so an operator override
+  // survives restarts (scribe#40 / paraclaw#145).
+  selfRegister({
+    boundPort: PORT,
+    installDir: resolveProjectRoot(),
+  });
 }

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -162,4 +162,16 @@ describe("services-manifest", () => {
       else process.env.PARACHUTE_HOME = orig;
     }
   });
+
+  describe("resolveManifestPath — env injection", () => {
+    test("honors PARACHUTE_HOME from the injected env", () => {
+      const p = resolveManifestPath({ PARACHUTE_HOME: "/tmp/parachute-home-override" });
+      expect(p).toBe("/tmp/parachute-home-override/services.json");
+    });
+
+    test("falls back to $HOME/.parachute when PARACHUTE_HOME unset", () => {
+      const p = resolveManifestPath({ HOME: "/Users/test-home" });
+      expect(p).toBe("/Users/test-home/.parachute/services.json");
+    });
+  });
 });

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -1,3 +1,23 @@
+/**
+ * Self-registration into `~/.parachute/services.json` on `parachute-scribe
+ * serve` boot.
+ *
+ * Mirrors `parachute-runner/src/services-manifest.ts` and
+ * `parachute-agent/src/web/services-manifest.ts` deliberately — the file
+ * shape is the contract between every Parachute module and the hub
+ * (`parachute-hub/src/services-manifest.ts` is the canonical reader).
+ *
+ * Failure mode: any write error is logged + swallowed by the caller. Self-
+ * registration is best-effort — the daemon still serves locally even if
+ * the manifest write fails (permissions, disk full, race with another
+ * writer, malformed pre-existing file).
+ *
+ * `installDir` is the third-party-module hook (parachute-hub#84): hub
+ * looks the field up to resolve `parachute restart scribe` back to the
+ * checkout it should drive. Self-registering it here means scribe doesn't
+ * need a vendored fallback in hub once vault#266 + runner#3 + scribe#38
+ * retire `SCRIBE_FALLBACK` from `parachute-hub/src/service-spec.ts`.
+ */
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -10,10 +30,12 @@ export interface ServiceEntry {
   version: string;
   displayName?: string;
   tagline?: string;
+  installDir?: string;
   /**
-   * Hub-stamped fields (e.g. `installDir` from parachute-hub#84) ride on the
-   * row even though scribe itself never sets them. We merge rather than
-   * replace on upsert so they survive scribe's self-registration writes.
+   * Hub-stamped fields (e.g. `installDir` from parachute-hub#84, future
+   * uiUrl / managementUrl pass-throughs) ride on the row even though scribe
+   * itself doesn't author them. The upsert merges rather than replaces so
+   * those survive a self-registration write.
    */
   [key: string]: unknown;
 }
@@ -22,8 +44,14 @@ interface ServicesManifest {
   services: ServiceEntry[];
 }
 
-export function resolveManifestPath(): string {
-  const base = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+/**
+ * Canonical location of `services.json`. Honors `PARACHUTE_HOME` for sandbox
+ * + Render deployments (matches the convention every other committed-core
+ * module follows). The `env` argument is injectable so tests can drive
+ * resolution without mutating `process.env`.
+ */
+export function resolveManifestPath(env: Record<string, string | undefined> = process.env): string {
+  const base = env.PARACHUTE_HOME ?? join(env.HOME ?? homedir(), ".parachute");
   return join(base, "services.json");
 }
 
@@ -54,17 +82,21 @@ export function readServiceEntry(
   return manifest.services.find((s) => s.name === name);
 }
 
-export function upsertService(
-  entry: ServiceEntry,
-  path: string = resolveManifestPath(),
-): void {
+/**
+ * Idempotent upsert of a service entry. Merges into any existing row rather
+ * than replacing it — preserves hub-stamped fields the module doesn't own
+ * (`installDir` from hub#84, future uiUrl, etc.). The module still wins for
+ * the fields it owns (port, paths, version, health, displayName, installDir
+ * — because `entry` spreads last in the merge).
+ *
+ * Atomic write: stages to `<path>.tmp-<pid>-<now>`, then renames over the
+ * target. A crash mid-write leaves the prior file intact rather than
+ * corrupting it.
+ */
+export function upsertService(entry: ServiceEntry, path: string = resolveManifestPath()): void {
   mkdirSync(dirname(path), { recursive: true });
   const manifest = readManifest(path);
   const idx = manifest.services.findIndex((s) => s.name === entry.name);
-  // Merge rather than replace so fields the hub stamps onto the row
-  // (`installDir` from parachute-hub#84, etc.) survive a self-registration
-  // pass. Scribe still wins for the fields it owns — port, paths, version,
-  // health — because they spread last.
   if (idx >= 0) manifest.services[idx] = { ...manifest.services[idx], ...entry };
   else manifest.services.push(entry);
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;


### PR DESCRIPTION
Closes #38.

## Summary

On `parachute-scribe serve` boot, scribe now reads its own `.parachute/module.json` and atomically upserts its row into `~/.parachute/services.json` — stamping `installDir`, paths/health/displayName/tagline/stripPrefix from the manifest, version from package.json. Mirrors the pattern already shipped in [vault#266](https://github.com/ParachuteComputer/parachute-vault/pull/266) and [runner#3](https://github.com/ParachuteComputer/parachute-runner/pull/3) (canonical env-injection shape going forward).

## Why

Hub-as-supervisor (v0.6) reads `~/.parachute/services.json` to know which modules exist on the host. Before this PR, scribe relied on the `bun link` install path (or hub's vendored `SCRIBE_FALLBACK` manifest) to stamp `installDir`. A `bun link`-mode dev tree that never went through `parachute install scribe` was missing the field, leaving `parachute restart scribe` unable to resolve back to the checkout. Self-registration closes that gap — scribe's `.parachute/module.json` is now the single source of truth.

## Design

- **Operator-override discipline preserved** (scribe#40 / paraclaw#145). If services.json already has a row for `parachute-scribe`, the existing `port` survives the write. First-boot writes the bound port; subsequent boots preserve.
- **Hub-stamped fields ride through.** `upsertService` merges rather than replaces, so `installDir` from [parachute-hub#84](https://github.com/ParachuteComputer/parachute-hub/issues/84) and future `uiUrl` / `managementUrl` survive every self-registration pass. We do re-stamp our own `installDir` so it follows the live checkout after a `git pull` moves the package root.
- **Graceful failure.** All four read/write boundaries (missing module.json, malformed module.json, malformed services.json, unwritable target) return `{ok: false}` with a `[scribe]` warn log rather than throwing. The daemon serves locally even when the discoverability bookkeeping fails.
- **Manifest is the source of truth.** Paths, health, displayName, tagline, stripPrefix are read from `.parachute/module.json` rather than hardcoded in the call site. This is the load-bearing piece of #38 — once all four committed-core modules self-register from their own manifest, hub's `FIRST_PARTY_FALLBACKS[scribe]` retires.

## `SCRIBE_FALLBACK` retirement deferred

Same as [vault#266](https://github.com/ParachuteComputer/parachute-vault/pull/266) + [runner#3](https://github.com/ParachuteComputer/parachute-runner/pull/3) — additive change. Hub's vendored `SCRIBE_FALLBACK` stays in place this release; it retires in a future hub PR after all four committed-core modules (vault/notes/scribe/runner) are confirmed self-registering reliably across the install matrix. No hub coordination required for this PR to ship.

## Files

- `src/self-register.ts` — `selfRegister()` helper + `resolveProjectRoot()`. Reads `.parachute/module.json` from `<installDir>/.parachute/module.json` (test-overridable via `moduleManifestPath`), respects an existing services.json port, swallows all errors with a warn log.
- `src/self-register.test.ts` — 14 tests covering first-boot, subsequent-boot port preservation, hub-stamped field merge, idempotency, sibling preservation, minimal-manifest defaults, the four graceful-failure modes, the `moduleManifestPath` test seam, and `resolveProjectRoot` pointing at the real package root.
- `src/services-manifest.ts` — refactored to mirror runner's env-injection shape: `resolveManifestPath(env?: Record<string, string | undefined>)`. Same `readServiceEntry` / `upsertService` semantics. Pure helpers.
- `src/services-manifest.test.ts` — added two env-injection coverage tests for `resolveManifestPath`.
- `src/server.ts` — replaced the existing inline `upsertService(...)` call after `Bun.serve` with `selfRegister({ boundPort, installDir })`. Drops the unused `SERVICE_NAME` / `MOUNT_PATH` / `DISPLAY_NAME` / `TAGLINE` imports (still exported from `parachute-info.ts` for `port-resolve.ts` + the `/.parachute/info` handler).
- `.parachute/module.json` — gained explicit `stripPrefix: true` (was implicit via hub's `SCRIBE_FALLBACK`).
- `package.json` + `CHANGELOG.md` — 0.4.4-rc.3 → 0.4.4-rc.4 per the governance rc-only versioning rule.

## Test plan

- [x] `bun test src/` — 360 pass, 0 fail, 749 expect() calls (was 344 / 691 on rc.3).
- [x] `bun run typecheck` — clean.
- [ ] Smoke: `bun link` from this branch, `parachute restart scribe`, confirm `~/.parachute/services.json`'s `parachute-scribe` row gains `installDir` pointing at the checkout.
- [ ] Smoke: confirm an operator-set port in services.json survives a restart cycle.