### PR TITLE
fix(admin-ui): strip just /admin to recover mount (404 fix #2) + rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.5-rc.1",
+  "version": "0.4.5-rc.2",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -59,3 +59,87 @@ describe("renderAdminPage", () => {
     expect(html).toContain("runtimeMount === null");
   });
 });
+
+/**
+ * Behavioral tests for the inline `detectMount` function. We extract
+ * the JS body via regex + evaluate it under a stubbed `window` so we
+ * can assert the actual return value for each pathname shape — not
+ * just the presence of source strings.
+ *
+ * Pinning the regression Aaron hit twice:
+ *   1. Original bug — pathname `/scribe/admin` produced mount `""`
+ *      because no detection logic existed at all (server-side mount
+ *      was "" because scribe was launched without --mount).
+ *   2. First-fix bug — pathname `/scribe/admin` STILL produced mount
+ *      `""` because the detection function's first branch stripped
+ *      the ENTIRE `/scribe/admin` suffix. The fix in this PR strips
+ *      just `/admin`, leaving `/scribe` as the prefix.
+ */
+function extractAndRunDetectMount(pathname: string): string | null {
+  const html = renderAdminPage("");
+  // The detect function body is the function literal in the inline
+  // <script>. Grab it via a sentinel comment + run it in a stubbed
+  // window context.
+  const start = html.indexOf("function detectMount()");
+  if (start === -1) throw new Error("detectMount not found in rendered HTML");
+  // Find the matching closing brace for the function body. Simple
+  // brace-counting since the body is well-formed.
+  let depth = 0;
+  let i = html.indexOf("{", start);
+  const bodyStart = i;
+  for (; i < html.length; i++) {
+    if (html[i] === "{") depth++;
+    else if (html[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  const fnSource = `(function () { ${html.slice(start, i + 1)} return detectMount; })`;
+  // biome-ignore lint/security/noGlobalEval: test-only eval of trusted source rendered by the page.
+  const factory = eval(fnSource);
+  const fn = factory();
+  // Stub window.location.pathname in a sandboxed global.
+  const prevWindow = (globalThis as { window?: { location: { pathname: string } } }).window;
+  (globalThis as { window?: { location: { pathname: string } } }).window = {
+    location: { pathname },
+  };
+  try {
+    return fn() as string | null;
+  } finally {
+    if (prevWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = prevWindow;
+    }
+  }
+  // Use `bodyStart` to silence lint (the brace-finder uses it as the entry index).
+  void bodyStart;
+}
+
+describe("detectMount runtime behavior", () => {
+  test("/admin (direct loopback) → mount = \"\"", () => {
+    expect(extractAndRunDetectMount("/admin")).toBe("");
+  });
+
+  test("/scribe/admin (hub proxy) → mount = \"/scribe\"", () => {
+    // Load-bearing assertion. The original bug AND the first-fix bug
+    // both produced "" here. The fix in this PR returns "/scribe".
+    expect(extractAndRunDetectMount("/scribe/admin")).toBe("/scribe");
+  });
+
+  test("/some/custom/prefix/admin → mount = \"/some/custom/prefix\"", () => {
+    expect(extractAndRunDetectMount("/some/custom/prefix/admin")).toBe("/some/custom/prefix");
+  });
+
+  test("/admin/ (trailing slash) → mount = \"\"", () => {
+    expect(extractAndRunDetectMount("/admin/")).toBe("");
+  });
+
+  test("/scribe/admin/ (trailing slash) → mount = \"/scribe\"", () => {
+    expect(extractAndRunDetectMount("/scribe/admin/")).toBe("/scribe");
+  });
+
+  test("unrecognized path → null (server fallback fires)", () => {
+    expect(extractAndRunDetectMount("/some/other/page")).toBeNull();
+  });
+});

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -174,10 +174,21 @@ export function renderAdminPage(mount = ""): string {
       function detectMount() {
         try {
           var path = window.location.pathname.replace(/\\/+$/, "");
-          // Hub-proxy path: /scribe/admin (full prefix included pre-strip).
-          // Loopback / direct path: /admin (no prefix).
-          // Both served by the same handler in src/server.ts.
-          if (path.endsWith("/scribe/admin")) return path.slice(0, -"/scribe/admin".length);
+          // The admin page is served at <mount>/admin. Strip just
+          // the trailing "/admin" segment to recover <mount>.
+          //
+          // Works for every shape (Aaron's fix #2 — the prior version
+          // had a buggy "/scribe/admin" first-branch that stripped the
+          // ENTIRE path, leaving mount="" for the hub-proxy case):
+          //
+          //   /admin           → mount = ""        (direct loopback)
+          //   /scribe/admin    → mount = "/scribe" (hub proxy)
+          //   /any/path/admin  → mount = "/any/path" (custom proxy)
+          //
+          // The dedicated /scribe/admin route in src/server.ts is a
+          // legacy alias scribe handles too — but for the purposes of
+          // the BROWSER, the path is just a path; what we need is the
+          // prefix that comes BEFORE /admin to build sibling URLs.
           if (path.endsWith("/admin")) return path.slice(0, -"/admin".length);
           // Unrecognized suffix — return null so the server-rendered
           // fallback fires. Avoids silently producing wrong URLs if a


### PR DESCRIPTION
## Summary

Aaron hit the same 404 again after pulling 0.4.5-rc.1. Root cause: the runtime mount detection in #60 had a logic error.

### The bug

For pathname \`/scribe/admin\` the first \`endsWith(\"/scribe/admin\")\` branch fired and stripped the ENTIRE 13-char suffix, leaving \`mount = \"\"\` — same as the original bug.

### The fix

Strip JUST \`/admin\` to recover the prefix that comes before it. Works for every shape:

  - \`/admin\` → mount = \`\"\"\` (direct loopback)
  - \`/scribe/admin\` → mount = \`\"/scribe\"\` (hub proxy — load-bearing case)
  - \`/any/prefix/admin\` → mount = \`\"/any/prefix\"\` (custom proxy)

### Why the prior tests didn't catch it

They were structural string-presence checks (\"the script contains '/scribe/admin'\"). Both branches' source code was present. Nothing exercised the actual return value.

This PR adds **6 behavioral tests** that eval the inline \`detectMount\` function under a stubbed \`window.location.pathname\` and assert the actual return value for each shape — including the failing case \`(\"/scribe/admin\") === \"/scribe\"\`.

Bumps to 0.4.5-rc.2.

## Test plan

- [x] \`bun test ./src\` → 386/386 pass (+6 new behavioral tests)
- [x] \`bun run typecheck\` → clean
- [ ] Aaron pulls + restarts → schema fetch works through the hub proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)