### PR TITLE
release: scribe 0.4.5 (stable cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.5-rc.3",
+  "version": "0.4.5",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Drop -rc → 0.4.5. Admin-UI-through-proxy fixes. Release mechanic on Aaron's ship.