### PR TITLE
feat(scribe): declare uiUrl per design-system + module-ui-declaration (workstream C)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,6 +7,7 @@
   "paths": ["/scribe"],
   "health": "/health",
   "stripPrefix": true,
+  "uiUrl": "/scribe/admin",
   "startCmd": ["parachute-scribe", "serve"],
   "scopes": {
     "defines": ["scribe:transcribe", "scribe:admin"]


### PR DESCRIPTION
## Summary

Adds `"uiUrl": "/scribe/admin"` to `.parachute/module.json` (single-instance form), following the pattern legitimized in [parachute-patterns#96](https://github.com/ParachuteComputer/parachute-patterns/pull/96) (merged at `aa55fb5`).

Scribe ships a real operator-facing admin page (`src/admin-ui.ts` — provider status, credential clearing, config form) but it's invisible to hub's discovery page today because module.json doesn't declare the URL. The pattern doc names scribe's row explicitly in §"Examples".

## Shape

Single-instance — `uiUrl` is the **hub-origin path directly** (no per-instance prefix needed; only vault is multi-instance today). Hub's `loadServiceUiMetadata` (`parachute-hub/src/hub-server.ts:741`) reads this on each well-known request and surfaces it to the discovery page's `renderServices`, which then renders one tile per declaring service.

## Path verification

Verified the path resolves end-to-end through the proxy:

- module.json: `paths: ["/scribe"]`, `stripPrefix: true`, `uiUrl: "/scribe/admin"`
- Hub mounts scribe at `/scribe` with strip-prefix
- External request `/scribe/admin` strips to scribe-internal `/admin`
- `src/server.ts:181` matches `internalPath === "/admin" || internalPath === "/scribe/admin"` and serves the SPA page (the legacy `/scribe/admin` alias is kept for callers that didn't strip)

## No self-register change needed

Hub reads `uiUrl` from `installDir/.parachute/module.json` per request, not from services.json — same pattern that `displayName` / `tagline` already use. The existing `self-register.test.ts:205-238` "hub-stamped fields survive merge" test already exercises uiUrl pass-through (the fixture seeds `uiUrl: "/scribe/admin"` on a prior services.json row and asserts it survives self-register's merge).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 375 pass / 0 fail / 794 expect calls
- [x] No test changes required — existing tests already cover the field shape
- [ ] Reviewer subagent — focus: (a) JSON shape matches pattern doc single-instance example exactly, (b) `/scribe/admin` path resolves via the proxy as expected, (c) no other tests assert on uiUrl's absence

## References

- parachute-patterns#96 (merged at `aa55fb5`) — the pattern doc
- [`patterns/module-ui-declaration.md` §"Examples" — scribe row](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md#examples)
- `parachute-hub/AUDIT-UI-UX.md` §5 row C — the audit row this closes (scribe side)

## Workstream C arc

- PR 1: parachute-patterns#96 — pattern doc — **MERGED**
- PR 2: parachute-vault#367 — vault declares `uiUrl: "/admin/"` — **OPEN (awaits Aaron)**
- PR 3: this PR — scribe declares `uiUrl: "/scribe/admin"`
- PR 4: parachute-hub — lift `loadServiceUiMetadata` vault-skip + per-instance prefix in `buildWellKnown` + retire hardcoded `Browse Vault` tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)