### PR TITLE
feat(scribe): config UX — backend availability warnings + surfaced cleanup tuning + token refresh

### DIFF
--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -340,7 +340,12 @@ describe("GET /scribe/admin", () => {
     const handler = buildHandler("/tmp/unused");
     const res = await handler(new Request("http://localhost/scribe/admin"));
     const html = await res.text();
-    expect(html).toContain("Restart scribe to apply");
+    // Change 4 — restart-required banner copy. The phrasing now leads with
+    // "Saved — but not live yet" (rendered from the &mdash; entity) and spells
+    // out the exact restart command so the operator doesn't assume a new
+    // backend is live before restarting.
+    expect(html).toContain("Saved &mdash; but not live yet");
+    expect(html).toContain("parachute restart scribe");
     expect(html).toContain("Transcription provider");
     expect(html).toContain("Cleanup provider");
   });
@@ -382,5 +387,60 @@ describe("GET /scribe/admin", () => {
       }),
     );
     expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /admin/backend-availability", () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  test("open mode → 200 with transcribe + cleanup report shape", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    // Inject a setup-token stub so the claude-code probe doesn't read the
+    // real ~/.claude.json on the test host.
+    const handler = buildHandler("/tmp/unused", {
+      setupTokenStatusFn: () => "not-configured",
+    });
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      transcribe: Record<string, { status: string }>;
+      cleanup: Record<string, { status: string }>;
+    };
+    expect(body.transcribe).toBeObject();
+    expect(body.cleanup).toBeObject();
+    // Every backend gets a verdict with a status string.
+    expect(body.cleanup["none"]?.status).toBe("ok-no-check");
+    expect(typeof body.transcribe["onnx-asr"]?.status).toBe("string");
+  });
+
+  test("closed mode without bearer → 401 (scribe:admin gated)", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("POST to the availability endpoint → 404 (GET-only)", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -157,3 +157,42 @@ describe("detectMount runtime behavior", () => {
     expect(extractAndRunDetectMount("/some/other/page")).toBeNull();
   });
 });
+
+describe("config UX additions (scribe config-UX PR)", () => {
+  test("renders inline backend-status containers for both provider selects", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain('id="status-transcribeProvider"');
+    expect(html).toContain('id="status-cleanupProvider"');
+  });
+
+  test("script fetches the backend-availability endpoint", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain("/admin/backend-availability");
+    expect(html).toContain("checkAvailability");
+  });
+
+  test("promotes a labeled 'Cleanup tuning' section with both knobs", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain("Cleanup tuning");
+    // Both fields still present, now inside the section.
+    expect(html).toContain('name="cleanupSystemPrompt"');
+    expect(html).toContain('name="cleanupContextTemplate"');
+    // Explains proper nouns are supplied per-request, not stored in config.
+    expect(html).toContain("per request");
+  });
+
+  test("wires the claude-code Refresh button + its endpoint", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain("claude-refresh-btn");
+    expect(html).toContain("/admin/refresh-claude-token-status");
+    expect(html).toContain("Refresh status");
+  });
+
+  test("restart banner is unmistakable + names the restart command", () => {
+    const html = renderAdminPage("");
+    // Source carries the &mdash; entity (non-ASCII glyphs are unreliable
+    // inside the String.raw page-script block — see admin-ui.ts).
+    expect(html).toContain("Saved &mdash; but not live yet");
+    expect(html).toContain("parachute restart scribe");
+  });
+});

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -104,12 +104,17 @@ export function renderAdminPage(mount = ""): string {
             <span class="field-label">Transcription provider</span>
             <select name="transcribeProvider" id="f-transcribeProvider"></select>
             <span class="field-hint" id="hint-transcribeProvider">Engine used to turn audio into text.</span>
+            <!-- Inline availability status for the SELECTED transcription
+                 backend. Populated by checkAvailability() — ✓ available, or
+                 ⚠ with the exact fix. Non-blocking: it never prevents save. -->
+            <div class="backend-status" id="status-transcribeProvider" hidden></div>
           </label>
 
           <label class="field">
             <span class="field-label">Cleanup provider</span>
             <select name="cleanupProvider" id="f-cleanupProvider"></select>
             <span class="field-hint" id="hint-cleanupProvider">Optional LLM pass — pick "none" to skip cleanup.</span>
+            <div class="backend-status" id="status-cleanupProvider" hidden></div>
           </label>
 
           <label class="field field-inline">
@@ -118,17 +123,38 @@ export function renderAdminPage(mount = ""): string {
             <span class="field-hint" id="hint-cleanupDefault">Applied when a transcription request omits an explicit cleanup flag.</span>
           </label>
 
-          <label class="field">
-            <span class="field-label">Cleanup system prompt</span>
-            <textarea name="cleanupSystemPrompt" id="f-cleanupSystemPrompt" rows="10" placeholder="Leave empty to use scribe's built-in prompt."></textarea>
-            <span class="field-hint">Full override of the built-in cleanup system prompt. The proper-nouns block from the request payload is still appended after this.</span>
-          </label>
+          <!-- Cleanup tuning — promoted into its own labeled section so the
+               system-prompt + proper-nouns knobs are discoverable, not buried
+               below the provider selects. -->
+          <div class="section" id="cleanup-tuning">
+            <div class="section-head">
+              <h2 class="section-title">Cleanup tuning</h2>
+              <p class="section-desc">
+                Shape how the cleanup LLM rewrites raw transcripts. Both fields are optional —
+                leave them empty to use scribe's built-in defaults.
+              </p>
+            </div>
 
-          <label class="field">
-            <span class="field-label">Cleanup context template</span>
-            <textarea name="cleanupContextTemplate" id="f-cleanupContextTemplate" rows="4" placeholder="e.g. \\n\\nKnown names: {{proper_nouns}}"></textarea>
-            <span class="field-hint">Template for the proper-nouns block. Use <code>{{proper_nouns}}</code> as the placeholder. Leave empty to use scribe's default rule.</span>
-          </label>
+            <label class="field">
+              <span class="field-label">Cleanup system prompt</span>
+              <textarea name="cleanupSystemPrompt" id="f-cleanupSystemPrompt" rows="10" placeholder="Leave empty to use scribe's built-in prompt."></textarea>
+              <span class="field-hint">
+                A full override of scribe's built-in cleanup instructions (filler-word removal, punctuation, formatting).
+                The proper-nouns / vocabulary block is still appended after this.
+              </span>
+            </label>
+
+            <label class="field">
+              <span class="field-label">Proper-nouns / vocabulary template</span>
+              <textarea name="cleanupContextTemplate" id="f-cleanupContextTemplate" rows="4" placeholder="e.g. \\n\\nKnown names &amp; terms: {{proper_nouns}}"></textarea>
+              <span class="field-hint">
+                Controls how vocabulary hints are appended to the prompt. Use <code>{{proper_nouns}}</code> as the placeholder.
+                Leave empty to use scribe's default rule.
+                <strong>Note:</strong> the proper nouns themselves are supplied <em>per request</em> (in the transcription
+                request's <code>context</code> part) — they are not stored here. This field only sets the wrapping template.
+              </span>
+            </label>
+          </div>
         </fieldset>
 
         <div class="button-row" id="button-row" hidden>
@@ -390,6 +416,94 @@ const STYLES = `
     font-weight: 500;
   }
 
+  /* Inline per-backend availability status — sits directly under the
+     provider select it describes. Three visual states keyed off the
+     server-computed verdict: ok (green ✓), warn (amber ⚠ + fix), unknown
+     (muted). NON-BLOCKING by design — purely advisory. */
+  .backend-status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.45rem;
+    padding: 0.55rem 0.7rem;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    border: 1px solid transparent;
+  }
+  .backend-status .bs-line { display: flex; align-items: baseline; gap: 0.4rem; }
+  .backend-status .bs-icon { font-size: 0.9rem; line-height: 1; }
+  .backend-status .bs-detail { font-weight: 500; }
+  .backend-status .bs-fix {
+    margin: 0;
+    font-weight: 400;
+    line-height: 1.45;
+    opacity: 0.95;
+  }
+  .backend-status code {
+    font-family: ${FONT_MONO};
+    font-size: 0.85em;
+    background: rgba(0,0,0,0.05);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+  .backend-status .bs-actions { margin-top: 0.35rem; }
+  .bs-ok {
+    background: ${PALETTE.successSoft};
+    border-color: ${PALETTE.success};
+    color: ${PALETTE.success};
+  }
+  .bs-warn {
+    background: ${PALETTE.dangerSoft};
+    border-color: ${PALETTE.danger};
+    color: ${PALETTE.danger};
+  }
+  .bs-unknown {
+    background: ${PALETTE.bgSoft};
+    border-color: ${PALETTE.border};
+    color: ${PALETTE.fgMuted};
+  }
+  /* A small inline button used inside a backend-status block (the claude-code
+     Refresh affordance). Smaller than the form buttons; inherits the status
+     color for its border so it reads as part of the block. */
+  .bs-btn {
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.3rem 0.7rem;
+    border-radius: 5px;
+    border: 1px solid currentColor;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .bs-btn:hover { background: rgba(0,0,0,0.06); }
+  .bs-btn:disabled { opacity: 0.6; cursor: progress; }
+
+  /* Cleanup tuning section — a labeled, visually-separated block so the
+     prompt + vocabulary knobs are discoverable instead of buried. */
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
+  .section-head { display: flex; flex-direction: column; gap: 0.3rem; }
+  .section-title {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.2rem;
+    margin: 0;
+    color: ${PALETTE.fg};
+  }
+  .section-desc {
+    margin: 0;
+    font-size: 0.85rem;
+    color: ${PALETTE.fgMuted};
+  }
+  .field-hint em { font-style: italic; }
+
   select, textarea, input[type=text], input[type=number] {
     font: inherit;
     width: 100%;
@@ -478,6 +592,11 @@ const STYLES = `
     .btn-secondary:hover { color: #e8e4dc; border-color: #6b6860; }
     .card-footer { border-color: #3a362f; }
     fieldset.loading { background: #1f1c18; }
+    .section { border-color: #3a362f; }
+    .section-title { color: #f0ece4; }
+    .section-desc { color: #a8a29a; }
+    .backend-status code { background: rgba(255,255,255,0.08); }
+    .bs-btn:hover { background: rgba(255,255,255,0.08); }
   }
 
   @media (max-width: 600px) {
@@ -510,6 +629,11 @@ const PAGE_SCRIPT = String.raw`
     cleanupProvider: "Cleanup provider",
     port: "Server port",
   };
+
+  // Latest backend-availability report (set by checkAvailability). Keyed by
+  // { transcribe: {name: {...}}, cleanup: {name: {...}} }. Held so a provider
+  // select-change can re-render the inline status without another fetch.
+  var AVAILABILITY = null;
 
   function el(id) { return document.getElementById(id); }
 
@@ -595,6 +719,119 @@ const PAGE_SCRIPT = String.raw`
     el(FIELD_IDS.cleanupContextTemplate).value = current.cleanupContextTemplate || "";
   }
 
+  // --- Backend availability (Change 1) -------------------------------------
+  //
+  // Fetch the server-side report and render the inline status for whatever
+  // backend is currently SELECTED in each provider dropdown. The report is
+  // advisory: we never disable Save based on it. A failed fetch leaves the
+  // status blocks hidden rather than erroring the page.
+
+  var STATUS_IDS = {
+    transcribeProvider: "status-transcribeProvider",
+    cleanupProvider: "status-cleanupProvider",
+  };
+
+  // Build the inner HTML for one status block from a verdict object.
+  function renderStatusInner(verdict, opts) {
+    opts = opts || {};
+    // Icons as HTML numeric entities -- NOT literal glyphs. This page-script
+    // string is a String.raw template, where non-ASCII source characters are
+    // unreliable (Bun's transpile can emit them as literal backslash-u escapes
+    // that String.raw then preserves verbatim). ASCII entities render fine via
+    // innerHTML on every browser: check = &#10003;, warn = &#9888;, info =
+    // &#8505;.
+    var icon;
+    var cls;
+    if (verdict.status === "available") { icon = "&#10003;"; cls = "bs-ok"; }
+    else if (verdict.status === "unavailable" || verdict.status === "warning") { icon = "&#9888;"; cls = "bs-warn"; }
+    else { icon = "&#8505;"; cls = "bs-unknown"; } // unknown / ok-no-check fall here; ok-no-check is filtered before render
+
+    var html = '<div class="bs-line"><span class="bs-icon">' + icon + '</span>' +
+      '<span class="bs-detail">' + escapeHtml(verdict.detail || "") + "</span></div>";
+    if (verdict.fix) {
+      html += '<p class="bs-fix">' + escapeHtml(verdict.fix) + "</p>";
+    }
+    if (opts.refreshButton) {
+      // The claude-code Refresh affordance (Change 3) -- re-reads the
+      // setup-token status + re-runs the availability probe in place.
+      html += '<div class="bs-actions">' +
+        '<button type="button" class="bs-btn" id="claude-refresh-btn">Refresh status</button>' +
+        "</div>";
+    }
+    return { html: html, cls: cls };
+  }
+
+  function renderBackendStatus(blockId, verdict, opts) {
+    var node = el(blockId);
+    if (!node) return;
+    // ok-no-check (e.g. cleanup "none", or a provider with no local dep AND no
+    // key requirement) -> nothing useful to show; keep the block hidden.
+    if (!verdict || verdict.status === "ok-no-check") {
+      node.hidden = true;
+      node.innerHTML = "";
+      node.className = "backend-status";
+      return;
+    }
+    var r = renderStatusInner(verdict, opts);
+    node.className = "backend-status " + r.cls;
+    node.innerHTML = r.html;
+    node.hidden = false;
+  }
+
+  // Re-render both inline status blocks for the currently-selected providers.
+  function refreshStatusDisplay() {
+    if (!AVAILABILITY) return;
+    var tName = el(FIELD_IDS.transcribeProvider).value;
+    var cName = el(FIELD_IDS.cleanupProvider).value;
+    var tVerdict = (AVAILABILITY.transcribe || {})[tName];
+    var cVerdict = (AVAILABILITY.cleanup || {})[cName];
+    renderBackendStatus(STATUS_IDS.transcribeProvider, tVerdict, {});
+    // The claude-code cleanup block gets the inline Refresh button.
+    renderBackendStatus(STATUS_IDS.cleanupProvider, cVerdict, {
+      refreshButton: cName === "claude-code",
+    });
+    wireClaudeRefresh();
+  }
+
+  async function checkAvailability() {
+    var base = (window.__SCRIBE_CONFIG_URL__ || "/.parachute/config").replace(/\/\.parachute\/config$/, "");
+    var url = base + "/admin/backend-availability";
+    try {
+      var res = await fetch(url);
+      if (!res.ok) return; // advisory: leave status hidden on non-200
+      AVAILABILITY = await res.json();
+      refreshStatusDisplay();
+    } catch (_e) {
+      // Network/parse failure -- advisory endpoint, swallow silently.
+    }
+  }
+
+  // --- claude-code Refresh button (Change 3) -------------------------------
+  function wireClaudeRefresh() {
+    var btn = el("claude-refresh-btn");
+    if (!btn) return;
+    btn.addEventListener("click", async function () {
+      btn.disabled = true;
+      var prev = btn.textContent;
+      // Plain ASCII "..." -- a literal ellipsis glyph in this String.raw block
+      // renders as a visible backslash-u escape in the served JS (Bun transpile
+      // + String.raw quirk). textContent can't use an HTML entity, so use "...".
+      btn.textContent = "Refreshing...";
+      var base = (window.__SCRIBE_CONFIG_URL__ || "/.parachute/config").replace(/\/\.parachute\/config$/, "");
+      try {
+        // POST /admin/refresh-claude-token-status re-reads ~/.claude.json. We
+        // then re-run the full availability probe so the inline status (CLI
+        // presence + token) updates in place without a page reload.
+        await fetch(base + "/admin/refresh-claude-token-status", { method: "POST" });
+      } catch (_e) { /* fall through to re-probe */ }
+      await checkAvailability();
+      // checkAvailability re-renders + re-wires; if it failed, restore the
+      // button so the operator can retry.
+      var stillThere = el("claude-refresh-btn");
+      if (stillThere) { stillThere.disabled = false; stillThere.textContent = prev; }
+    });
+  }
+
   async function loadConfig() {
     clearBanner();
     clearFieldErrors();
@@ -626,6 +863,9 @@ const PAGE_SCRIPT = String.raw`
       el("form-loading").hidden = true;
       el("form-body").hidden = false;
       el("button-row").hidden = false;
+      // Inline backend-availability status (Change 1) -- fire after the form
+      // is visible so a slow/failing probe never blocks rendering the config.
+      checkAvailability();
     } catch (err) {
       el("form-loading").hidden = true;
       setBanner(
@@ -641,7 +881,9 @@ const PAGE_SCRIPT = String.raw`
     clearFieldErrors();
     const saveBtn = el("save-btn");
     saveBtn.disabled = true;
-    saveBtn.textContent = "Saving…";
+    // ASCII "..." -- see the Refreshing button note: a literal ellipsis renders
+    // as a visible backslash-u escape in this String.raw page-script.
+    saveBtn.textContent = "Saving...";
 
     const body = collectForm();
     let res;
@@ -685,10 +927,10 @@ const PAGE_SCRIPT = String.raw`
     } else {
       const restart = (payload && payload.restart_required) || [];
       if (restart.length === 0) {
-        setBanner("success", "<strong>Configuration saved.</strong> Changes take effect immediately.");
+        setBanner("success", "<strong>Configuration saved.</strong> Changes take effect immediately &mdash; no restart needed.");
       } else {
         const items = restart.map(function (f) {
-          return "<li><code>" + escapeHtml(f) + "</code> — " + escapeHtml(RESTART_LABELS[f] || f) + "</li>";
+          return "<li><code>" + escapeHtml(f) + "</code> &mdash; " + escapeHtml(RESTART_LABELS[f] || f) + "</li>";
         }).join("");
         // Surface the port-is-not-in-config.json gotcha: when 'port' shows
         // up in restart_required, an unwary operator will edit config.json
@@ -699,11 +941,25 @@ const PAGE_SCRIPT = String.raw`
         const portNote = restart.indexOf("port") !== -1
           ? "<p class=\"banner-footnote\">Note: <code>port</code> is set via <code>services.json</code> or the <code>SCRIBE_PORT</code> environment variable, not <code>config.json</code>.</p>"
           : "";
+        // Change 4 -- make restart-required unmistakable + actionable. The
+        // saved value is on disk but the RUNNING server still uses the old
+        // provider until restart; an operator who doesn't restart thinks the
+        // new backend is live when it isn't. Spell out HOW to restart.
+        // Banner copy uses the &mdash; entity, not a literal em-dash -- see the
+        // icon-entity note above; non-ASCII glyphs in this String.raw block are
+        // unreliable. innerHTML renders &mdash; as the em-dash.
         setBanner(
           "success",
-          "<strong>Configuration saved.</strong> Restart scribe to apply these changes:<ul>" + items + "</ul>" + portNote
+          "<strong>Saved &mdash; but not live yet.</strong> These changes only take effect after you restart scribe:" +
+            "<ul>" + items + "</ul>" +
+            "<p class=\"banner-footnote\">Restart now: run <code>parachute restart scribe</code> (or restart it however you run scribe). " +
+            "Until you do, the server keeps using the previous setting.</p>" +
+            portNote
         );
       }
+      // A successful save can change availability (e.g. an API key was just
+      // stored) -- re-probe so the inline status reflects reality immediately.
+      checkAvailability();
     }
 
     saveBtn.disabled = false;
@@ -713,6 +969,11 @@ const PAGE_SCRIPT = String.raw`
   document.addEventListener("DOMContentLoaded", function () {
     el("config-form").addEventListener("submit", saveConfig);
     el("reload-btn").addEventListener("click", loadConfig);
+    // When the operator picks a different backend, re-render the inline
+    // availability status for the newly-selected one from the cached report
+    // (no refetch needed -- the report covers every backend).
+    el(FIELD_IDS.transcribeProvider).addEventListener("change", refreshStatusDisplay);
+    el(FIELD_IDS.cleanupProvider).addEventListener("change", refreshStatusDisplay);
     loadConfig();
   });
 `;

--- a/src/backend-availability.test.ts
+++ b/src/backend-availability.test.ts
@@ -267,6 +267,48 @@ describe("computeBackendAvailability — ollama + custom + none", () => {
     expect(v.detail).toContain("http://localhost:8080/v1");
   });
 
+  test("custom URL with embedded credentials → password not surfaced in detail", async () => {
+    // A custom endpoint of the form https://user:pass@host/v1 must not leak the
+    // embedded password into the admin-UI detail string. We echo only the
+    // credential-stripped origin + pathname.
+    const cfg: ScribeConfig = {
+      cleanupProviders: { custom: { url: "https://user:s3cr3t-pass@example.com/v1" } },
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: cfg,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["custom"]!;
+    expect(v.status).toBe("available");
+    // The password (and the userinfo separator) are gone…
+    expect(v.detail).not.toContain("s3cr3t-pass");
+    expect(v.detail).not.toContain("user:");
+    expect(v.detail).not.toContain("@");
+    // …but the operator still sees which host the endpoint points at.
+    expect(v.detail).toContain("https://example.com/v1");
+  });
+
+  test("custom URL that can't be parsed → generic echo-free detail", async () => {
+    // An unparseable URL falls back to a generic confirmation with no echo,
+    // rather than risk surfacing whatever the raw string contains.
+    const cfg: ScribeConfig = {
+      cleanupProviders: { custom: { url: "not a valid url with :pass@ in it" } },
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: cfg,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["custom"]!;
+    expect(v.status).toBe("available");
+    expect(v.detail).toBe("Endpoint URL set.");
+  });
+
   test("none → ok-no-check", async () => {
     const report = await computeBackendAvailability({
       which: whichWith([]),

--- a/src/backend-availability.test.ts
+++ b/src/backend-availability.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for per-backend availability detection.
+ *
+ * All side-effecting probes (`Bun.which`, ollama reachability, the
+ * setup-token reader) go through injectable seams so these tests are fully
+ * hermetic — they never touch the host PATH, network, or `~/.claude.json`.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  computeBackendAvailability,
+  type WhichFn,
+  type ReachFn,
+} from "./backend-availability.ts";
+import type { ScribeConfig } from "./config.ts";
+import type { SetupTokenStatus } from "./config-schema.ts";
+
+/** A which that reports the given set of bins as present, everything else absent. */
+function whichWith(present: string[]): WhichFn {
+  const set = new Set(present);
+  return (bin) => (set.has(bin) ? `/usr/local/bin/${bin}` : null);
+}
+
+const reachableTrue: ReachFn = async () => true;
+const reachableFalse: ReachFn = async () => false;
+
+function tokenStatus(s: SetupTokenStatus): () => SetupTokenStatus {
+  return () => s;
+}
+
+const EMPTY_CONFIG: ScribeConfig = {};
+const NO_ENV: Record<string, string | undefined> = {};
+
+describe("computeBackendAvailability — transcription binaries", () => {
+  test("onnx-asr missing → unavailable with pip install + ffmpeg fix", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["onnx-asr"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.detail).toContain("onnx-asr");
+    expect(v.fix).toContain("pip install onnx-asr");
+    // ffmpeg note appended since ffmpeg also absent.
+    expect(v.fix).toContain("ffmpeg");
+  });
+
+  test("onnx-asr present but ffmpeg missing → warning naming ffmpeg", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["onnx-asr"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["onnx-asr"]!;
+    expect(v.status).toBe("warning");
+    expect(v.detail).toContain("ffmpeg");
+    expect(v.fix).toContain("ffmpeg");
+  });
+
+  test("onnx-asr + ffmpeg both present → available", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["onnx-asr", "ffmpeg"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.transcribe["onnx-asr"]!.status).toBe("available");
+  });
+
+  test("whisper backend checks the whisper-ctranslate2 binary (not bare `whisper`)", async () => {
+    // Bare `whisper` present must NOT satisfy the whisper backend — the impl
+    // shells to `whisper-ctranslate2`.
+    const report = await computeBackendAvailability({
+      which: whichWith(["whisper"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["whisper"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.fix).toContain("whisper-ctranslate2");
+  });
+
+  test("parakeet-mlx missing → unavailable with install hint", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["parakeet-mlx"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.fix).toContain("parakeet-mlx");
+  });
+
+  test("which throwing degrades to unknown, never crashes", async () => {
+    const throwingWhich: WhichFn = () => {
+      throw new Error("boom");
+    };
+    const report = await computeBackendAvailability({
+      which: throwingWhich,
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.transcribe["onnx-asr"]!.status).toBe("unknown");
+  });
+});
+
+describe("computeBackendAvailability — API key backends", () => {
+  test("groq transcribe with no key → unavailable naming GROQ_API_KEY", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["groq"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.detail).toContain("GROQ_API_KEY");
+    expect(v.fix).toContain("GROQ_API_KEY");
+  });
+
+  test("anthropic cleanup with env key set → available", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: { ANTHROPIC_API_KEY: "sk-ant-xxx" },
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["anthropic"]!;
+    expect(v.status).toBe("available");
+    expect(v.detail).toContain("ANTHROPIC_API_KEY");
+  });
+
+  test("openai cleanup with config-stored key → available", async () => {
+    const cfg: ScribeConfig = {
+      cleanupProviders: { openai: { apiKey: "sk-stored" } },
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: cfg,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.cleanup["openai"]!.status).toBe("available");
+  });
+});
+
+describe("computeBackendAvailability — claude-code", () => {
+  test("claude missing → unavailable with install + setup-token fix", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["claude-code"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.fix).toContain("claude.com/claude-code");
+    expect(v.fix).toContain("setup-token");
+    expect(v.setupTokenStatus).toBe("not-configured");
+  });
+
+  test("claude present + token configured → available", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+    });
+    const v = report.cleanup["claude-code"]!;
+    expect(v.status).toBe("available");
+    expect(v.setupTokenStatus).toBe("configured");
+  });
+
+  test("claude present + token expired → warning", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("expired"),
+    });
+    const v = report.cleanup["claude-code"]!;
+    expect(v.status).toBe("warning");
+    expect(v.fix).toContain("setup-token");
+  });
+
+  test("claude present + token not-configured → unavailable", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("unavailable");
+  });
+});
+
+describe("computeBackendAvailability — ollama + custom + none", () => {
+  test("ollama unreachable → unavailable naming the url", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableFalse,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["ollama"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.detail).toContain("http://localhost:11434");
+    expect(v.fix).toContain("ollama");
+  });
+
+  test("ollama reachable → available", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.cleanup["ollama"]!.status).toBe("available");
+  });
+
+  test("ollama reach throwing → unknown", async () => {
+    const throwingReach: ReachFn = async () => {
+      throw new Error("net boom");
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: throwingReach,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.cleanup["ollama"]!.status).toBe("unknown");
+  });
+
+  test("custom has a localhost default url → available (default counts)", async () => {
+    // The custom provider carries a built-in localhost default, so with an
+    // empty config it resolves to that default and reports available.
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.cleanup["custom"]!;
+    expect(v.status).toBe("available");
+    expect(v.detail).toContain("http://localhost:8080/v1");
+  });
+
+  test("none → ok-no-check", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.cleanup["none"]!.status).toBe("ok-no-check");
+  });
+});

--- a/src/backend-availability.ts
+++ b/src/backend-availability.ts
@@ -1,0 +1,393 @@
+/**
+ * Per-backend availability detection for the admin SPA.
+ *
+ * The pain this fixes: selecting a transcription backend (`onnx-asr`) + a
+ * cleanup backend (`claude-code`) in the admin UI *saves fine* — the config
+ * write succeeds — but the first actual transcription fails with an opaque
+ * subprocess error (`exit 127` / "command not found") because the underlying
+ * CLI was never installed. There were ZERO dependency checks anywhere in the
+ * config flow; the silent failure surfaced only at request time, far from
+ * where the operator made the choice.
+ *
+ * This module probes each backend's real prerequisite (a CLI on PATH, an
+ * API key, a reachable URL) and returns a structured status the SPA renders
+ * INLINE next to each backend select. The owner's chosen behavior is
+ * **warn + how-to-fix, NON-BLOCKING** — saving is never blocked, but a
+ * missing dependency is impossible to miss, and every warning carries the
+ * exact fix.
+ *
+ * Design constraints:
+ *
+ *   - **Fast + non-fatal.** Each check is a `Bun.which` lookup (a PATH stat),
+ *     an env/config read, or a single short-timeout fetch. Any check that
+ *     throws degrades to `status: "unknown"` for that one backend — it never
+ *     crashes the endpoint or the page.
+ *   - **Server-side.** The browser can't `Bun.which` or read the host's env;
+ *     detection runs in-process and is surfaced over
+ *     `GET /admin/backend-availability`.
+ *   - **No secrets on the wire.** API-key checks report only presence
+ *     (configured / env-set / missing), never the value.
+ */
+
+import { readSetupTokenStatus } from "./claude-token-status.ts";
+import { resolveCleanupProviderConfig } from "./provider-config.ts";
+import type { ProviderBlock, ScribeConfig } from "./config.ts";
+import type { SetupTokenStatus } from "./config-schema.ts";
+
+/** True when the on-disk config block for `name` carries a non-empty apiKey. */
+function rawConfigApiKey(
+  map: Record<string, ProviderBlock> | undefined,
+  name: string,
+): boolean {
+  const v = map?.[name]?.apiKey;
+  return typeof v === "string" && v.length > 0;
+}
+
+/** Availability verdict for a single backend. */
+export type BackendAvailability = {
+  /**
+   *   - `available`   — prerequisite satisfied (binary on PATH, key present,
+   *                     url reachable). Safe to use.
+   *   - `unavailable` — a hard prerequisite is missing. `detail` + `fix`
+   *                     carry the exact remedy.
+   *   - `warning`     — usable-but-incomplete (e.g. a self-hosted URL we
+   *                     couldn't reach but the operator may bring up).
+   *   - `unknown`     — the check itself errored / couldn't determine. Never
+   *                     a hard fail; the SPA shows "couldn't determine".
+   *   - `ok-no-check` — nothing to check (e.g. cleanup `none`).
+   */
+  status: "available" | "unavailable" | "warning" | "unknown" | "ok-no-check";
+  /** One-line human summary, safe to render directly. */
+  detail: string;
+  /** Exact fix when status is unavailable/warning — install cmd, env export, etc. */
+  fix?: string;
+  /**
+   * For `claude-code`: the raw setup-token status so the SPA can render the
+   * token pill alongside the CLI-presence verdict. Omitted for other backends.
+   */
+  setupTokenStatus?: SetupTokenStatus;
+};
+
+export type BackendAvailabilityReport = {
+  transcribe: Record<string, BackendAvailability>;
+  cleanup: Record<string, BackendAvailability>;
+};
+
+/**
+ * Seam for testing — defaults to `Bun.which` but overridable so unit tests
+ * can simulate present/absent binaries without touching the host PATH.
+ */
+export type WhichFn = (bin: string) => string | null;
+
+/**
+ * Seam for the ollama reachability probe. Defaults to a short-timeout fetch;
+ * tests inject a stub so they never hit the network.
+ */
+export type ReachFn = (url: string) => Promise<boolean>;
+
+export type AvailabilityDeps = {
+  which?: WhichFn;
+  reach?: ReachFn;
+  env?: Record<string, string | undefined>;
+  scribeConfig: ScribeConfig;
+  setupTokenStatusFn?: (env?: Record<string, string | undefined>) => SetupTokenStatus;
+};
+
+const defaultWhich: WhichFn = (bin) => Bun.which(bin);
+
+const defaultReach: ReachFn = async (url) => {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 600);
+    try {
+      // Hit the ollama root — 200/404/any HTTP response means "reachable".
+      // We only care that *something* answered, not the status code.
+      const res = await fetch(url, { signal: controller.signal });
+      // Touch the body-less response just enough to satisfy lint; the bare
+      // fact we got a Response (didn't throw) is the signal.
+      void res.status;
+      return true;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+};
+
+/** Install command per local transcription CLI. Sourced from README + .env.example. */
+const TRANSCRIBE_INSTALL: Record<string, { bin: string; fix: string }> = {
+  // parakeet-mlx: macOS / Apple-Silicon only (MLX). Published as a uv/pip tool.
+  "parakeet-mlx": {
+    bin: "parakeet-mlx",
+    fix: "Install the parakeet-mlx CLI (macOS / Apple Silicon only): `uv tool install parakeet-mlx` (or `pip install parakeet-mlx`), then ensure it's on PATH.",
+  },
+  "onnx-asr": {
+    bin: "onnx-asr",
+    fix: "Install the onnx-asr CLI: `pip install onnx-asr[cpu,hub]` (cross-platform), then ensure it's on PATH.",
+  },
+  // The `whisper` backend shells to the `whisper-ctranslate2` binary, NOT a
+  // bare `whisper` — the install command + the PATH check both target it.
+  whisper: {
+    bin: "whisper-ctranslate2",
+    fix: "Install whisper-ctranslate2: `pip install whisper-ctranslate2`, then ensure it's on PATH.",
+  },
+};
+
+/** API-backend env-var names — mirrors provider-config.ts so the message names the real var. */
+const TRANSCRIBE_API_ENV: Record<string, string> = {
+  groq: "GROQ_API_KEY",
+  openai: "OPENAI_API_KEY",
+};
+
+const CLEANUP_API_ENV: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  gemini: "GEMINI_API_KEY",
+  groq: "GROQ_API_KEY",
+};
+
+function safeWhich(which: WhichFn, bin: string): string | null | "error" {
+  try {
+    return which(bin);
+  } catch {
+    return "error";
+  }
+}
+
+/** ffmpeg is a shared prerequisite for onnx-asr (it converts non-wav input). */
+function ffmpegNote(which: WhichFn): string {
+  const ff = safeWhich(which, "ffmpeg");
+  if (ff === null) {
+    return " Also install `ffmpeg` (needed to convert non-WAV audio): `brew install ffmpeg` on macOS, `apt install ffmpeg` on Debian/Ubuntu.";
+  }
+  return "";
+}
+
+function checkTranscribeBinary(
+  name: string,
+  which: WhichFn,
+): BackendAvailability {
+  const spec = TRANSCRIBE_INSTALL[name];
+  if (!spec) {
+    return { status: "ok-no-check", detail: "No local dependency to check." };
+  }
+  const found = safeWhich(which, spec.bin);
+  if (found === "error") {
+    return { status: "unknown", detail: `Couldn't check whether \`${spec.bin}\` is installed.` };
+  }
+  if (found === null) {
+    const extra = name === "onnx-asr" ? ffmpegNote(which) : "";
+    return {
+      status: "unavailable",
+      detail: `\`${spec.bin}\` isn't installed.`,
+      fix: spec.fix + extra,
+    };
+  }
+  const extra = name === "onnx-asr" ? ffmpegNote(which) : "";
+  if (extra) {
+    return {
+      status: "warning",
+      detail: `\`${spec.bin}\` is installed, but \`ffmpeg\` is missing.`,
+      fix: extra.trim(),
+    };
+  }
+  return { status: "available", detail: `\`${spec.bin}\` is installed.` };
+}
+
+/**
+ * API-key presence check. `configHasKey` is the raw config-block presence
+ * (NOT the env-merged resolution) so the detail message can correctly
+ * distinguish a key stored in config.json from one supplied via the
+ * environment — otherwise an env-only key gets mislabeled "stored in config".
+ */
+function checkApiKey(
+  envVar: string,
+  configHasKey: boolean,
+  env: Record<string, string | undefined>,
+): BackendAvailability {
+  if (configHasKey) {
+    return { status: "available", detail: `API key stored in config (\`${envVar}\` not needed).` };
+  }
+  const fromEnv = env[envVar];
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    return { status: "available", detail: `Using \`${envVar}\` from the environment.` };
+  }
+  return {
+    status: "unavailable",
+    detail: `No \`${envVar}\` set.`,
+    fix: `Paste an API key in the field below, or export \`${envVar}\` in scribe's environment and restart.`,
+  };
+}
+
+async function checkOllama(
+  scribeConfig: ScribeConfig,
+  reach: ReachFn,
+  env: Record<string, string | undefined>,
+): Promise<BackendAvailability> {
+  const resolved = resolveCleanupProviderConfig("ollama", scribeConfig, env);
+  const url = resolved.url ?? "http://localhost:11434";
+  let reachable: boolean;
+  try {
+    reachable = await reach(url);
+  } catch {
+    return { status: "unknown", detail: `Couldn't check whether ollama is reachable at ${url}.` };
+  }
+  if (reachable) {
+    return { status: "available", detail: `Ollama is reachable at ${url}.` };
+  }
+  return {
+    status: "unavailable",
+    detail: `Ollama isn't reachable at ${url}.`,
+    fix: `Start ollama (\`ollama serve\`) on this host, or set the Ollama URL below to where it's running.`,
+  };
+}
+
+function checkClaudeCode(
+  which: WhichFn,
+  env: Record<string, string | undefined>,
+  setupTokenStatusFn: (env?: Record<string, string | undefined>) => SetupTokenStatus,
+): BackendAvailability {
+  let tokenStatus: SetupTokenStatus;
+  try {
+    tokenStatus = setupTokenStatusFn(env);
+  } catch {
+    tokenStatus = "unknown";
+  }
+  const claudeBin = safeWhich(which, "claude");
+  if (claudeBin === "error") {
+    return {
+      status: "unknown",
+      detail: "Couldn't check whether the `claude` CLI is installed.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+  if (claudeBin === null) {
+    return {
+      status: "unavailable",
+      detail: "The `claude` CLI isn't installed.",
+      fix: "Install Claude Code (https://claude.com/claude-code), then run `claude setup-token` on this host and click Refresh.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+  // CLI present — the deciding factor is now the setup-token.
+  if (tokenStatus === "configured") {
+    return {
+      status: "available",
+      detail: "`claude` CLI installed and a setup-token is configured.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+  if (tokenStatus === "expired") {
+    return {
+      status: "warning",
+      detail: "`claude` CLI installed, but the setup-token has expired.",
+      fix: "Re-run `claude setup-token` on this host, then click Refresh.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+  if (tokenStatus === "not-configured") {
+    return {
+      status: "unavailable",
+      detail: "`claude` CLI installed, but no setup-token is configured.",
+      fix: "Run `claude setup-token` on this host, then click Refresh.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+  // unknown token status (file present but unreadable)
+  return {
+    status: "warning",
+    detail: "`claude` CLI installed; couldn't determine the setup-token status.",
+    fix: "If transcription cleanup fails, run `claude setup-token` on this host and click Refresh.",
+    setupTokenStatus: tokenStatus,
+  };
+}
+
+function checkCustom(
+  scribeConfig: ScribeConfig,
+  env: Record<string, string | undefined>,
+): BackendAvailability {
+  const resolved = resolveCleanupProviderConfig("custom", scribeConfig, env);
+  const url = resolved.url;
+  // The custom provider has a built-in localhost default; treat an explicit
+  // empty/unset as "needs a URL" only when neither config nor env supplied one.
+  if (!url || url.length === 0) {
+    return {
+      status: "unavailable",
+      detail: "No endpoint URL set for the custom provider.",
+      fix: "Set the endpoint URL below to your OpenAI-compatible server.",
+    };
+  }
+  return { status: "available", detail: `Endpoint URL set (${url}).` };
+}
+
+/**
+ * Compute the availability report for every transcription + cleanup backend.
+ * Pure-ish: all side-effecting probes go through injectable seams so tests
+ * stay hermetic. Each per-backend check is independently try/caught so one
+ * failing probe can't blank the whole report.
+ */
+export async function computeBackendAvailability(
+  deps: AvailabilityDeps,
+): Promise<BackendAvailabilityReport> {
+  const which = deps.which ?? defaultWhich;
+  const reach = deps.reach ?? defaultReach;
+  const env = deps.env ?? process.env;
+  const setupTokenStatusFn = deps.setupTokenStatusFn ?? readSetupTokenStatus;
+  const scribeConfig = deps.scribeConfig;
+
+  const transcribe: Record<string, BackendAvailability> = {};
+  // Local CLI transcribers.
+  for (const name of Object.keys(TRANSCRIBE_INSTALL)) {
+    try {
+      transcribe[name] = checkTranscribeBinary(name, which);
+    } catch {
+      transcribe[name] = { status: "unknown", detail: "Check failed." };
+    }
+  }
+  // API transcribers. We read the RAW config block presence (not the
+  // env-merged resolution) so an env-only key isn't mislabeled "stored in
+  // config." The merged resolution is still useful for the available-vs-not
+  // decision, but checkApiKey re-derives that from (configHasKey || env).
+  for (const [name, envVar] of Object.entries(TRANSCRIBE_API_ENV)) {
+    try {
+      const configHasKey = rawConfigApiKey(scribeConfig.transcribeProviders, name);
+      transcribe[name] = checkApiKey(envVar, configHasKey, env);
+    } catch {
+      transcribe[name] = { status: "unknown", detail: "Check failed." };
+    }
+  }
+
+  const cleanup: Record<string, BackendAvailability> = {};
+  // API cleaners.
+  for (const [name, envVar] of Object.entries(CLEANUP_API_ENV)) {
+    try {
+      const configHasKey = rawConfigApiKey(scribeConfig.cleanupProviders, name);
+      cleanup[name] = checkApiKey(envVar, configHasKey, env);
+    } catch {
+      cleanup[name] = { status: "unknown", detail: "Check failed." };
+    }
+  }
+  // claude-code.
+  try {
+    cleanup["claude-code"] = checkClaudeCode(which, env, setupTokenStatusFn);
+  } catch {
+    cleanup["claude-code"] = { status: "unknown", detail: "Check failed." };
+  }
+  // ollama (reachability probe).
+  try {
+    cleanup["ollama"] = await checkOllama(scribeConfig, reach, env);
+  } catch {
+    cleanup["ollama"] = { status: "unknown", detail: "Check failed." };
+  }
+  // custom.
+  try {
+    cleanup["custom"] = checkCustom(scribeConfig, env);
+  } catch {
+    cleanup["custom"] = { status: "unknown", detail: "Check failed." };
+  }
+  // none — nothing to check.
+  cleanup["none"] = { status: "ok-no-check", detail: "No cleanup — nothing to check." };
+
+  return { transcribe, cleanup };
+}

--- a/src/backend-availability.ts
+++ b/src/backend-availability.ts
@@ -318,7 +318,22 @@ function checkCustom(
       fix: "Set the endpoint URL below to your OpenAI-compatible server.",
     };
   }
-  return { status: "available", detail: `Endpoint URL set (${url}).` };
+  // Echo a credential-stripped display URL: a custom endpoint of the form
+  // `https://user:pass@host/v1` would otherwise surface the embedded password
+  // in the admin UI. Rebuild from origin + pathname (drops userinfo, query, and
+  // fragment too — none of which belong in a "URL set" confirmation). Fall back
+  // to a generic, echo-free message if the URL can't be parsed.
+  let display: string | null;
+  try {
+    const parsed = new URL(url);
+    display = parsed.origin + parsed.pathname;
+  } catch {
+    display = null;
+  }
+  return {
+    status: "available",
+    detail: display ? `Endpoint URL set (${display}).` : "Endpoint URL set.",
+  };
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import {
   writeConfigFileAtomic,
 } from "./config-write.ts";
 import { readSetupTokenStatus } from "./claude-token-status.ts";
+import { computeBackendAvailability } from "./backend-availability.ts";
 import { renderAdminPage } from "./admin-ui.ts";
 import {
   SCOPE_ADMIN,
@@ -164,6 +165,9 @@ async function route(
 
   // Admin actions live under /admin/* — refresh-claude-token-status and
   // clear-credential (Phase 2 polish from scribe#47).
+  if (internalPath === "/admin/backend-availability" && req.method === "GET") {
+    return handleBackendAvailability(deps);
+  }
   if (internalPath === "/admin/refresh-claude-token-status" && req.method === "POST") {
     return handleRefreshSetupTokenStatus(deps);
   }
@@ -234,6 +238,37 @@ function handleConfigGet(deps: ServerDeps): Response {
     setupTokenStatusFn: deps.setupTokenStatusFn,
   });
   return Response.json(resolved);
+}
+
+/**
+ * `GET /admin/backend-availability` — probe every transcription + cleanup
+ * backend's real prerequisite (CLI on PATH, API key present, URL reachable)
+ * and return a structured report the SPA renders inline next to each backend
+ * select.
+ *
+ * The pain this fixes: selecting a backend whose dependency isn't installed
+ * SAVES fine, then fails opaquely (`exit 127`) only at the first
+ * transcription. This endpoint surfaces the missing dependency at config
+ * time with the exact fix — warn, never block. Each per-backend probe is
+ * try/caught inside `computeBackendAvailability` so a flaky check degrades to
+ * `"unknown"` rather than failing the whole response. The outer try/catch is
+ * belt-and-braces: a top-level failure still returns a 200 with an empty
+ * report so the page never breaks on this advisory endpoint.
+ */
+async function handleBackendAvailability(deps: ServerDeps): Promise<Response> {
+  try {
+    const report = await computeBackendAvailability({
+      scribeConfig: deps.scribeConfig,
+      setupTokenStatusFn: deps.setupTokenStatusFn,
+    });
+    return Response.json(report);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[scribe] backend-availability check failed: ${message}`);
+    // Advisory endpoint — never 500 the SPA over it. Return an empty report;
+    // the page falls back to "couldn't determine" for every backend.
+    return Response.json({ transcribe: {}, cleanup: {} });
+  }
 }
 
 /**


### PR DESCRIPTION
## Why

Selecting a transcription backend (`onnx-asr`) + cleanup backend (`claude-code`) in scribe's admin config page **saved fine** but failed only at the **first transcription** with an opaque subprocess error (`exit 127` / "command not found"). There were **zero dependency checks** anywhere in the config flow, so a missing CLI/key surfaced far from where the operator made the choice. The cleanup-prompt / proper-nouns knobs were also buried below the provider selects with no emphasis.

This PR makes the config page genuinely user-friendly.

## Decision: WARN + how-to-fix, NON-BLOCKING

Per the owner's chosen behavior, saving is **never blocked** — but a missing dependency is **impossible to miss**, and every warning carries the **exact fix**. The check is advisory: a probe that errors degrades to "unknown" and never crashes the page.

## The silent failure this fixes

Before: pick `onnx-asr` → Save → 200 OK → looks done → send audio → `exit 127`, no hint why. After: pick `onnx-asr` → inline `⚠ \`onnx-asr\` isn't installed — \`pip install onnx-asr[cpu,hub]\`… Also install \`ffmpeg\`…` right under the select, at config time.

## Changes

**Change 1 — Per-backend availability detection.** New `src/backend-availability.ts` + `GET /admin/backend-availability` endpoint (scribe:admin-gated). Probes each backend's real prerequisite:
- Transcription CLIs via `Bun.which`: `parakeet-mlx`, `onnx-asr` (+ flags missing `ffmpeg`), and `whisper-ctranslate2` — the real binary the `whisper` backend shells to, **not** bare `whisper`.
- `claude-code`: `Bun.which("claude")` + the existing `claude-token-status.ts` reader → surfaces CLI-presence AND setup-token status, with the `claude setup-token` fix.
- API backends (`anthropic`/`openai`/`gemini`/`groq`): config-stored OR env-var key present → names the exact env var in the fix.
- `ollama`: short-timeout reachability probe to configured/default `http://localhost:11434`.
- `custom`: warns when no endpoint URL.

Each per-backend probe is independently try/caught → "unknown" on error; the endpoint is wrapped so a top-level failure still returns 200 with an empty report. `admin-ui.ts` renders the verdict **inline under the selected backend's select** (green ✓ / amber ⚠ + fix / muted unknown), re-renders on select-change, and re-probes after a save (a just-stored key changes availability).

**Change 2 — Surfaced "Cleanup tuning" section.** `cleanupSystemPrompt` + `cleanupContextTemplate` promoted out of the buried list into a labeled section with explanations. Calls out that **proper nouns are supplied per-request** (in the request `context` part), NOT stored in config — only the wrapping template lives here.

**Change 3 — Wired the claude-code Refresh button.** The `POST /admin/refresh-claude-token-status` endpoint existed with no button. Added a "Refresh status" affordance inside the claude-code status block that re-reads the token and re-probes availability in place.

**Change 4 — Restart-required clarity.** Banner now leads "**Saved — but not live yet**", lists the changed fields, and spells out the exact command (`parachute restart scribe`) so an operator doesn't think a new backend is live before restarting.

**Also fixed a latent rendering bug:** non-ASCII glyphs inside the `String.raw` page-script (e.g. the existing `"Saving…"`) were emitted as literal `\uXXXX` escapes in the served JS — so the live UI actually showed `Saving…`. Switched user-facing copy to ASCII / HTML entities (`&#10003;` `&#9888;` `&#8505;` `&mdash;`) and cleaned the served page-script of all literal escapes.

## Availability-detection approach

- **Endpoint:** `GET /admin/backend-availability` (server-side — the browser can't `Bun.which` or read the host env). Returns `{ transcribe: {name: {status, detail, fix?, setupTokenStatus?}}, cleanup: {...} }`.
- **Statuses:** `available` / `unavailable` / `warning` / `unknown` / `ok-no-check`.
- **No secrets on the wire** — API-key checks report presence only.
- All side-effecting probes (`Bun.which`, ollama reach, setup-token reader) are injectable seams → hermetic unit tests.

## Tests / gates

- `bun test`: **413 pass / 0 fail** (was 387; +26 new across `backend-availability.test.ts`, `admin-routes.test.ts`, `admin-ui.test.ts`).
- `tsc --noEmit`: clean.
- Smoke-tested live (`bun run src/cli.ts serve` in a sandbox `PARACHUTE_HOME`): `GET /admin/backend-availability` returns correct verdicts (local CLIs available, API backends unavailable w/ exact env-var fix, claude-code "CLI installed but no setup-token" + status, ollama unreachable, custom default-url available, none ok-no-check); refresh endpoint + rendered page elements verified.

## Scope

No security items bundled — parachute-scribe#66 (0.0.0.0 bind + open-auth) is a separate fix.

## Version-bump convention

Version left at **0.4.5** (unchanged). Per workspace governance rule 2, code-touching PRs don't bump the `rc.N` suffix per-PR; the bump + tag happen together only when ready-to-ship. Flag if scribe wants a different convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)