### PR TITLE
chore(scribe): drop kind from module.json (hub#301 Phase B)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -3,7 +3,6 @@
   "manifestName": "parachute-scribe",
   "displayName": "Scribe",
   "tagline": "Audio transcription (Whisper-compatible API + LLM cleanup)",
-  "kind": "api",
   "port": 1943,
   "paths": ["/scribe"],
   "health": "/health",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.4-rc.6] - 2026-05-23
+
+### chore(scribe): drop `kind` from `.parachute/module.json` (hub#301 Phase B)
+
+- Dropped `kind` field from `.parachute/module.json`. Per hub#301 Phase B. No behavior change.
+
 ## [0.4.4-rc.5] - 2026-05-21
 
 ### feat(scribe): POST /admin/clear-credential endpoint (Phase 2 polish from #47)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4-rc.5",
+  "version": "0.4.4-rc.6",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/self-register.test.ts
+++ b/src/self-register.test.ts
@@ -60,7 +60,6 @@ function makeFakeInstall(root: string, overrides: Record<string, unknown> = {}):
     manifestName: "parachute-scribe",
     displayName: "Scribe",
     tagline: "Audio transcription (Whisper-compatible API + LLM cleanup)",
-    kind: "api",
     port: 1943,
     paths: ["/scribe"],
     health: "/health",


### PR DESCRIPTION
## Summary

Drops the `kind` field from `.parachute/module.json`. Per **hub#301 Phase B** (kind retirement) — `kind` is being retired from the module manifest contract; module classification moves elsewhere.

No behavior change. Scribe's runtime config, routes, and `/.parachute/info` payload (which still emits `kind: "api"` for back-compat with discovery clients — that's a separate surface, distinct from the manifest contract being retired here) are unaffected.

Also updates the `self-register.test.ts` fixture to mirror the real manifest shape (per its own comment: "Mirrors scribe's real `.parachute/module.json` shape"). The field was already tolerated as unknown by the manifest reader — tests passed both before and after the fixture change.

Cross-refs: hub#327, hub#330, `parachute-patterns/module-surfaces.md`.

Bumps to `0.4.4-rc.6`.

## Patterns check

- Touches the **module-surfaces** pattern (the manifest schema in `.parachute/module.json`). Conforms — this PR drops a field per the ongoing kind-retirement migration; nothing new established.
- Touches **governance rule 2** (rc bump) — code-touching PR, bumps `rc.5 → rc.6` keeping `0.4.4` fixed.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` clean (375/375 pass)
- [x] `.parachute/module.json` valid JSON (no dangling comma)
- [x] `self-register.test.ts` fixture updated to match real shape
- [ ] Reviewer dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)