### PR TITLE
feat(scribe): POST /admin/clear-credential endpoint (#47 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.4.4-rc.5] - 2026-05-21
+
+### feat(scribe): POST /admin/clear-credential endpoint (Phase 2 polish from #47)
+
+Adds `POST /admin/clear-credential/<kind>/<name>` — the only way to erase a stored writeOnly credential without hand-editing `~/.parachute/scribe/config.json`. Pairs with the PUT omit-to-keep semantics shipped in [scribe#47](https://github.com/ParachuteComputer/parachute-scribe/pull/47): PUT preserves `apiKey` when omitted (so the SPA's password input can leave the field blank to mean "keep what's there"), and this endpoint is the operator's escape hatch for "actually drop it." Flagged as Phase 2 polish on the scribe#47 + scribe#48 reviews; closes the TODO that referenced it from `config-write.ts` and `server.ts`.
+
+**Endpoint shape.**
+- `POST /admin/clear-credential/{kind}/{name}` where `kind ∈ ["transcribe", "cleanup"]` and `name` is the registry-valid provider name (e.g. `cleanup/anthropic`, `transcribe/groq`).
+- Auth: `scribe:admin` scope, inherited from the existing `/admin/*` route gate.
+- Empty body (no payload — the path segments are the whole request).
+- 200 `{ok: true, cleared: {kind, name, field: "apiKey"}, hadStoredValue: bool}` on success. `hadStoredValue` distinguishes a real clear from a no-op (clearing a provider with nothing stored still returns 200; the operator's intent — "ensure this credential is gone" — is satisfied either way).
+- 400 `{error: "invalid_kind"|"unknown_provider"|"invalid_path", message}` for bad inputs.
+- 401/403 inherited from the standard auth + scope gates.
+
+**Idempotency posture: 200 always, distinguish via `hadStoredValue`.** Chose 200-on-no-op over 404 so the SPA's "Clear" button doesn't need separate error UI for "was already cleared" vs "didn't exist." The `hadStoredValue` flag carries the distinction for callers that want to know.
+
+**Field-explicit response shape.** Today the only clearable field is `apiKey`; the response carries `field` explicitly so the wire contract can extend (e.g. claude-code `setupToken` once that flow is implemented) without reshaping callers.
+
+**Tidy on-disk shape.** When the cleared provider entry held *only* `apiKey` (no `model`/`url`), the entry is removed entirely rather than left as an empty `{}` shell. When that was the last entry in the `cleanupProviders` / `transcribeProviders` map, the whole map is dropped from the file. Mirrors the housekeeping in `mergeIntoFileShape`.
+
+**In-process sync.** After the atomic write, the in-process `scribeConfig.transcribeProviders` / `cleanupProviders` are replaced with the post-clear shape so the next transcribe/cleanup request doesn't keep using the just-cleared apiKey from memory. Same pattern PUT already uses.
+
+**Phase 2 != SPA work.** This PR ships the server-side endpoint only. Hub#300's admin SPA still has password-input fields for writeOnly credentials but no "Clear" button — that affordance is a future hub PR. Operators can hit this endpoint via `curl` today:
+
+```bash
+curl -X POST http://localhost:1943/admin/clear-credential/cleanup/anthropic \
+  -H "Authorization: Bearer $SCRIBE_AUTH_TOKEN"
+```
+
+**Test gate.** `bun test src/` — 375 pass (was 360 on rc.4), 794 expect() calls. 14 new tests covering happy path (200 + on-disk strip + in-process sync), idempotent no-op (200 + `hadStoredValue: false`), apiKey-only entry removal, transcribe-kind happy path, GET reflects post-clear state (`apiKeyConfigured` flag flips), 400 invalid_kind / unknown_provider / cross-kind name / missing segment / extra segment, 401 missing+wrong bearer in closed mode, 200 with matching shared-secret, GET-method-rejection, sibling-provider preservation. `bun run typecheck` clean. `bunx biome check .` clean.
+
+**Files touched.** `src/config-write.ts` (added `validateClearCredentialTarget` + `clearProviderCredential` + `CREDENTIAL_KINDS` / `CLEARABLE_FIELDS` exports + updated docstring), `src/server.ts` (route dispatch + `handleClearCredential` handler), `src/site-52-routes.test.ts` (14-test describe block), `package.json` version, `CHANGELOG.md`.
+
 ## [0.4.4-rc.4] - 2026-05-21
 
 ### feat(scribe): self-register manifest + installDir at startup (#38)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4-rc.4",
+  "version": "0.4.4-rc.5",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/config-write.ts
+++ b/src/config-write.ts
@@ -31,7 +31,9 @@
  *   - **Omit-to-keep PUT semantics for writeOnly credential fields.** Sending
  *     an empty string or omitting an `apiKey` field on PUT preserves the
  *     stored value. Sending a non-empty string replaces it. Explicit
- *     clearing uses `POST /admin/clear-credential/<kind>/<name>` instead.
+ *     clearing uses `POST /admin/clear-credential/<kind>/<name>` (see
+ *     `clearProviderCredential` below) — the only way to remove a stored
+ *     writeOnly value short of hand-editing `config.json`.
  *
  * Pre-0.4.4 wire fields stay supported. `cleanupDefault` (old name) is
  * still accepted on PUT and translated to `cleanupDefault` so existing
@@ -436,6 +438,125 @@ function mergeProviderMap(
     result[name] = target;
   }
   return result;
+}
+
+/**
+ * Provider kinds for `POST /admin/clear-credential/<kind>/<name>`. The kind
+ * routes the lookup to the right per-provider map; the name is the registry
+ * key inside it (e.g. `cleanup/anthropic` → `cleanupProviders.anthropic`).
+ */
+export const CREDENTIAL_KINDS = ["transcribe", "cleanup"] as const;
+export type CredentialKind = (typeof CREDENTIAL_KINDS)[number];
+
+/**
+ * Currently the only clearable writeOnly field is `apiKey`. Surfacing this
+ * as a tuple so future fields (e.g. claude-code `setupToken` once that flow
+ * lands) can be added without reshaping callers — the response always
+ * echoes `field` so the SPA knows exactly what was removed.
+ */
+export const CLEARABLE_FIELDS = ["apiKey"] as const;
+export type ClearableField = (typeof CLEARABLE_FIELDS)[number];
+
+export type ClearCredentialResult = {
+  /** True when an existing value was actually removed; false on no-op. */
+  cleared: boolean;
+  /** The post-clear config, ready to atomically persist. */
+  config: ScribeConfig;
+};
+
+/**
+ * Validate kind/name against the allowed enums + the live provider registry.
+ * Returns `null` on success or an error tuple for the route to translate
+ * into a 400 response.
+ */
+export function validateClearCredentialTarget(
+  kind: string,
+  name: string,
+): { ok: true; kind: CredentialKind; name: string } | { ok: false; error: string; message: string } {
+  if (!(CREDENTIAL_KINDS as readonly string[]).includes(kind)) {
+    return {
+      ok: false,
+      error: "invalid_kind",
+      message: `kind must be one of: ${CREDENTIAL_KINDS.join(", ")} (got "${kind}")`,
+    };
+  }
+  const validNames = kind === "transcribe" ? VALID_TRANSCRIBE_PROVIDER_NAMES : VALID_CLEANUP_PROVIDER_NAMES;
+  if (!validNames.has(name)) {
+    return {
+      ok: false,
+      error: "unknown_provider",
+      message: `unknown ${kind} provider "${name}" — known: ${Array.from(validNames).sort().join(", ")}`,
+    };
+  }
+  return { ok: true, kind: kind as CredentialKind, name };
+}
+
+/**
+ * Remove the `apiKey` field from `<kind>Providers.<name>`. Returns `cleared:
+ * false` when there was no stored value to begin with — the operator's intent
+ * ("ensure this credential is cleared") is satisfied either way, so the
+ * endpoint returns 200 idempotently and only differs in the `cleared` flag.
+ *
+ * Pairs with `mergeIntoFileShape` (PUT preserves writeOnly fields when
+ * omitted; this is the only way to remove them).
+ */
+export function clearProviderCredential(
+  existing: ScribeConfig,
+  kind: CredentialKind,
+  name: string,
+): ClearCredentialResult {
+  const mapKey = kind === "transcribe" ? "transcribeProviders" : "cleanupProviders";
+  const next: ScribeConfig = {
+    ...existing,
+    // Shallow-clone the per-provider map so we don't mutate the caller's
+    // object — the in-process scribeConfig is the same reference the
+    // running handler reads per-request.
+    transcribeProviders: existing.transcribeProviders ? { ...existing.transcribeProviders } : undefined,
+    cleanupProviders: existing.cleanupProviders ? { ...existing.cleanupProviders } : undefined,
+  };
+  const providerMap = next[mapKey];
+  const block = providerMap?.[name];
+  if (!block || block.apiKey === undefined || block.apiKey === "") {
+    // No stored credential — drop the empty/undef apiKey shell if it's there
+    // so the on-disk shape stays tidy, but report `cleared: false` for the
+    // wire response. Don't synthesize a provider entry that wasn't already
+    // there.
+    if (block && "apiKey" in block) {
+      const { apiKey: _drop, ...rest } = block;
+      if (Object.keys(rest).length === 0 && providerMap) {
+        delete providerMap[name];
+      } else if (providerMap) {
+        providerMap[name] = rest;
+      }
+    }
+    return { cleared: false, config: trimEmptyProviderMaps(next) };
+  }
+  // Real clear — strip apiKey, keep model/url. Drop the provider entry
+  // entirely if it was apiKey-only so the on-disk file doesn't accumulate
+  // empty `{}` blocks per provider that was once configured.
+  const { apiKey: _stripped, ...rest } = block;
+  if (Object.keys(rest).length === 0 && providerMap) {
+    delete providerMap[name];
+  } else if (providerMap) {
+    providerMap[name] = rest;
+  }
+  return { cleared: true, config: trimEmptyProviderMaps(next) };
+}
+
+/**
+ * Drop empty per-provider maps so the on-disk file stays tidy when the last
+ * configured provider in a kind gets its apiKey cleared. Mirrors the
+ * housekeeping in `mergeIntoFileShape`.
+ */
+function trimEmptyProviderMaps(cfg: ScribeConfig): ScribeConfig {
+  const out = { ...cfg };
+  if (out.transcribeProviders && Object.keys(out.transcribeProviders).length === 0) {
+    delete out.transcribeProviders;
+  }
+  if (out.cleanupProviders && Object.keys(out.cleanupProviders).length === 0) {
+    delete out.cleanupProviders;
+  }
+  return out;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,10 +25,12 @@ import {
 } from "./config-schema.ts";
 import {
   buildPublicResolvedConfig,
+  clearProviderCredential,
   detectRestartRequired,
   mergeIntoFileShape,
   readExistingConfig,
   toFileShape,
+  validateClearCredentialTarget,
   validateConfig,
   writeConfigFileAtomic,
 } from "./config-write.ts";
@@ -160,10 +162,13 @@ async function route(
     return new Response("Not found", { status: 404 });
   }
 
-  // Admin actions live under /admin/* — refresh-claude-token-status is the
-  // only one shipped in 0.4.4-rc.1; clear-credential follows in Phase 2.
+  // Admin actions live under /admin/* — refresh-claude-token-status and
+  // clear-credential (Phase 2 polish from scribe#47).
   if (internalPath === "/admin/refresh-claude-token-status" && req.method === "POST") {
     return handleRefreshSetupTokenStatus(deps);
+  }
+  if (internalPath.startsWith("/admin/clear-credential/") && req.method === "POST") {
+    return handleClearCredential(internalPath, deps);
   }
   if (internalPath.startsWith("/admin/") && req.method !== "GET") {
     return Response.json({ error: "Not found" }, { status: 404 });
@@ -240,6 +245,107 @@ function handleConfigGet(deps: ServerDeps): Response {
 function handleRefreshSetupTokenStatus(deps: ServerDeps): Response {
   const status = (deps.setupTokenStatusFn ?? readSetupTokenStatus)();
   return Response.json({ setupTokenStatus: status });
+}
+
+/**
+ * `POST /admin/clear-credential/<kind>/<name>` — remove the stored
+ * writeOnly `apiKey` for a provider. Pairs with PUT /.parachute/config's
+ * omit-to-keep semantics: PUT preserves apiKey when omitted, so this
+ * endpoint is the only way to actually erase a stored credential without
+ * hand-editing `config.json`.
+ *
+ * - 200 `{ok: true, cleared: {kind, name, field}, hadStoredValue: bool}`
+ *   on success. Idempotent: clearing a provider with no stored apiKey still
+ *   returns 200, with `hadStoredValue: false` to distinguish the no-op.
+ * - 400 `{error: "invalid_kind"|"unknown_provider", message}` for bad path
+ *   segments (kind not in enum, name not in the provider registry).
+ * - 401/403 inherited from the standard auth gate (scribe:admin scope).
+ *
+ * Phase 2 polish from scribe#47 + #48 reviews. Today the only clearable
+ * `field` is `apiKey`; the response carries `field` explicitly so future
+ * additions (e.g. claude-code `setupToken`) can extend without reshaping
+ * the wire contract.
+ */
+async function handleClearCredential(
+  internalPath: string,
+  deps: ServerDeps,
+): Promise<Response> {
+  // Path is `/admin/clear-credential/<kind>/<name>` — anything past the
+  // two segments is a bad request (no field-targeting yet; apiKey is the
+  // only clearable field for now).
+  const suffix = internalPath.slice("/admin/clear-credential/".length);
+  const parts = suffix.split("/").filter((s) => s.length > 0);
+  if (parts.length !== 2) {
+    return Response.json(
+      {
+        error: "invalid_path",
+        message:
+          "expected /admin/clear-credential/<kind>/<name> — e.g. /admin/clear-credential/cleanup/anthropic",
+      },
+      { status: 400 },
+    );
+  }
+  const [kindRaw, nameRaw] = parts;
+  // Decode in case the SPA URL-encoded a provider name with special chars.
+  let kind: string;
+  let name: string;
+  try {
+    kind = decodeURIComponent(kindRaw!);
+    name = decodeURIComponent(nameRaw!);
+  } catch {
+    return Response.json(
+      { error: "invalid_path", message: "malformed URL encoding in path" },
+      { status: 400 },
+    );
+  }
+  const validation = validateClearCredentialTarget(kind, name);
+  if (!validation.ok) {
+    return Response.json(
+      { error: validation.error, message: validation.message },
+      { status: 400 },
+    );
+  }
+
+  const path = deps.configPath ?? resolveDefaultConfigPath();
+  let existing: ScribeConfig;
+  try {
+    existing = readExistingConfig(path);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[scribe] clear-credential config read failed (${path}): ${message}`);
+    return Response.json(
+      { error: "read_failed", message: `failed to read ${path}: ${message}` },
+      { status: 500 },
+    );
+  }
+
+  const { cleared, config: nextConfig } = clearProviderCredential(
+    existing,
+    validation.kind,
+    validation.name,
+  );
+
+  try {
+    writeConfigFileAtomic(path, nextConfig);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[scribe] clear-credential config write failed (${path}): ${message}`);
+    return Response.json(
+      { error: "write_failed", message: `failed to write ${path}: ${message}` },
+      { status: 500 },
+    );
+  }
+
+  // Sync the in-process scribeConfig so the next transcribe/cleanup request
+  // doesn't keep using the just-cleared apiKey from memory.
+  deps.scribeConfig.transcribeProviders = nextConfig.transcribeProviders;
+  deps.scribeConfig.cleanupProviders = nextConfig.cleanupProviders;
+
+  return Response.json({
+    ok: true,
+    cleared: { kind: validation.kind, name: validation.name, field: "apiKey" },
+    hadStoredValue: cleared,
+  });
 }
 
 /**

--- a/src/site-52-routes.test.ts
+++ b/src/site-52-routes.test.ts
@@ -426,3 +426,231 @@ describe("PUT /.parachute/config — empty-body no-op", () => {
     expect(onDisk.transcribeProviders.groq.model).toBe("m");
   });
 });
+
+describe("POST /admin/clear-credential/<kind>/<name> — Phase 2 (scribe#47 follow-up)", () => {
+  let dir: string;
+  let configPath: string;
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scribe-clear-cred-"));
+    configPath = join(dir, "scribe", "config.json");
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+    delete process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  function clearReq(path: string, token?: string): Request {
+    const headers: Record<string, string> = {};
+    if (token !== undefined) headers.Authorization = `Bearer ${token}`;
+    return new Request(`http://localhost${path}`, { method: "POST", headers });
+  }
+
+  function seedConfig(cfg: Record<string, unknown>): void {
+    mkdirSync(join(dir, "scribe"), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(cfg), { mode: 0o600 });
+  }
+
+  test("happy path: clears cleanup/anthropic apiKey + returns 200 with hadStoredValue:true", async () => {
+    seedConfig({
+      cleanupProviders: { anthropic: { apiKey: "sk-ant-real", model: "claude-3-5-sonnet" } },
+    });
+    const scribeConfig: ScribeConfig = {
+      cleanupProviders: { anthropic: { apiKey: "sk-ant-real", model: "claude-3-5-sonnet" } },
+    };
+    const handler = buildHandler(configPath, { scribeConfig });
+
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      cleared: { kind: string; name: string; field: string };
+      hadStoredValue: boolean;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.cleared).toEqual({ kind: "cleanup", name: "anthropic", field: "apiKey" });
+    expect(body.hadStoredValue).toBe(true);
+
+    // On-disk: model survives, apiKey is gone.
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(onDisk.cleanupProviders.anthropic.apiKey).toBeUndefined();
+    expect(onDisk.cleanupProviders.anthropic.model).toBe("claude-3-5-sonnet");
+    // In-process scribeConfig mirrors disk so the next request doesn't keep the stale key.
+    expect(scribeConfig.cleanupProviders?.anthropic?.apiKey).toBeUndefined();
+    expect(scribeConfig.cleanupProviders?.anthropic?.model).toBe("claude-3-5-sonnet");
+  });
+
+  test("idempotent no-op: clearing when nothing stored returns 200 with hadStoredValue:false", async () => {
+    // No seed — config doesn't exist yet on disk.
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; hadStoredValue: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.hadStoredValue).toBe(false);
+  });
+
+  test("idempotent no-op: clearing apiKey-only provider drops the empty entry", async () => {
+    // Provider entry that holds ONLY apiKey gets removed entirely so the
+    // on-disk file doesn't accumulate `{provider: {}}` shells.
+    seedConfig({
+      cleanupProviders: { anthropic: { apiKey: "sk-ant-real" } },
+    });
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+    expect(res.status).toBe(200);
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    // Provider entry gone AND cleanupProviders map gone (it's now empty).
+    expect(onDisk.cleanupProviders).toBeUndefined();
+  });
+
+  test("transcribe kind: clears groq apiKey while preserving model", async () => {
+    seedConfig({
+      transcribeProviders: { groq: { apiKey: "gsk_real", model: "whisper-large-v3" } },
+    });
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/transcribe/groq"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cleared: { kind: string; name: string; field: string } };
+    expect(body.cleared.kind).toBe("transcribe");
+    expect(body.cleared.name).toBe("groq");
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(onDisk.transcribeProviders.groq.apiKey).toBeUndefined();
+    expect(onDisk.transcribeProviders.groq.model).toBe("whisper-large-v3");
+  });
+
+  test("GET /.parachute/config reflects the clear: apiKeyConfigured is false after", async () => {
+    seedConfig({
+      cleanupProviders: { anthropic: { apiKey: "sk-ant-real", model: "claude-3-5-sonnet" } },
+    });
+    const scribeConfig: ScribeConfig = {
+      cleanupProviders: { anthropic: { apiKey: "sk-ant-real", model: "claude-3-5-sonnet" } },
+    };
+    const handler = buildHandler(configPath, { scribeConfig });
+
+    // Pre: GET shows apiKeyConfigured: true.
+    const preRes = await handler(getConfigReq());
+    const preBody = (await preRes.json()) as { cleanupProviders: Record<string, { apiKeyConfigured?: boolean; model?: string }> };
+    expect(preBody.cleanupProviders.anthropic?.apiKeyConfigured).toBe(true);
+
+    // Clear.
+    await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+
+    // Post: GET no longer reports apiKeyConfigured (writeOnly omission + no value).
+    const postRes = await handler(getConfigReq());
+    const postBody = (await postRes.json()) as { cleanupProviders: Record<string, { apiKeyConfigured?: boolean; model?: string }> };
+    expect(postBody.cleanupProviders.anthropic?.apiKeyConfigured).toBeUndefined();
+    // Model survives in the GET response too.
+    expect(postBody.cleanupProviders.anthropic?.model).toBe("claude-3-5-sonnet");
+  });
+
+  test("400 invalid_kind: kind not in enum", async () => {
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/bogus/anthropic"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("invalid_kind");
+    expect(body.message).toContain("transcribe");
+    expect(body.message).toContain("cleanup");
+  });
+
+  test("400 unknown_provider: kind valid but name not in registry", async () => {
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/not-a-thing"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("unknown_provider");
+    expect(body.message).toContain("not-a-thing");
+  });
+
+  test("400 unknown_provider: name from the OTHER kind's registry is rejected", async () => {
+    // `parakeet-mlx` is a transcribe provider — not valid under cleanup.
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/parakeet-mlx"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unknown_provider");
+  });
+
+  test("400 invalid_path: missing name segment", async () => {
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_path");
+  });
+
+  test("400 invalid_path: extra segments past kind/name", async () => {
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic/apiKey"));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_path");
+  });
+
+  test("401 missing bearer in closed mode", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    seedConfig({ cleanupProviders: { anthropic: { apiKey: "sk-ant" } } });
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+    expect(res.status).toBe(401);
+    // On-disk apiKey untouched.
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(onDisk.cleanupProviders.anthropic.apiKey).toBe("sk-ant");
+  });
+
+  test("401 wrong bearer in closed mode", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    seedConfig({ cleanupProviders: { anthropic: { apiKey: "sk-ant" } } });
+    const handler = buildHandler(configPath);
+    const res = await handler(
+      clearReq("/admin/clear-credential/cleanup/anthropic", "wrong"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("200 with matching shared-secret bearer (grants scribe:admin)", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    seedConfig({ cleanupProviders: { anthropic: { apiKey: "sk-ant", model: "m" } } });
+    const handler = buildHandler(configPath);
+    const res = await handler(
+      clearReq("/admin/clear-credential/cleanup/anthropic", "s3cret"),
+    );
+    expect(res.status).toBe(200);
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(onDisk.cleanupProviders.anthropic.apiKey).toBeUndefined();
+    expect(onDisk.cleanupProviders.anthropic.model).toBe("m");
+  });
+
+  test("405-ish: GET on the clear-credential path falls through to 404", async () => {
+    // The route only matches POST. GET hits the catch-all 404 — by design,
+    // since this is a side-effecting verb only.
+    const handler = buildHandler(configPath);
+    const res = await handler(
+      new Request("http://localhost/admin/clear-credential/cleanup/anthropic"),
+    );
+    // Either 404 or 405 is acceptable here; the contract is "not a GET endpoint."
+    expect([404, 405]).toContain(res.status);
+  });
+
+  test("clearing one provider's apiKey doesn't touch siblings", async () => {
+    seedConfig({
+      cleanupProviders: {
+        anthropic: { apiKey: "sk-ant-real", model: "claude-3-5-sonnet" },
+        openai: { apiKey: "sk-openai-real", model: "gpt-4o" },
+      },
+    });
+    const handler = buildHandler(configPath);
+    const res = await handler(clearReq("/admin/clear-credential/cleanup/anthropic"));
+    expect(res.status).toBe(200);
+    const onDisk = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(onDisk.cleanupProviders.anthropic.apiKey).toBeUndefined();
+    expect(onDisk.cleanupProviders.openai.apiKey).toBe("sk-openai-real");
+    expect(onDisk.cleanupProviders.openai.model).toBe("gpt-4o");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `POST /admin/clear-credential/<kind>/<name>` — the operator's escape hatch for erasing a stored writeOnly `apiKey` without hand-editing `~/.parachute/scribe/config.json`. Pairs with the PUT omit-to-keep semantics shipped in scribe#47: PUT preserves `apiKey` when omitted (so the SPA password input can leave the field blank to mean "keep what's there"), and this endpoint is the only way to actually drop it. Closes the TODO that referenced it from `config-write.ts` (line 34) and `server.ts` (line 118). Phase 2 polish flagged on the scribe#47 + scribe#48 reviews.

## Endpoint shape

- `POST /admin/clear-credential/{kind}/{name}` — `kind in ["transcribe", "cleanup"]`, `name` is the live-registry provider name (e.g. `cleanup/anthropic`, `transcribe/groq`).
- Auth: `scribe:admin` scope, inherited from the existing `/admin/*` route gate.
- Empty body — the path segments are the whole request.
- 200 `{ok: true, cleared: {kind, name, field: "apiKey"}, hadStoredValue: bool}` on success.
- 400 `{error: "invalid_kind"|"unknown_provider"|"invalid_path", message}` on bad input.
- 401/403 inherited from the standard auth + scope gates.

`hadStoredValue` distinguishes a real clear from a no-op. **Idempotency posture chosen: 200 always.** Clearing a provider with nothing stored still returns 200 — the operator's intent ("ensure this credential is gone") is satisfied either way, so the SPA doesn't need separate error UI for "was already cleared" vs "didn't exist." The flag carries the distinction for callers that want it.

`field` is explicit in the response so the contract can extend (e.g. claude-code `setupToken` once that flow lands) without reshaping callers.

## On-disk hygiene

- apiKey-only provider entries are removed entirely after clear (no `{anthropic: {}}` shells).
- Empty per-provider maps are dropped from the file (mirrors `mergeIntoFileShape`'s housekeeping).
- In-process `scribeConfig.transcribeProviders` / `cleanupProviders` are synced post-write so the next transcribe/cleanup call doesn't keep using the just-cleared key from memory.

## Tests

14 new tests under `site-52-routes.test.ts`:
- happy path (transcribe + cleanup kinds) — 200 + on-disk apiKey strip + in-process sync
- idempotent no-op — 200 with `hadStoredValue: false`
- apiKey-only entry removal — drops the empty `{}` shell + the empty map
- GET `/.parachute/config` reflects post-clear state (`apiKeyConfigured` flips false)
- 400 paths: `invalid_kind`, `unknown_provider`, cross-kind name (parakeet-mlx under cleanup), missing segment, extra segment
- auth: 401 missing+wrong bearer in closed mode, 200 with matching shared-secret
- 404/405 on GET (POST-only verb by design)
- sibling-provider preservation (clearing anthropic doesn't touch openai)

**Suite delta.** 375 pass / 794 expects (was 360 / 749 on rc.4 — +15 pass, +45 expects). `bun run typecheck` clean. `bunx biome check .` clean.

## SPA follow-up (out of scope)

Hub#300's admin SPA has password inputs for writeOnly fields but no "Clear" button. Adding that UI touches the hub repo and is a future PR. Operators can hit the endpoint via curl today:

```bash
curl -X POST http://localhost:1943/admin/clear-credential/cleanup/anthropic \
  -H "Authorization: Bearer $SCRIBE_AUTH_TOKEN"
```

## Versioning

Bumps to `0.4.4-rc.5`. CHANGELOG entry under `## [0.4.4-rc.5] - 2026-05-21` titled "feat(scribe): POST /admin/clear-credential endpoint (Phase 2 polish from #47)."

## Test plan

- [ ] `bun test src/` passes — 375 pass, 794 expects
- [ ] `bun run typecheck` clean
- [ ] `bunx biome check .` clean
- [ ] Manual smoke: seed a config with `{cleanupProviders: {anthropic: {apiKey: "real"}}}`, hit `POST /admin/clear-credential/cleanup/anthropic`, verify on-disk file no longer carries the apiKey
- [ ] Manual smoke: hit the endpoint when nothing is stored — verify 200 + `hadStoredValue: false`
- [ ] Manual smoke: hit with `kind=bogus` — verify 400 `invalid_kind`