### PR TITLE
fix(admin-ui): override fieldset display so [hidden] hides the loading legend

### DIFF
--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -46,6 +46,20 @@ describe("renderAdminPage", () => {
     expect(html).toContain('"/scribe/.parachute/config/schema"');
   });
 
+  test("STYLES carries fieldset[hidden] override so the loading legend can be hidden", () => {
+    // The 'fieldset { display: flex }' rule in the styles block beats the
+    // UA-stylesheet `[hidden] { display: none }` in specificity (author
+    // element selector vs. UA attribute selector), so without an explicit
+    // `fieldset[hidden] { display: none !important }` the `hidden` attribute
+    // toggles in loadConfig() set the attribute but don't visually hide the
+    // legend — operator sees both "Loading current configuration…" AND the
+    // rendered form fields stacked together. Caught 2026-05-27 on Aaron's
+    // deploy after the 0.4.5 mount-detect fix made the form reachable.
+    const html = renderAdminPage("");
+    expect(html).toContain("fieldset[hidden]");
+    expect(html).toContain("display: none !important");
+  });
+
   test("inline script wires both runtime and fallback URL branches", () => {
     // Pure structural check: the runtime-detected branch (uses
     // `runtimeMount + ...`) and the server-rendered fallback branch

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -335,6 +335,18 @@ const STYLES = `
     flex-direction: column;
     gap: 1rem;
   }
+  /* The 'hidden' HTML attribute resolves to UA-stylesheet 'display: none',
+   * which loses specificity to the author-stylesheet 'fieldset { display:
+   * flex; }' rule above. Without this override, el("form-loading").hidden
+   * = true sets the attribute but the loading legend stays visible —
+   * stacked on top of the loaded form below it. The operator sees BOTH
+   * "Loading current configuration…" AND the rendered fields. Same
+   * collision applies to #form-body's initial 'hidden' state (it hides
+   * via the display: none rule below before applyConfig runs), so the
+   * !important is necessary to make the attribute reliably win over any
+   * fieldset display rule. Caught 2026-05-27 on Aaron's deploy after the
+   * 0.4.5 mount-detect fix made the form actually reachable. */
+  fieldset[hidden] { display: none !important; }
   fieldset.loading {
     padding: 1.25rem;
     background: ${PALETTE.bgSoft};


### PR DESCRIPTION
## Summary

The author-stylesheet `fieldset { display: flex }` rule beats the UA-stylesheet `[hidden] { display: none }` rule in specificity, so when `loadConfig()` sets `el(\"form-loading\").hidden = true` the attribute lands but the legend stays visually present. Operator sees both **\"Loading current configuration…\"** AND the rendered form fields stacked together.

Add an explicit `fieldset[hidden] { display: none !important }` rule to the STYLES block so the attribute toggle reliably clears the legend.

## Root cause

CSS specificity:
- `fieldset { display: flex }` — author element selector, specificity (0,0,1)
- `[hidden] { display: none }` — **UA** attribute selector, loses to any author rule on the same property

The `hidden` HTML attribute is implemented as a UA stylesheet rule, not browser-native magic. An author rule on `fieldset`'s `display` property silently overrides it.

The bug surfaced after 0.4.5's mount-detect fix (#62) made the form reachable on Aaron's live deploy — pre-fix, the page never loaded so the loading legend never got a chance to be stuck visible alongside the form.

## Test plan

- [x] `bun test ./src` — 387 pass (was 386; +1 new test pinning the rule)
- [x] `bun run typecheck` clean
- [ ] Aaron loads the live deploy: only the rendered form is visible (no \"Loading…\" legend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)