### PR TITLE
fix(admin-ui): detect mount at runtime so /scribe/admin works through hub proxy

### DIFF
--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for `renderAdminPage()`. Focused on the runtime-mount-detection
+ * shape — the load-bearing fix for the "hub strips /scribe before
+ * forwarding" case where server-side `mount` is empty but the browser
+ * page URL is `/scribe/admin`.
+ *
+ * No DOM tests here; this just verifies the rendered HTML strings
+ * carry the right script shape.
+ */
+import { describe, expect, test } from "bun:test";
+import { renderAdminPage } from "./admin-ui.ts";
+
+describe("renderAdminPage", () => {
+  test("renders with the server-side mount in the visible chrome", () => {
+    const html = renderAdminPage("/scribe");
+    expect(html).toContain('href="/scribe/.parachute/config"');
+    expect(html).toContain('href="/scribe/.parachute/config/schema"');
+  });
+
+  test("renders with empty server-side mount → visible URLs at root", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain('href="/.parachute/config"');
+    expect(html).toContain('href="/.parachute/config/schema"');
+  });
+
+  test("inline script contains the runtime-mount-detection function", () => {
+    const html = renderAdminPage("");
+    // The detection function strips /scribe/admin and /admin suffixes
+    // from window.location.pathname. The test asserts both literal
+    // suffix strings are present in the script body — guards against
+    // a future refactor accidentally removing the legacy alias.
+    expect(html).toContain('"/scribe/admin"');
+    expect(html).toContain('"/admin"');
+    expect(html).toContain("window.location.pathname");
+    expect(html).toContain("__SCRIBE_CONFIG_URL__");
+    expect(html).toContain("__SCRIBE_SCHEMA_URL__");
+  });
+
+  test("inline script falls back to server-rendered URLs when detection fails", () => {
+    // The detection function returns null when window.location is
+    // unavailable. The script then uses the server-rendered fallback
+    // (the literal string the server interpolated).
+    const html = renderAdminPage("/scribe");
+    // The fallback values are JSON-encoded literals in the script.
+    expect(html).toContain('"/scribe/.parachute/config"');
+    expect(html).toContain('"/scribe/.parachute/config/schema"');
+  });
+
+  test("inline script uses runtime-detected mount, not server-side, as primary", () => {
+    // Pure structural check: the runtime-detection branch must come
+    // FIRST in the if/else. If a refactor flips the priority, the
+    // bug Aaron hit (server-side mount = "" but real public mount is
+    // /scribe) reappears.
+    const html = renderAdminPage("");
+    const runtimeIdx = html.indexOf("runtimeMount + ");
+    const fallbackIdx = html.indexOf("= serverConfigUrl");
+    expect(runtimeIdx).toBeGreaterThan(-1);
+    expect(fallbackIdx).toBeGreaterThan(-1);
+    // The runtime + branch should appear AFTER the fallback branch in
+    // the if/else (the fallback is the `if (runtimeMount === null)`
+    // arm; runtime is the `else` arm).
+    // Both should be present and the script should reference both.
+    expect(html).toContain("runtimeMount === null");
+  });
+});

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -46,20 +46,16 @@ describe("renderAdminPage", () => {
     expect(html).toContain('"/scribe/.parachute/config/schema"');
   });
 
-  test("inline script uses runtime-detected mount, not server-side, as primary", () => {
-    // Pure structural check: the runtime-detection branch must come
-    // FIRST in the if/else. If a refactor flips the priority, the
-    // bug Aaron hit (server-side mount = "" but real public mount is
-    // /scribe) reappears.
+  test("inline script wires both runtime and fallback URL branches", () => {
+    // Pure structural check: the runtime-detected branch (uses
+    // `runtimeMount + ...`) and the server-rendered fallback branch
+    // (uses the JSON-encoded server values) must BOTH be present and
+    // gated by the `runtimeMount === null` discriminator. If a
+    // refactor removes either branch, the bug Aaron hit (server-side
+    // mount = "" but real public mount is /scribe) reappears.
     const html = renderAdminPage("");
-    const runtimeIdx = html.indexOf("runtimeMount + ");
-    const fallbackIdx = html.indexOf("= serverConfigUrl");
-    expect(runtimeIdx).toBeGreaterThan(-1);
-    expect(fallbackIdx).toBeGreaterThan(-1);
-    // The runtime + branch should appear AFTER the fallback branch in
-    // the if/else (the fallback is the `if (runtimeMount === null)`
-    // arm; runtime is the `else` arm).
-    // Both should be present and the script should reference both.
+    expect(html).toContain("runtimeMount + ");
+    expect(html).toContain("= serverConfigUrl");
     expect(html).toContain("runtimeMount === null");
   });
 });

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -174,10 +174,15 @@ export function renderAdminPage(mount = ""): string {
       function detectMount() {
         try {
           var path = window.location.pathname.replace(/\\/+$/, "");
-          // Canonical suffix: /admin. Legacy alias: /scribe/admin.
+          // Hub-proxy path: /scribe/admin (full prefix included pre-strip).
+          // Loopback / direct path: /admin (no prefix).
+          // Both served by the same handler in src/server.ts.
           if (path.endsWith("/scribe/admin")) return path.slice(0, -"/scribe/admin".length);
           if (path.endsWith("/admin")) return path.slice(0, -"/admin".length);
-          return "";
+          // Unrecognized suffix — return null so the server-rendered
+          // fallback fires. Avoids silently producing wrong URLs if a
+          // future proxy nests scribe under a non-canonical shape.
+          return null;
         } catch (_e) {
           return null;
         }

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -58,9 +58,16 @@ const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", mono
  * shape for direct-loopback callers. Issue #39.
  */
 export function renderAdminPage(mount = ""): string {
-  // Build the mount-aware URLs server-side so the page script is a
-  // pure no-state interpolation. `mount` is already normalized by the
-  // server boot path (see `src/mount.ts`).
+  // Server-side `mount` builds the visible "Live values" links in the
+  // page chrome. For the in-page JS fetches we ALSO detect the mount
+  // at runtime from `window.location.pathname` (see the inline
+  // <script> below) — that path is the one that works when scribe is
+  // launched without `--mount` and accessed through the hub's
+  // `/scribe` proxy (the hub strips the `/scribe` prefix before
+  // forwarding, so scribe's request-level mount is empty even though
+  // the public mount is `/scribe`). Without the runtime fallback the
+  // page hits `/.parachute/config/schema` at the origin root and the
+  // hub 404s. Aaron hit this 2026-05-27 on the live deploy.
   const configUrl = `${mount}/.parachute/config`;
   const schemaUrl = `${mount}/.parachute/config/schema`;
   return `<!doctype html>
@@ -141,11 +148,51 @@ export function renderAdminPage(mount = ""): string {
   </main>
 
   <script>
-    // Mount-prefix the page-script's fetch URLs see. Server-rendered so
-    // the script body can stay a plain string literal (no per-request
-    // template interpolation inside the script itself). Issue #39.
-    window.__SCRIBE_CONFIG_URL__ = ${JSON.stringify(configUrl)};
-    window.__SCRIBE_SCHEMA_URL__ = ${JSON.stringify(schemaUrl)};
+    // Mount-prefix the page-script's fetch URLs see. Two sources of
+    // truth here, in priority order:
+    //
+    //   1. RUNTIME detection from window.location.pathname (the
+    //      load-bearing path). The admin page is served at
+    //      \`<mount>/admin\` (canonical) or \`<mount>/scribe/admin\`
+    //      (legacy alias). Strip the suffix to recover \`<mount>\`.
+    //      Works regardless of how scribe was launched: direct
+    //      loopback (mount = ""), through a hub mounted at /scribe
+    //      (mount = "/scribe"), or any custom prefix.
+    //
+    //   2. SERVER-rendered fallback (\`${schemaUrl}\` etc.) — used
+    //      only when window.location is unavailable (server-side
+    //      render harness, future SSR, paranoid env).
+    //
+    // Aaron hit the wrong-URL bug on 2026-05-27 when scribe was
+    // launched without \`--mount /scribe\` but accessed through the
+    // hub's /scribe proxy. The hub strips /scribe before forwarding,
+    // so scribe's server-side mount is "", but the browser-visible
+    // page URL is /scribe/admin and the schema lives at
+    // /scribe/.parachute/config/schema. Runtime detection captures
+    // this without needing the launcher to pass --mount.
+    (function () {
+      function detectMount() {
+        try {
+          var path = window.location.pathname.replace(/\\/+$/, "");
+          // Canonical suffix: /admin. Legacy alias: /scribe/admin.
+          if (path.endsWith("/scribe/admin")) return path.slice(0, -"/scribe/admin".length);
+          if (path.endsWith("/admin")) return path.slice(0, -"/admin".length);
+          return "";
+        } catch (_e) {
+          return null;
+        }
+      }
+      var runtimeMount = detectMount();
+      var serverConfigUrl = ${JSON.stringify(configUrl)};
+      var serverSchemaUrl = ${JSON.stringify(schemaUrl)};
+      if (runtimeMount === null) {
+        window.__SCRIBE_CONFIG_URL__ = serverConfigUrl;
+        window.__SCRIBE_SCHEMA_URL__ = serverSchemaUrl;
+      } else {
+        window.__SCRIBE_CONFIG_URL__ = runtimeMount + "/.parachute/config";
+        window.__SCRIBE_SCHEMA_URL__ = runtimeMount + "/.parachute/config/schema";
+      }
+    })();
   </script>
   <script>${PAGE_SCRIPT}</script>
 </body>


### PR DESCRIPTION
## Summary

Aaron hit \`Could not load configuration. schema fetch failed (404)\` loading scribe's admin page through the hub's /scribe proxy on 2026-05-27.

### Root cause

Scribe's startCmd in parachute-hub's service-spec is \`["parachute-scribe", "serve"]\` — no \`--mount\` flag. The hub's proxy strips /scribe before forwarding, so scribe's server-side \`mount\` is \`""\`. The admin page rendered absolute URLs at origin root (\`/.parachute/config/schema\`). When loaded through the hub at \`https://aaron.parachute.computer/scribe/admin\`, the browser fetched \`https://aaron.parachute.computer/.parachute/config/schema\` — the hub doesn't route that bare path to scribe → 404.

### Fix

Runtime mount detection. The inline \`<script>\` block now derives the mount from \`window.location.pathname\`, stripping the \`/admin\` or \`/scribe/admin\` suffix. Server-rendered URLs become the fallback (used only when window.location is unavailable).

Works for every shape:
- Direct loopback (\`http://127.0.0.1:1943/admin\`) → mount = \`""\`
- Through hub's /scribe proxy (\`http://hub/scribe/admin\`) → mount = \`/scribe\`
- Custom mount through proxy (\`http://hub/foo/scribe/admin\`) → mount = \`/foo\`

Visible "Live values" debug links still use the server-side \`mount\` (they're informational; not worth JS-rewriting \`<a href>\`s after render). The functional fetches are correct.

## Alternative fix considered

Adding \`--mount /scribe\` to scribe's startCmd in parachute-hub's service-spec. Requires scribe NOT to strip the mount internally (hub already strips). Bigger refactor. Runtime detection ships the fix today; launcher cleanup can follow.

## Test plan

- [x] \`bun test ./src\` → 380/380 pass (+5 new admin-ui.test.ts cases)
- [x] \`bun run typecheck\` → clean
- [x] biome clean on touched files
- [ ] Reviewer to verify the inline JS detection logic doesn't break for unusual page-URL shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)