### PR TITLE
chore(scribe): drop kind from /.parachute/info endpoint response (hub#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.4-rc.7] - 2026-05-23
+
+### Removed
+
+- Dropped `kind` field from the `/.parachute/info` runtime endpoint response. Companion to scribe#52's module.json drop. Closes part of hub#340.
+
 ## [0.4.4-rc.6] - 2026-05-23
 
 ### chore(scribe): drop `kind` from `.parachute/module.json` (hub#301 Phase B)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4-rc.6",
+  "version": "0.4.4-rc.7",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "module": "src/index.ts",
   "type": "module",

--- a/src/parachute-info.test.ts
+++ b/src/parachute-info.test.ts
@@ -24,7 +24,6 @@ describe("parachute-info", () => {
       name: SERVICE_NAME,
       displayName: DISPLAY_NAME,
       tagline: TAGLINE,
-      kind: "api",
       version: pkg.version,
       iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
     });

--- a/src/parachute-info.ts
+++ b/src/parachute-info.ts
@@ -13,7 +13,6 @@ export function handleParachuteInfo(): Response {
     name: SERVICE_NAME,
     displayName: DISPLAY_NAME,
     tagline: TAGLINE,
-    kind: "api",
     version: pkg.version,
     iconUrl: `${MOUNT_PATH}/.parachute/icon.svg`,
   });


### PR DESCRIPTION
## Summary

Drops the `kind: "api"` field from scribe's `/.parachute/info` runtime endpoint response. Companion cleanup to [scribe#52](https://github.com/ParachuteComputer/parachute-scribe/pull/52) (which dropped `kind` from `.parachute/module.json`), closing part of [hub#340](https://github.com/ParachuteComputer/parachute-hub/issues/340). `kind` is no longer part of the module discovery contract — [hub#330](https://github.com/ParachuteComputer/parachute-hub/pull/330) retired the field from the consumer side.

The flagged emission site (`src/parachute-info.ts:16`) was the last `kind` literal in scribe's discovery surface; `parachute-info.test.ts` updated to match the new shape. No TypeScript response type to update — `Response.json` infers from the literal.

Cross-refs: scribe#52, hub#330, hub#340.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/` — 375 pass, 794 expect() calls, 0 fail
- [ ] Hub no longer reads `info.kind` on any code path (verified via hub#330)

## Patterns check

Touches the module-discovery contract documented in `parachute-patterns/patterns/module-self-registration.md`. Conforms — `kind` was already removed from the canonical contract; this drops the last lingering producer-side emission.

## Version

`0.4.4-rc.6` → `0.4.4-rc.7` (rc chain continues; promotes to `0.4.4` stable when Aaron says ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)