### PR TITLE
ci(scribe): add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+# Release workflow — triggered by pushing a semver tag.
+#
+# Tag conventions (matches parachute-patterns governance rule 2):
+#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.4.4-rc.7)
+#   - stable: v<X>.<Y>.<Z>          (e.g. v0.4.4)
+#
+# Release flow:
+#   1. Code-touching PR merges to main, bumping `version` in package.json
+#      (rc.N → rc.N+1 for the rc chain; or drop -rc.N suffix for stable).
+#   2. After merge, push a matching tag:
+#        git tag v$(grep '"version"' package.json | cut -d'"' -f4) && git push --tags
+#   3. CI runs tests, then publishes to npm (with provenance attestation,
+#      dist-tag = rc or latest).
+#
+# Operator setup (one-time):
+#   - npmjs.com → package @openparachute/scribe → Settings → Trusted
+#     Publishers → Add (GitHub Actions): org=ParachuteComputer,
+#     repo=parachute-scribe, workflow=release.yml, environment blank.
+#   - No NPM_TOKEN secret needed; OIDC handles auth.
+#
+# Why tag-triggered (not push-to-main):
+#   - tag = explicit release signal; main commits without a tag don't publish.
+#   - Preserves a deliberate gate (you push the tag when you mean to ship).
+#   - Tag-as-canonical means the tag itself is the audit trail of what was
+#     released and when.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+concurrency:
+  # Don't let two releases race on the same tag.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: scribe tests
+        run: bun test src/
+
+  publish-npm:
+    name: publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance attestation + Trusted Publishing OIDC.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
+          # support built in. Node 20 LTS only has npm 10 and would
+          # silently fall back to token auth (failing without NPM_TOKEN).
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        # Defense against tag-vs-package.json drift. If they don't match,
+        # we'd publish under the wrong version.
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        # Trusted Publishing: npm verifies the OIDC token from this workflow
+        # against the package's configured trusted publisher rule
+        # (org=ParachuteComputer, repo=parachute-scribe, workflow=release.yml).
+        # No NPM_TOKEN secret needed; `id-token: write` permission above
+        # makes the OIDC token available to npm CLI.
+        run: |
+          # Detect rc vs stable from tag name. Tag pattern in `on:` above
+          # enforces the shape, so this is just disambiguation.
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,84 @@
+# Releasing `@openparachute/scribe`
+
+Releases are automated via [`.github/workflows/release.yml`](./.github/workflows/release.yml). Pushing a git tag triggers CI which:
+
+1. Runs `bun run typecheck` + `bun test src/`
+2. Publishes to npm (with provenance attestation, via Trusted Publishing / OIDC)
+
+Scribe ships as a pure npm package — no container image, no SPA bundle.
+
+## Tag conventions
+
+Per [parachute-patterns governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md):
+
+| Tag shape | Example | npm `dist-tag` |
+|---|---|---|
+| `vX.Y.Z-rc.N` | `v0.4.4-rc.7` | `rc` |
+| `vX.Y.Z` | `v0.4.4` | `latest` |
+
+The workflow auto-detects rc vs stable from the tag string (`-rc.` substring).
+
+## Release flow
+
+### For an rc bump (each code-touching PR merge)
+
+After your PR merges to `main` with a bumped `rc.N`:
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+VERSION="v$(node -p "require('./package.json').version")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+CI takes over from there — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-scribe/actions).
+
+### Promoting an rc chain to stable
+
+When the rc chain is ready to release:
+
+1. Open a PR that drops the `-rc.N` suffix from `package.json` (e.g. `0.4.4-rc.7` → `0.4.4`).
+2. Reviewer + merge as usual.
+3. Tag the merged commit with the bare version: `git tag v0.4.4 && git push origin v0.4.4`.
+4. CI publishes with `dist-tag=latest`.
+
+### Doc-only PRs
+
+Per governance, doc-only PRs are EXEMPT from rc.N bumping — they merge without a version bump and get picked up by the next code-touching PR's rc bump (or by the stable promotion, whichever comes first). Don't fragment a release into many patch bumps mid-validation.
+
+If you DO need to ship a doc-only fix outside an active rc chain (i.e. main is on a stable version with no rc.N in flight), bump the next patch (`0.4.4` → `0.4.5`), tag, ship.
+
+## One-time setup (operator)
+
+Before the workflow can publish, this repo needs:
+
+**npm Trusted Publisher**: log into npmjs.com → package `@openparachute/scribe` → Settings → Trusted Publishers → "Add a new publisher" → choose **GitHub Actions**. Fill:
+- Organization: `ParachuteComputer`
+- Repository name: `parachute-scribe`
+- Workflow filename: `release.yml`
+- Environment name: (leave blank)
+
+No `NPM_TOKEN` secret needed — the workflow uses OIDC. The `id-token: write` permission on the `publish-npm` job makes the OIDC token available to the npm CLI; npm verifies it against the Trusted Publisher rule above.
+
+## Verifying a release
+
+```sh
+npm view @openparachute/scribe@<version> dist.tarball
+npm view @openparachute/scribe dist-tags
+```
+
+The npm tarball page links to the GitHub Actions run that produced it (provenance attestation).
+
+## Rolling back
+
+There's no clean "unpublish" path (npm has a strict 72-hour unpublish policy that you should avoid for published packages anyway). To roll back:
+
+- Cut a new patch from a known-good commit (e.g. `0.4.4` → `0.4.5` reverting the bad change).
+- Update consumers' `dist-tag` pointer if needed (e.g. demote `latest` by tagging an older version: `npm dist-tag add @openparachute/scribe@0.4.3 latest`).
+
+## Troubleshooting
+
+- **Workflow doesn't trigger**: confirm the tag matches the workflow's `on.push.tags` pattern (`v[0-9]+.[0-9]+.[0-9]+` or `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+`).
+- **`version mismatch` error in publish-npm**: package.json version differs from the tag. Re-tag the correct commit.
+- **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-scribe` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
+- **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` + `RELEASING.md` to scribe, mirroring the canonical release-CI pattern just landed in parachute-hub.

Pushing a semver tag (`v0.X.Y` or `v0.X.Y-rc.N`) triggers CI to:
1. Run `bun run typecheck` + `bun test src/`
2. Publish `@openparachute/scribe` to npm with provenance attestation, dist-tag `rc` or `latest` (auto-detected from tag string)

## Differences vs hub's release.yml

- **Single-package repo** — no workspace sub-packages, no scope-guard split.
- **No container image** — scribe ships as a pure npm package, so the `publish-image` job is omitted entirely.
- **Trusted Publishing (OIDC)** — uses `actions/setup-node@v4` with `node-version: '24'` (npm 11.5+ has OIDC built in) + `permissions: id-token: write` on `publish-npm`. No `NPM_TOKEN` secret. Operator one-time setup is documented in RELEASING.md.
- Test gate cites scribe's canonical `bun test src/` (matches `package.json` `"test"` script).

## Version

Unchanged. Scribe's npm `@rc` and the repo are both at `0.4.4-rc.7`, so the workflow lands dormant — no tag will be pushed off this PR. The next code-touching rc bump fires it for real.

## Pattern references

- [parachute-patterns/patterns/release-ci.md](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/release-ci.md)
- [parachute-patterns#91](https://github.com/ParachuteComputer/parachute-patterns/issues/91)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/` — 375 pass / 0 fail
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No `NPM_TOKEN` references except in explanatory comments stating it's not needed
- [ ] Operator: configure Trusted Publisher on npmjs.com (`@openparachute/scribe` → org `ParachuteComputer`, repo `parachute-scribe`, workflow `release.yml`, env blank) before pushing the first tag post-merge
- [ ] Smoke: after merge, the first rc-chain tag push fires the workflow and publishes successfully

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>