### PR TITLE
chore(release): 0.4.5-rc.1 — scribe admin fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.4",
+  "version": "0.4.5-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bump to 0.4.5-rc.1. Aaron-authorized 2026-05-27 ("push to rc — testing on another machine").

Code-touching PR since v0.4.4 stable:
- #60 fix(admin-ui): detect mount at runtime so /scribe/admin works through hub proxy

The admin page's schema-fetch 404 on the live deploy is now closed. Runtime mount detection makes the bundle work regardless of how scribe was launched.

Next patch from v0.4.4 stable.

## Test plan

- [x] #60 merged with green CI
- [ ] Tag push `v0.4.5-rc.1` after merge → CI publishes to @rc