### PR TITLE
Make transcription failures legible (ffmpeg preflight + cleanup-skip signal + live claude auth probe)

### DIFF
--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFetchHandler, type ServerDeps } from "./server.ts";
 import type { ResolvedConfig } from "./config-schema.ts";
+import type { ClaudeProbeFn } from "./backend-availability.ts";
 
 const RESOLVED: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
@@ -442,5 +443,55 @@ describe("GET /admin/backend-availability", () => {
       }),
     );
     expect(res.status).toBe(404);
+  });
+
+  test("no ?probe → live claude probe seam NOT invoked (fast default path)", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    let probeCalls = 0;
+    const probe: ClaudeProbeFn = async () => {
+      probeCalls++;
+      return { outcome: "ok" };
+    };
+    const handler = buildHandler("/tmp/unused", {
+      setupTokenStatusFn: () => "configured",
+      claudeProbeFn: probe,
+    });
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability"),
+    );
+    expect(res.status).toBe(200);
+    expect(probeCalls).toBe(0);
+  });
+
+  test("?probe=1 → endpoint stays 200 and never spawns a real claude (seam is honored)", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    let probeCalls = 0;
+    // A "fail/Not logged in" stub: if the route reaches the probe branch (i.e.
+    // claude is on the host PATH), the verdict is `unauthenticated`. If claude
+    // is absent, the binary-absent branch returns `unavailable` and the seam is
+    // never consulted. Either way NO real `claude` is spawned — the seam stands
+    // in. The per-verdict mapping is exhaustively covered by the unit tests in
+    // backend-availability.test.ts; here we only assert the route wiring +
+    // safety (no subprocess, never throws, advisory 200).
+    const probe: ClaudeProbeFn = async () => {
+      probeCalls++;
+      return { outcome: "fail", output: "Not logged in" };
+    };
+    const handler = buildHandler("/tmp/unused", {
+      setupTokenStatusFn: () => "configured",
+      claudeProbeFn: probe,
+    });
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability?probe=1"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      cleanup: Record<string, { status: string }>;
+    };
+    const status = body.cleanup["claude-code"]?.status ?? "";
+    expect(["unauthenticated", "unavailable"]).toContain(status);
+    // When the probe branch was reached it was the injected seam, not a real
+    // subprocess. When it wasn't (claude absent), probeCalls stays 0.
+    expect(probeCalls).toBeLessThanOrEqual(1);
   });
 });

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -743,7 +743,7 @@ const PAGE_SCRIPT = String.raw`
     var icon;
     var cls;
     if (verdict.status === "available") { icon = "&#10003;"; cls = "bs-ok"; }
-    else if (verdict.status === "unavailable" || verdict.status === "warning") { icon = "&#9888;"; cls = "bs-warn"; }
+    else if (verdict.status === "unavailable" || verdict.status === "warning" || verdict.status === "unauthenticated") { icon = "&#9888;"; cls = "bs-warn"; }
     else { icon = "&#8505;"; cls = "bs-unknown"; } // unknown / ok-no-check fall here; ok-no-check is filtered before render
 
     var html = '<div class="bs-line"><span class="bs-icon">' + icon + '</span>' +
@@ -793,9 +793,15 @@ const PAGE_SCRIPT = String.raw`
     wireClaudeRefresh();
   }
 
-  async function checkAvailability() {
+  // "probe" opts into the live "claude -p" auth probe server-side (?probe=1).
+  // Initial page load passes it falsy (fast, file-token only -- no subprocess
+  // spawned on every page view); the claude-code Refresh button passes true so
+  // the operator gets an authoritative auth verdict (the file-token read is
+  // unreliable on macOS under launchd). NB: avoid backticks in this comment --
+  // this whole block is a String.raw template; a backtick would close it early.
+  async function checkAvailability(probe) {
     var base = (window.__SCRIBE_CONFIG_URL__ || "/.parachute/config").replace(/\/\.parachute\/config$/, "");
-    var url = base + "/admin/backend-availability";
+    var url = base + "/admin/backend-availability" + (probe ? "?probe=1" : "");
     try {
       var res = await fetch(url);
       if (!res.ok) return; // advisory: leave status hidden on non-200
@@ -824,7 +830,9 @@ const PAGE_SCRIPT = String.raw`
         // presence + token) updates in place without a page reload.
         await fetch(base + "/admin/refresh-claude-token-status", { method: "POST" });
       } catch (_e) { /* fall through to re-probe */ }
-      await checkAvailability();
+      // Pass probe=true: run the authoritative live "claude -p" auth probe,
+      // not just the (macOS-unreliable) file-token read.
+      await checkAvailability(true);
       // checkAvailability re-renders + re-wires; if it failed, restore the
       // button so the operator can retry.
       var stillThere = el("claude-refresh-btn");

--- a/src/backend-availability.test.ts
+++ b/src/backend-availability.test.ts
@@ -10,6 +10,7 @@ import {
   computeBackendAvailability,
   type WhichFn,
   type ReachFn,
+  type ClaudeProbeFn,
 } from "./backend-availability.ts";
 import type { ScribeConfig } from "./config.ts";
 import type { SetupTokenStatus } from "./config-schema.ts";
@@ -98,6 +99,59 @@ describe("computeBackendAvailability — transcription binaries", () => {
     const v = report.transcribe["parakeet-mlx"]!;
     expect(v.status).toBe("unavailable");
     expect(v.fix).toContain("parakeet-mlx");
+  });
+
+  test("parakeet-mlx present but ffmpeg missing → warning naming ffmpeg (needsFfmpeg flag, was unchecked before)", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["parakeet-mlx"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["parakeet-mlx"]!;
+    expect(v.status).toBe("warning");
+    expect(v.detail).toContain("ffmpeg");
+    expect(v.fix).toContain("ffmpeg");
+  });
+
+  test("parakeet-mlx + ffmpeg both present → available", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["parakeet-mlx", "ffmpeg"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    expect(report.transcribe["parakeet-mlx"]!.status).toBe("available");
+  });
+
+  test("whisper (whisper-ctranslate2) present but ffmpeg missing → warning naming ffmpeg", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith(["whisper-ctranslate2"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["whisper"]!;
+    expect(v.status).toBe("warning");
+    expect(v.detail).toContain("ffmpeg");
+    expect(v.fix).toContain("ffmpeg");
+  });
+
+  test("whisper binary missing → unavailable names BOTH whisper-ctranslate2 and ffmpeg", async () => {
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+    });
+    const v = report.transcribe["whisper"]!;
+    expect(v.status).toBe("unavailable");
+    expect(v.fix).toContain("whisper-ctranslate2");
+    expect(v.fix).toContain("ffmpeg");
   });
 
   test("which throwing degrades to unknown, never crashes", async () => {
@@ -318,5 +372,161 @@ describe("computeBackendAvailability — ollama + custom + none", () => {
       setupTokenStatusFn: tokenStatus("not-configured"),
     });
     expect(report.cleanup["none"]!.status).toBe("ok-no-check");
+  });
+});
+
+describe("computeBackendAvailability — claude-code live auth probe", () => {
+  test("probe NOT invoked unless probeClaude is set (default per-call path stays subprocess-free)", async () => {
+    let probeCalls = 0;
+    const probe: ClaudeProbeFn = async () => {
+      probeCalls++;
+      return { outcome: "ok" };
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      claudeProbeFn: probe,
+      // probeClaude omitted → defaults false
+    });
+    expect(probeCalls).toBe(0);
+    // Falls back to the file-token heuristic.
+    expect(report.cleanup["claude-code"]!.status).toBe("available");
+  });
+
+  test("probe ok → available (live probe authoritative even when token file says not-configured)", async () => {
+    const probe: ClaudeProbeFn = async () => ({ outcome: "ok" });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      // The macOS-unreliable file read says not-configured…
+      setupTokenStatusFn: tokenStatus("not-configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    // …but the LIVE probe is authoritative → available.
+    expect(report.cleanup["claude-code"]!.status).toBe("available");
+  });
+
+  test("probe fail + not-logged-in signature → unauthenticated with launchd-keychain fix", async () => {
+    const probe: ClaudeProbeFn = async () => ({
+      outcome: "fail",
+      output: "Error: Not logged in. Run `claude login`.",
+    });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    const v = report.cleanup["claude-code"]!;
+    expect(v.status).toBe("unauthenticated");
+    expect(v.fix).toContain("claude setup-token");
+    expect(v.fix).toContain("ANTHROPIC_API_KEY");
+    expect(v.fix).toContain("keychain");
+  });
+
+  test("probe fail + invalid-api-key signature → unauthenticated", async () => {
+    const probe: ClaudeProbeFn = async () => ({
+      outcome: "fail",
+      output: "API Error: invalid API key provided",
+    });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("unauthenticated");
+  });
+
+  test("probe enoent → unavailable (binary not runnable)", async () => {
+    const probe: ClaudeProbeFn = async () => ({ outcome: "enoent" });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("unavailable");
+  });
+
+  test("probe fail without a recognized signature → warning (inconclusive), not a false unauthenticated", async () => {
+    const probe: ClaudeProbeFn = async () => ({
+      outcome: "fail",
+      output: "some unrelated runtime error",
+    });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("warning");
+  });
+
+  test("probe error (e.g. timeout) → warning, never crashes the endpoint", async () => {
+    const probe: ClaudeProbeFn = async () => ({ outcome: "error" });
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("warning");
+  });
+
+  test("probe throwing degrades to warning, never crashes", async () => {
+    const probe: ClaudeProbeFn = async () => {
+      throw new Error("boom");
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith(["claude"]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("warning");
+  });
+
+  test("claude binary absent → unavailable, probe never consulted", async () => {
+    let probeCalls = 0;
+    const probe: ClaudeProbeFn = async () => {
+      probeCalls++;
+      return { outcome: "ok" };
+    };
+    const report = await computeBackendAvailability({
+      which: whichWith([]),
+      reach: reachableTrue,
+      env: NO_ENV,
+      scribeConfig: EMPTY_CONFIG,
+      setupTokenStatusFn: tokenStatus("not-configured"),
+      probeClaude: true,
+      claudeProbeFn: probe,
+    });
+    expect(report.cleanup["claude-code"]!.status).toBe("unavailable");
+    expect(probeCalls).toBe(0);
   });
 });

--- a/src/backend-availability.ts
+++ b/src/backend-availability.ts
@@ -55,8 +55,18 @@ export type BackendAvailability = {
    *   - `unknown`     — the check itself errored / couldn't determine. Never
    *                     a hard fail; the SPA shows "couldn't determine".
    *   - `ok-no-check` — nothing to check (e.g. cleanup `none`).
+   *   - `unauthenticated` — the dependency is installed but a live probe
+   *                     proved it isn't authenticated (claude-code only, and
+   *                     only when an explicit `?probe=1` ran the `claude -p`
+   *                     auth probe). `fix` carries the remedy.
    */
-  status: "available" | "unavailable" | "warning" | "unknown" | "ok-no-check";
+  status:
+    | "available"
+    | "unavailable"
+    | "warning"
+    | "unknown"
+    | "ok-no-check"
+    | "unauthenticated";
   /** One-line human summary, safe to render directly. */
   detail: string;
   /** Exact fix when status is unavailable/warning — install cmd, env export, etc. */
@@ -85,12 +95,48 @@ export type WhichFn = (bin: string) => string | null;
  */
 export type ReachFn = (url: string) => Promise<boolean>;
 
+/**
+ * Result of the live `claude -p` auth probe. The runner seam returns this
+ * shape; the default implementation maps a real subprocess onto it.
+ *
+ *   - `outcome: "ok"`     — `claude -p` exited 0. Authenticated.
+ *   - `outcome: "fail"`   — exited non-zero. `output` is the combined
+ *                           stdout+stderr we pattern-match against the
+ *                           not-authenticated signatures.
+ *   - `outcome: "enoent"` — the binary couldn't be spawned (not installed).
+ *   - `outcome: "error"`  — spawn/timeout/other error — degrade to `unknown`.
+ */
+export type ClaudeProbeResult =
+  | { outcome: "ok" }
+  | { outcome: "fail"; output: string }
+  | { outcome: "enoent" }
+  | { outcome: "error" };
+
+/**
+ * Seam for the live `claude -p` auth probe. Defaults to spawning the real
+ * CLI with a trivial prompt under a ~4s timeout; tests inject a stub so they
+ * never spawn `claude`. Only invoked when `probeClaude` is set — never on the
+ * default per-call availability path.
+ */
+export type ClaudeProbeFn = () => Promise<ClaudeProbeResult>;
+
 export type AvailabilityDeps = {
   which?: WhichFn;
   reach?: ReachFn;
   env?: Record<string, string | undefined>;
   scribeConfig: ScribeConfig;
   setupTokenStatusFn?: (env?: Record<string, string | undefined>) => SetupTokenStatus;
+  /**
+   * When true, run the live `claude -p` auth probe for the claude-code
+   * cleanup backend (the file-based token read is unreliable on macOS under
+   * launchd — the credential lives in the login keychain the daemon can't
+   * unlock). Gated behind an explicit request (the admin SPA's Refresh button
+   * sends `?probe=1`) so we never spawn a subprocess on every availability
+   * call. Defaults off.
+   */
+  probeClaude?: boolean;
+  /** Seam for the live claude probe. Defaults to the real subprocess runner. */
+  claudeProbeFn?: ClaudeProbeFn;
 };
 
 const defaultWhich: WhichFn = (bin) => Bun.which(bin);
@@ -115,22 +161,87 @@ const defaultReach: ReachFn = async (url) => {
   }
 };
 
-/** Install command per local transcription CLI. Sourced from README + .env.example. */
-const TRANSCRIBE_INSTALL: Record<string, { bin: string; fix: string }> = {
+/**
+ * Default live `claude -p` auth probe. Spawns the real CLI with a trivial
+ * prompt under a ~4s timeout, capturing combined stdout+stderr. Maps the
+ * subprocess outcome onto `ClaudeProbeResult`:
+ *
+ *   - clean exit 0           → `ok`
+ *   - non-zero exit          → `fail` with combined output
+ *   - spawn ENOENT           → `enoent` (binary not present)
+ *   - timeout / other error  → `error` (caller degrades to `unknown`)
+ *
+ * Never throws — every failure mode maps to a result so the endpoint can't
+ * be broken by a hung or missing probe.
+ */
+const CLAUDE_PROBE_TIMEOUT_MS = 4000;
+
+const defaultClaudeProbe: ClaudeProbeFn = async () => {
+  try {
+    // Bound the spawn with an AbortSignal so a hung `claude` is killed at the
+    // timeout — a never-returning probe can't pin the request open.
+    const proc = Bun.spawn(["claude", "-p", "Reply with the single word: ok"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      signal: AbortSignal.timeout(CLAUDE_PROBE_TIMEOUT_MS),
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exitCode === 0) return { outcome: "ok" };
+    return { outcome: "fail", output: stdout + "\n" + stderr };
+  } catch (err) {
+    // Bun.spawn throws synchronously-as-rejection when the binary can't be
+    // found (ENOENT). A timeout surfaces as an AbortError. Distinguish
+    // ENOENT → "enoent" (missing); everything else → "error" → caller
+    // degrades to `unknown`.
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code === "ENOENT" || (typeof code === "string" && code.includes("ENOENT"))) {
+      return { outcome: "enoent" };
+    }
+    return { outcome: "error" };
+  }
+};
+
+/** Signatures that mark `claude -p` as installed-but-not-authenticated. */
+const CLAUDE_UNAUTH_SIGNATURE = /not logged in|invalid api key|unauthorized|authentication/i;
+
+/**
+ * Install command per local transcription CLI. Sourced from README +
+ * .env.example.
+ *
+ * `needsFfmpeg` marks backends that shell to `ffmpeg` internally to decode
+ * non-WAV audio. ffmpeg is a *silent* prerequisite: when it's missing these
+ * tools can print an error yet exit 0 with no output, so the failure only
+ * surfaces opaquely at request time. Probing for it here lets the admin UI
+ * warn the operator at config time, naming ffmpeg with an install fix. All
+ * three local backends need it — previously only onnx-asr was checked (a
+ * hardcoded `name === "onnx-asr"` gate), which is why parakeet-mlx/whisper
+ * operators hit the silent ffmpeg failure with no warning.
+ */
+const TRANSCRIBE_INSTALL: Record<
+  string,
+  { bin: string; fix: string; needsFfmpeg?: boolean }
+> = {
   // parakeet-mlx: macOS / Apple-Silicon only (MLX). Published as a uv/pip tool.
   "parakeet-mlx": {
     bin: "parakeet-mlx",
     fix: "Install the parakeet-mlx CLI (macOS / Apple Silicon only): `uv tool install parakeet-mlx` (or `pip install parakeet-mlx`), then ensure it's on PATH.",
+    needsFfmpeg: true,
   },
   "onnx-asr": {
     bin: "onnx-asr",
     fix: "Install the onnx-asr CLI: `pip install onnx-asr[cpu,hub]` (cross-platform), then ensure it's on PATH.",
+    needsFfmpeg: true,
   },
   // The `whisper` backend shells to the `whisper-ctranslate2` binary, NOT a
   // bare `whisper` — the install command + the PATH check both target it.
   whisper: {
     bin: "whisper-ctranslate2",
     fix: "Install whisper-ctranslate2: `pip install whisper-ctranslate2`, then ensure it's on PATH.",
+    needsFfmpeg: true,
   },
 };
 
@@ -155,7 +266,7 @@ function safeWhich(which: WhichFn, bin: string): string | null | "error" {
   }
 }
 
-/** ffmpeg is a shared prerequisite for onnx-asr (it converts non-wav input). */
+/** ffmpeg is a shared prerequisite for the local CLI transcribers that decode non-WAV input. */
 function ffmpegNote(which: WhichFn): string {
   const ff = safeWhich(which, "ffmpeg");
   if (ff === null) {
@@ -177,14 +288,14 @@ function checkTranscribeBinary(
     return { status: "unknown", detail: `Couldn't check whether \`${spec.bin}\` is installed.` };
   }
   if (found === null) {
-    const extra = name === "onnx-asr" ? ffmpegNote(which) : "";
+    const extra = spec.needsFfmpeg ? ffmpegNote(which) : "";
     return {
       status: "unavailable",
       detail: `\`${spec.bin}\` isn't installed.`,
       fix: spec.fix + extra,
     };
   }
-  const extra = name === "onnx-asr" ? ffmpegNote(which) : "";
+  const extra = spec.needsFfmpeg ? ffmpegNote(which) : "";
   if (extra) {
     return {
       status: "warning",
@@ -243,11 +354,24 @@ async function checkOllama(
   };
 }
 
-function checkClaudeCode(
+/**
+ * Fix text for the launchd-keychain mechanism — the live "Not logged in"
+ * cause on macOS. A launchd-spawned scribe can't unlock the login keychain
+ * where Claude Code's interactive-login credential lives, so even an
+ * interactively-authenticated `claude` reads as unauthenticated under the
+ * daemon. The file-based token (`claude setup-token`) and `ANTHROPIC_API_KEY`
+ * both sidestep the keychain.
+ */
+const CLAUDE_LAUNCHD_FIX =
+  "`claude` is installed but not authenticated in the environment scribe runs under. Under launchd the login keychain is unavailable — run `claude setup-token` (file-based token) or set ANTHROPIC_API_KEY, then Refresh.";
+
+async function checkClaudeCode(
   which: WhichFn,
   env: Record<string, string | undefined>,
   setupTokenStatusFn: (env?: Record<string, string | undefined>) => SetupTokenStatus,
-): BackendAvailability {
+  probeClaude: boolean,
+  claudeProbeFn: ClaudeProbeFn,
+): Promise<BackendAvailability> {
   let tokenStatus: SetupTokenStatus;
   try {
     tokenStatus = setupTokenStatusFn(env);
@@ -270,7 +394,56 @@ function checkClaudeCode(
       setupTokenStatus: tokenStatus,
     };
   }
-  // CLI present — the deciding factor is now the setup-token.
+
+  // CLI present. When an explicit probe was requested, the LIVE `claude -p`
+  // result is AUTHORITATIVE — the file-token read is unreliable on macOS
+  // under launchd (the credential lives in the login keychain the daemon
+  // can't unlock; that's the live "Not logged in" mechanism). Without a
+  // probe, fall back to the file-token heuristic below.
+  if (probeClaude) {
+    let probe: ClaudeProbeResult;
+    try {
+      probe = await claudeProbeFn();
+    } catch {
+      probe = { outcome: "error" };
+    }
+    if (probe.outcome === "ok") {
+      return {
+        status: "available",
+        detail: "`claude` CLI installed and authenticated (live probe succeeded).",
+        setupTokenStatus: tokenStatus,
+      };
+    }
+    if (probe.outcome === "enoent") {
+      // The which() said present but the spawn couldn't find it — treat as
+      // not installed (PATH skew between Bun.which and the spawn env).
+      return {
+        status: "unavailable",
+        detail: "The `claude` CLI isn't runnable (spawn failed: not found).",
+        fix: "Install Claude Code (https://claude.com/claude-code), then run `claude setup-token` on this host and click Refresh.",
+        setupTokenStatus: tokenStatus,
+      };
+    }
+    if (probe.outcome === "fail" && CLAUDE_UNAUTH_SIGNATURE.test(probe.output)) {
+      return {
+        status: "unauthenticated",
+        detail: "`claude` CLI installed, but the live probe reports it isn't authenticated.",
+        fix: CLAUDE_LAUNCHD_FIX,
+        setupTokenStatus: tokenStatus,
+      };
+    }
+    // Non-zero exit without a recognized auth signature, or a probe error /
+    // timeout — can't conclude. Degrade to a non-fatal warning rather than a
+    // false "unauthenticated."
+    return {
+      status: "warning",
+      detail: "`claude` CLI installed; the live auth probe was inconclusive.",
+      fix: "If transcription cleanup fails, run `claude setup-token` on this host or set ANTHROPIC_API_KEY, then Refresh.",
+      setupTokenStatus: tokenStatus,
+    };
+  }
+
+  // No live probe — the deciding factor is the setup-token file (advisory).
   if (tokenStatus === "configured") {
     return {
       status: "available",
@@ -294,10 +467,11 @@ function checkClaudeCode(
       setupTokenStatus: tokenStatus,
     };
   }
-  // unknown token status (file present but unreadable)
+  // unknown token status (file present but unreadable, OR — on macOS — the
+  // credential may live in the login keychain rather than the file).
   return {
     status: "warning",
-    detail: "`claude` CLI installed; couldn't determine the setup-token status.",
+    detail: "`claude` CLI installed; couldn't determine the setup-token status from the file (on macOS the credential may be in the login keychain — click Refresh to run a live auth probe).",
     fix: "If transcription cleanup fails, run `claude setup-token` on this host and click Refresh.",
     setupTokenStatus: tokenStatus,
   };
@@ -350,6 +524,8 @@ export async function computeBackendAvailability(
   const env = deps.env ?? process.env;
   const setupTokenStatusFn = deps.setupTokenStatusFn ?? readSetupTokenStatus;
   const scribeConfig = deps.scribeConfig;
+  const probeClaude = deps.probeClaude ?? false;
+  const claudeProbeFn = deps.claudeProbeFn ?? defaultClaudeProbe;
 
   const transcribe: Record<string, BackendAvailability> = {};
   // Local CLI transcribers.
@@ -385,7 +561,13 @@ export async function computeBackendAvailability(
   }
   // claude-code.
   try {
-    cleanup["claude-code"] = checkClaudeCode(which, env, setupTokenStatusFn);
+    cleanup["claude-code"] = await checkClaudeCode(
+      which,
+      env,
+      setupTokenStatusFn,
+      probeClaude,
+      claudeProbeFn,
+    );
   } catch {
     cleanup["claude-code"] = { status: "unknown", detail: "Check failed." };
   }

--- a/src/claude-token-status.test.ts
+++ b/src/claude-token-status.test.ts
@@ -18,6 +18,12 @@ function seed(dir: string, body: unknown): string {
   return path;
 }
 
+// Pin the platform explicitly in token-absence tests so the expected verdict
+// is deterministic across host OSes (on macOS, file-absence maps to `unknown`,
+// not `not-configured` — the credential may live in the login keychain).
+const LINUX: NodeJS.Platform = "linux";
+const DARWIN: NodeJS.Platform = "darwin";
+
 describe("claude-token-status", () => {
   let dir: string;
   let env: Record<string, string | undefined>;
@@ -35,13 +41,13 @@ describe("claude-token-status", () => {
     expect(resolveClaudeConfigPath(env)).toBe(join(dir, ".claude.json"));
   });
 
-  test("not-configured when file is missing", () => {
-    expect(readSetupTokenStatus(env)).toBe("not-configured");
+  test("not-configured when file is missing (non-macOS)", () => {
+    expect(readSetupTokenStatus(env, Date.now(), LINUX)).toBe("not-configured");
   });
 
-  test("not-configured when file is empty", () => {
+  test("not-configured when file is empty (non-macOS)", () => {
     seed(dir, "");
-    expect(readSetupTokenStatus(env)).toBe("not-configured");
+    expect(readSetupTokenStatus(env, Date.now(), LINUX)).toBe("not-configured");
   });
 
   test("unknown when file is unparseable", () => {
@@ -73,14 +79,14 @@ describe("claude-token-status", () => {
     expect(readSetupTokenStatus(env)).toBe("configured");
   });
 
-  test("not-configured when oauthAccount block exists but accessToken empty", () => {
+  test("not-configured when oauthAccount block exists but accessToken empty (non-macOS)", () => {
     seed(dir, { oauthAccount: { accessToken: "" } });
-    expect(readSetupTokenStatus(env)).toBe("not-configured");
+    expect(readSetupTokenStatus(env, Date.now(), LINUX)).toBe("not-configured");
   });
 
-  test("not-configured when file is an object with no token-shaped fields", () => {
+  test("not-configured when file is an object with no token-shaped fields (non-macOS)", () => {
     seed(dir, { otherField: 1, deeply: { nested: {} } });
-    expect(readSetupTokenStatus(env)).toBe("not-configured");
+    expect(readSetupTokenStatus(env, Date.now(), LINUX)).toBe("not-configured");
   });
 
   test("unknown when file is a JSON array (unreadable shape)", () => {
@@ -94,5 +100,26 @@ describe("claude-token-status", () => {
       oauthAccount: { accessToken: "x", expiresAt: 1_000_000 },
     });
     expect(readSetupTokenStatus(env, Date.now())).toBe("expired");
+  });
+
+  // --- macOS advisory behavior -------------------------------------------
+  // On macOS the credential may live in the login keychain, so file-absence
+  // is NOT definitive — it maps to `unknown` (advisory), deferring to the
+  // live `claude -p` probe rather than falsely reporting "not configured."
+
+  test("macOS: missing file → unknown (keychain may hold the credential)", () => {
+    expect(readSetupTokenStatus(env, Date.now(), DARWIN)).toBe("unknown");
+  });
+
+  test("macOS: file present but no token-shaped field → unknown, not not-configured", () => {
+    seed(dir, { otherField: 1 });
+    expect(readSetupTokenStatus(env, Date.now(), DARWIN)).toBe("unknown");
+  });
+
+  test("macOS: a real token in the file is still authoritative → configured", () => {
+    // A file-based setup-token sidesteps the keychain — when one is present we
+    // still report `configured` on macOS.
+    seed(dir, { oauthAccount: { accessToken: "sk-ant-xxxx" } });
+    expect(readSetupTokenStatus(env, Date.now(), DARWIN)).toBe("configured");
   });
 });

--- a/src/claude-token-status.ts
+++ b/src/claude-token-status.ts
@@ -11,13 +11,17 @@
  * Status values:
  *
  *   - `configured`    — file exists + carries a token-shaped field.
- *   - `not-configured` — file doesn't exist OR carries no token-shaped field.
+ *   - `not-configured` — (non-macOS only) file doesn't exist OR carries no
+ *                       token-shaped field. On macOS this maps to `unknown`
+ *                       instead — see the macOS caveat on `readSetupTokenStatus`.
  *   - `expired`       — file carries a token field with an explicit expiry
  *                       in the past (Claude Code rotates these — see the
  *                       `expiresAt` field on `oauthAccount` blocks).
- *   - `unknown`       — file exists but unreadable / unparseable. Surfaced
- *                       so the SPA can show "couldn't determine" rather than
- *                       falsely claim "not configured."
+ *   - `unknown`       — file exists but unreadable / unparseable, OR (on
+ *                       macOS) the file carries no token — the credential may
+ *                       live in the login keychain, so the live probe is
+ *                       authoritative. Surfaced so the SPA shows "couldn't
+ *                       determine" rather than falsely claim "not configured."
  *
  * What we look for:
  *
@@ -137,18 +141,39 @@ function parseExpiry(raw: unknown): number | undefined {
  * Return the current setup-token status. Pure-read, no side effects, fast
  * (single file read + parse). The endpoint that calls this is rate-limited
  * by the SPA's Refresh button, not by us.
+ *
+ * **macOS caveat (the "Not logged in" mechanism).** On macOS, Claude Code's
+ * interactive-login credential lives in the *login keychain*, not in
+ * `~/.claude.json`. A launchd-spawned scribe can't unlock that keychain, so
+ * the file may legitimately carry no token even when `claude` is fully
+ * authenticated interactively. Treating file-absence as a definitive
+ * `not-configured` on macOS therefore produces false "not logged in"
+ * verdicts. We instead map file-absence to `unknown` (advisory) on macOS, and
+ * defer to the live `claude -p` probe (run via the admin Refresh button) as
+ * the authoritative signal. Non-macOS keeps the crisp `not-configured`.
+ *
+ * `platform` is injectable so tests can exercise both branches without
+ * depending on the host OS.
  */
 export function readSetupTokenStatus(
   env: Record<string, string | undefined> = process.env,
   now: number = Date.now(),
+  platform: NodeJS.Platform = process.platform,
 ): SetupTokenStatus {
   const path = resolveClaudeConfigPath(env);
   const result = safeReadJson(path);
-  if (result === "missing") return "not-configured";
+  if (result === "missing") {
+    // On macOS the credential may be in the login keychain rather than the
+    // file — file-absence is NOT definitive. Stay advisory (`unknown`) and let
+    // the live probe decide. Elsewhere, file-absence does mean not-configured.
+    return platform === "darwin" ? "unknown" : "not-configured";
+  }
   if (result === "unreadable") return "unknown";
 
   const token = findToken(result);
-  if (!token.found) return "not-configured";
+  if (!token.found) {
+    return platform === "darwin" ? "unknown" : "not-configured";
+  }
   if (token.expiresAt !== undefined && token.expiresAt < now) return "expired";
   return "configured";
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3,6 +3,7 @@ import { createFetchHandler, type ServerDeps } from "./server.ts";
 import type { ResolvedConfig } from "./config-schema.ts";
 import type { Cleaner } from "./providers.ts";
 import type { ScribeConfig } from "./config.ts";
+import { TranscribeBackendError } from "./transcribe/backend-error.ts";
 
 const RESOLVED: ResolvedConfig = {
   transcribeProvider: "parakeet-mlx",
@@ -166,7 +167,7 @@ describe("createFetchHandler — cleanup failure behavior", () => {
     console.error = originalError;
   });
 
-  test("cleanup throw → 200 with raw transcription, not 500", async () => {
+  test("cleanup throw → 200 with raw transcription + cleanup.applied:false + unmissable warning", async () => {
     const throwingCleanup: Cleaner = async () => {
       throw new Error("upstream LLM unreachable");
     };
@@ -178,8 +179,23 @@ describe("createFetchHandler — cleanup failure behavior", () => {
 
     const res = await handler(transcribeReq());
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ text: "raw transcribed words" });
-    expect(errors.some((e) => e.includes("Cleanup failed") && e.includes("upstream LLM unreachable"))).toBe(true);
+    // Raw transcript is still returned (semantics unchanged) — but the
+    // additive `cleanup` field makes the skip legible to the caller.
+    expect(await res.json()).toEqual({
+      text: "raw transcribed words",
+      cleanup: { applied: false, provider: "anthropic", error: "upstream LLM unreachable" },
+    });
+    // The log is now an unmissable WARNING naming the provider + that the
+    // returned transcript is RAW (not the silent single-line console.error).
+    expect(
+      errors.some(
+        (e) =>
+          e.includes("WARNING: cleanup skipped") &&
+          e.includes("provider=anthropic") &&
+          e.includes("upstream LLM unreachable") &&
+          e.includes("RAW transcript returned"),
+      ),
+    ).toBe(true);
   });
 
   test("transcription throw → still 500 (cleanup fallback only covers cleanup)", async () => {
@@ -193,7 +209,27 @@ describe("createFetchHandler — cleanup failure behavior", () => {
     expect(res.status).toBe(500);
   });
 
-  test("cleanup success → 200 with cleaned text", async () => {
+  test("typed TranscribeBackendError (ffmpeg) → structured 503 backend_unavailable, not generic 500", async () => {
+    const handler = buildHandler({
+      transcribe: async () => {
+        throw new TranscribeBackendError(
+          "ffmpeg_unavailable",
+          "The transcription backend needs ffmpeg...",
+        );
+      },
+      resolvedConfig: CLEANUP_RESOLVED,
+    });
+    const res = await handler(transcribeReq());
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; error_code: string; message: string };
+    // Mirrors the missing_provider shape vault's worker JSON-parses:
+    // {error, error_code, message}. error_code is the stable branch key.
+    expect(body.error_code).toBe("backend_unavailable");
+    expect(body.message).toContain("ffmpeg");
+    expect(body.error).toContain("ffmpeg");
+  });
+
+  test("cleanup success → 200 with cleaned text + cleanup.applied:true", async () => {
     const handler = buildHandler({
       transcribe: async () => "raw",
       cleanup: async (text) => `cleaned(${text})`,
@@ -201,7 +237,10 @@ describe("createFetchHandler — cleanup failure behavior", () => {
     });
     const res = await handler(transcribeReq());
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ text: "cleaned(raw)" });
+    expect(await res.json()).toEqual({
+      text: "cleaned(raw)",
+      cleanup: { applied: true, provider: "anthropic" },
+    });
   });
 
   test("threads cleanup.system_prompt + context_template from config into cleaner opts", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,8 @@ import {
   writeConfigFileAtomic,
 } from "./config-write.ts";
 import { readSetupTokenStatus } from "./claude-token-status.ts";
-import { computeBackendAvailability } from "./backend-availability.ts";
+import { computeBackendAvailability, type ClaudeProbeFn } from "./backend-availability.ts";
+import { TranscribeBackendError } from "./transcribe/backend-error.ts";
 import { renderAdminPage } from "./admin-ui.ts";
 import {
   SCOPE_ADMIN,
@@ -67,6 +68,13 @@ export type ServerDeps = {
    * this instead of reading `~/.claude.json`. Production never passes it.
    */
   setupTokenStatusFn?: () => ReturnType<typeof readSetupTokenStatus>;
+  /**
+   * Optional seam for the live `claude -p` auth probe (the `?probe=1` path on
+   * `/admin/backend-availability`). When set, the handler forwards it to
+   * `computeBackendAvailability` so tests never spawn a real `claude`.
+   * Production leaves it undefined → the real subprocess probe is used.
+   */
+  claudeProbeFn?: ClaudeProbeFn;
   /**
    * Mount prefix this scribe instance answers under. Default `""` means
    * "bare routes at the origin root" — legacy behavior, unchanged for
@@ -166,7 +174,10 @@ async function route(
   // Admin actions live under /admin/* — refresh-claude-token-status and
   // clear-credential (Phase 2 polish from scribe#47).
   if (internalPath === "/admin/backend-availability" && req.method === "GET") {
-    return handleBackendAvailability(deps);
+    // `?probe=1` opts into the live `claude -p` auth probe (the SPA's Refresh
+    // button sends it). Absent → fast, file-token-only path (no subprocess).
+    const probeClaude = url.searchParams.get("probe") === "1";
+    return handleBackendAvailability(deps, probeClaude);
   }
   if (internalPath === "/admin/refresh-claude-token-status" && req.method === "POST") {
     return handleRefreshSetupTokenStatus(deps);
@@ -255,11 +266,16 @@ function handleConfigGet(deps: ServerDeps): Response {
  * belt-and-braces: a top-level failure still returns a 200 with an empty
  * report so the page never breaks on this advisory endpoint.
  */
-async function handleBackendAvailability(deps: ServerDeps): Promise<Response> {
+async function handleBackendAvailability(
+  deps: ServerDeps,
+  probeClaude = false,
+): Promise<Response> {
   try {
     const report = await computeBackendAvailability({
       scribeConfig: deps.scribeConfig,
       setupTokenStatusFn: deps.setupTokenStatusFn,
+      probeClaude,
+      claudeProbeFn: deps.claudeProbeFn,
     });
     return Response.json(report);
   } catch (err) {
@@ -604,11 +620,23 @@ export async function runTranscribePipeline(
   try {
     text = await deps.transcribe(file);
   } catch (err: unknown) {
+    // A typed backend error (e.g. ffmpeg missing) is a structured,
+    // operator-fixable failure — return a stable `backend_unavailable` 503
+    // mirroring the `missing_provider` 400 path, so the cause + fix reach the
+    // caller (and vault's transcription worker) instead of an opaque 500.
+    if (err instanceof TranscribeBackendError) {
+      return backendUnavailableResponse(err);
+    }
     const message = err instanceof Error ? err.message : "transcription failed";
     console.error("Transcription error:", message);
     return Response.json({ error: message }, { status: 500 });
   }
 
+  // Cleanup outcome, surfaced on the response so a skipped cleanup is no
+  // longer silent (Part 2 / finding C). `applied:false` carries the short
+  // error; the raw transcript is still returned with a 200 (semantics
+  // unchanged — additive field only).
+  let cleanup: CleanupOutcome | undefined;
   if (doCleanup) {
     try {
       const properNouns = contextPayload
@@ -618,13 +646,54 @@ export async function runTranscribePipeline(
         systemPrompt: deps.scribeConfig.cleanup?.system_prompt,
         contextTemplate: deps.scribeConfig.cleanup?.context_template,
       });
+      cleanup = { applied: true, provider: cleanupProvider };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`Cleanup failed (provider=${cleanupProvider}): ${message} — returning raw transcription`);
+      cleanup = { applied: false, provider: cleanupProvider, error: message };
+      // Unmissable WARNING — the operator must know the returned transcript is
+      // RAW (proper-noun correction NOT applied), not the cleaned text they
+      // configured. (Previously a single quiet console.error.)
+      console.error(
+        `[scribe] WARNING: cleanup skipped (provider=${cleanupProvider}): ${message} — RAW transcript returned, proper-noun correction NOT applied`,
+      );
     }
   }
 
-  return Response.json(source ? { text, source } : { text });
+  const body: { text: string; source?: typeof source; cleanup?: CleanupOutcome } = { text };
+  if (source) body.source = source;
+  if (cleanup) body.cleanup = cleanup;
+  return Response.json(body);
+}
+
+/**
+ * Cleanup outcome surfaced on the transcribe response. Additive +
+ * backwards-compatible: present only when cleanup was attempted (i.e. a
+ * cleanup provider other than `none` was selected for the request). Callers
+ * that don't know the field ignore it; callers that do can detect "raw
+ * transcript returned because cleanup failed" without parsing logs.
+ */
+type CleanupOutcome =
+  | { applied: true; provider: string }
+  | { applied: false; provider: string; error: string };
+
+/**
+ * Structured 503 for a typed transcription-backend failure (today: ffmpeg
+ * missing). Mirrors `missingProviderResponse`'s shape so vault's worker —
+ * which JSON-parses `{error, error_code, message}` — gets a clean,
+ * branch-able body. 503 (≥500) is retriable in vault's `callScribe`, which is
+ * the desired behavior: the operator installs ffmpeg and the next sweep
+ * succeeds without a manual re-queue.
+ */
+function backendUnavailableResponse(err: TranscribeBackendError): Response {
+  console.error(`[scribe] transcription backend unavailable (${err.code}): ${err.message}`);
+  return Response.json(
+    {
+      error: err.message,
+      error_code: "backend_unavailable",
+      message: err.message,
+    },
+    { status: 503 },
+  );
 }
 
 function guardMissingProvider(deps: ServerDeps): Response | null {

--- a/src/site-52-routes.test.ts
+++ b/src/site-52-routes.test.ts
@@ -384,7 +384,13 @@ describe("POST /v1/audio/transcriptions — graceful missing-provider 400", () =
     });
     const res = await handler(audioReq());
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ text: "transcribed" });
+    // BASE_RESOLVED enables cleanup (anthropic, default true) and the stub
+    // cleaner passes the text through — so the response carries the additive
+    // `cleanup.applied:true` field alongside the (unchanged) text.
+    expect(await res.json()).toEqual({
+      text: "transcribed",
+      cleanup: { applied: true, provider: "anthropic" },
+    });
   });
 });
 

--- a/src/transcribe/backend-error.test.ts
+++ b/src/transcribe/backend-error.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the ffmpeg-missing signature detector + the typed backend error.
+ * The detector has to be tolerant — ffmpeg's "not found" phrasing varies
+ * across shells, tool versions, and OSes — without false-positiving on
+ * ordinary output that merely mentions ffmpeg.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  FFMPEG_MISSING_MESSAGE,
+  TranscribeBackendError,
+  looksLikeFfmpegMissing,
+} from "./backend-error.ts";
+
+describe("looksLikeFfmpegMissing", () => {
+  test("matches `ffmpeg: command not found`", () => {
+    expect(looksLikeFfmpegMissing("/bin/sh: ffmpeg: command not found")).toBe(true);
+  });
+
+  test("matches a Python traceback: No such file or directory: 'ffmpeg'", () => {
+    const out = [
+      "Traceback (most recent call last):",
+      "  ...",
+      "FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'",
+    ].join("\n");
+    expect(looksLikeFfmpegMissing(out)).toBe(true);
+  });
+
+  test("matches `ffmpeg is not installed`", () => {
+    expect(looksLikeFfmpegMissing("error: ffmpeg is not installed on this system")).toBe(true);
+  });
+
+  test("matches across non-adjacent lines (ffmpeg named on one line, not-found on another)", () => {
+    const out = "Running ffmpeg to decode audio...\n... later ...\nerror: command not found";
+    expect(looksLikeFfmpegMissing(out)).toBe(true);
+  });
+
+  test("case-insensitive on the ffmpeg token", () => {
+    expect(looksLikeFfmpegMissing("FFMPEG not found")).toBe(true);
+  });
+
+  test("does NOT match ordinary ffmpeg output with no not-found signature", () => {
+    expect(looksLikeFfmpegMissing("ffmpeg version 6.0 Copyright (c) 2000-2023")).toBe(false);
+  });
+
+  test("does NOT match a not-found message that has nothing to do with ffmpeg", () => {
+    expect(looksLikeFfmpegMissing("model checkpoint not found")).toBe(false);
+  });
+
+  test("empty / whitespace output → false", () => {
+    expect(looksLikeFfmpegMissing("")).toBe(false);
+  });
+});
+
+describe("TranscribeBackendError", () => {
+  test("carries the stable code + is an Error", () => {
+    const err = new TranscribeBackendError("ffmpeg_unavailable", FFMPEG_MISSING_MESSAGE);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(TranscribeBackendError);
+    expect(err.code).toBe("ffmpeg_unavailable");
+    expect(err.message).toContain("ffmpeg");
+    expect(err.name).toBe("TranscribeBackendError");
+  });
+});

--- a/src/transcribe/backend-error.ts
+++ b/src/transcribe/backend-error.ts
@@ -1,0 +1,54 @@
+/**
+ * Typed transcription-backend errors — make a class of silent failures
+ * legible to the HTTP layer + downstream callers (vault's transcription
+ * worker).
+ *
+ * The motivating bug: parakeet-mlx (and whisper-ctranslate2) shell out to
+ * `ffmpeg` internally to decode non-WAV audio. When ffmpeg is missing the
+ * tool prints an error but **exits 0** and writes no `.txt` — so the
+ * provider's `exitCode !== 0` gate never fires, and the only signal left was
+ * the opaque `No .txt output found in <tmpDir>` throw, surfaced to the caller
+ * as a generic 500. The operator had no way to know the real cause was a
+ * missing system dependency they could `brew install`.
+ *
+ * `TranscribeBackendError` carries a stable `code` so `runTranscribePipeline`
+ * can branch to a structured 503 `backend_unavailable` response (mirroring
+ * the `missing_provider` 400 path) with an actionable fix message, instead of
+ * the opaque generic-500.
+ */
+
+/** Stable, branch-able failure codes for transcription backends. */
+export type TranscribeBackendErrorCode = "ffmpeg_unavailable";
+
+export class TranscribeBackendError extends Error {
+  readonly code: TranscribeBackendErrorCode;
+  constructor(code: TranscribeBackendErrorCode, message: string) {
+    super(message);
+    this.name = "TranscribeBackendError";
+    this.code = code;
+  }
+}
+
+/**
+ * Detect an ffmpeg-missing signature in a transcription tool's combined
+ * stdout+stderr.
+ *
+ * Tolerant by design — the exact wording varies across ffmpeg shells,
+ * parakeet-mlx / whisper-ctranslate2 versions, and OSes. We require the
+ * co-occurrence of an `ffmpeg` mention with a "not installed / not found"
+ * phrasing anywhere in the output (e.g. `ffmpeg: command not found`,
+ * `[Errno 2] No such file or directory: 'ffmpeg'`, `ffmpeg is not installed`).
+ * The two halves don't have to be adjacent — a multi-line traceback that
+ * names ffmpeg in one line and "No such file" in another still matches.
+ */
+const FFMPEG_TOKEN = /ffmpeg/i;
+const NOT_PRESENT = /not (?:installed|found)|no such file/i;
+
+export function looksLikeFfmpegMissing(combinedOutput: string): boolean {
+  if (!combinedOutput) return false;
+  return FFMPEG_TOKEN.test(combinedOutput) && NOT_PRESENT.test(combinedOutput);
+}
+
+/** Shared, actionable message for the ffmpeg-missing case. */
+export const FFMPEG_MISSING_MESSAGE =
+  "The transcription backend needs `ffmpeg` to decode this audio, but ffmpeg isn't installed or isn't on scribe's PATH. Install it (e.g. `brew install ffmpeg` on macOS, `apt install ffmpeg` on Debian/Ubuntu) and restart scribe.";

--- a/src/transcribe/parakeet-mlx.ts
+++ b/src/transcribe/parakeet-mlx.ts
@@ -1,4 +1,9 @@
 import { $ } from "bun";
+import {
+  FFMPEG_MISSING_MESSAGE,
+  TranscribeBackendError,
+  looksLikeFfmpegMissing,
+} from "./backend-error.ts";
 
 export async function transcribe(audio: File): Promise<string> {
   const id = crypto.randomUUID();
@@ -13,6 +18,12 @@ export async function transcribe(audio: File): Promise<string> {
       .nothrow()
       .quiet();
 
+    // Capture BOTH streams: parakeet-mlx shells to ffmpeg internally and,
+    // when ffmpeg is missing, prints the error then exits 0 (so the
+    // exitCode gate below never fires) — the signature is the only signal.
+    const combined =
+      result.stdout.toString() + "\n" + result.stderr.toString();
+
     if (result.exitCode !== 0) {
       const stderr = result.stderr.toString().trim();
       throw new Error(
@@ -26,7 +37,15 @@ export async function transcribe(audio: File): Promise<string> {
       // parakeet-mlx may use the original filename stem
       const files = await Array.fromAsync(new Bun.Glob("*.txt").scan(tmpDir));
       if (files.length === 0) {
-        throw new Error(`No .txt output found in ${tmpDir}`);
+        // No output AND the tool exited 0 — the classic ffmpeg-missing mask.
+        // Promote to a typed error so the HTTP layer returns an actionable
+        // 503 instead of an opaque 500.
+        if (looksLikeFfmpegMissing(combined)) {
+          throw new TranscribeBackendError("ffmpeg_unavailable", FFMPEG_MISSING_MESSAGE);
+        }
+        throw new Error(
+          `No .txt output found in ${tmpDir} — the backend produced no output, often a missing system dependency (ffmpeg).`,
+        );
       }
       return (await Bun.file(`${tmpDir}/${files[0]}`).text()).trim();
     }

--- a/src/transcribe/whisper.ts
+++ b/src/transcribe/whisper.ts
@@ -1,5 +1,10 @@
 import { $ } from "bun";
 import { getTranscribeProviderConfig } from "../provider-config.ts";
+import {
+  FFMPEG_MISSING_MESSAGE,
+  TranscribeBackendError,
+  looksLikeFfmpegMissing,
+} from "./backend-error.ts";
 
 export async function transcribe(audio: File): Promise<string> {
   const id = crypto.randomUUID();
@@ -17,6 +22,12 @@ export async function transcribe(audio: File): Promise<string> {
       .nothrow()
       .quiet();
 
+    // Capture BOTH streams: whisper-ctranslate2 shells to ffmpeg internally;
+    // a missing ffmpeg can print an error yet exit 0 with no output — the
+    // signature in the combined output is the only signal.
+    const combined =
+      result.stdout.toString() + "\n" + result.stderr.toString();
+
     if (result.exitCode !== 0) {
       const stderr = result.stderr.toString().trim();
       throw new Error(
@@ -32,7 +43,12 @@ export async function transcribe(audio: File): Promise<string> {
     if (!(await file.exists())) {
       const files = await Array.fromAsync(new Bun.Glob("*.txt").scan(tmpDir));
       if (files.length === 0) {
-        throw new Error(`No .txt output found in ${tmpDir}`);
+        if (looksLikeFfmpegMissing(combined)) {
+          throw new TranscribeBackendError("ffmpeg_unavailable", FFMPEG_MISSING_MESSAGE);
+        }
+        throw new Error(
+          `No .txt output found in ${tmpDir} — the backend produced no output, often a missing system dependency (ffmpeg).`,
+        );
       }
       return (await Bun.file(`${tmpDir}/${files[0]}`).text()).trim();
     }


### PR DESCRIPTION
Two triaged "silent failure" classes (feedback findings **B** + **C**), fixed in one cohesive PR: transcription failures now carry an honest cause + fix instead of an opaque 500 or a quietly-dropped warning.

## Part 1 (#2) — ffmpeg preflight + structured backend-unavailable

**The exit-0 masking.** parakeet-mlx (and whisper-ctranslate2) shell out to `ffmpeg` internally to decode non-WAV audio. When ffmpeg is missing the tool prints an error but **exits 0** and writes no `.txt` — so the `exitCode !== 0` gate never fires, and the only signal left was the opaque `No .txt output found in <tmpDir>` throw, surfaced as a generic 500. Operators had no way to know the real cause was a system dependency they could `brew install`.

- New `src/transcribe/backend-error.ts` — `TranscribeBackendError` (stable `code`) + a tolerant `looksLikeFfmpegMissing()` detector.
- parakeet-mlx + whisper now capture **both** stdout and stderr, and — after the exitCode gate, before the no-output throw — scan combined output for the ffmpeg-missing signature; on match they throw the typed error. The residual no-output message now reads "…the backend produced no output, often a missing system dependency (ffmpeg)."
- `runTranscribePipeline` branches on the typed error → structured **503** `{error, error_code: "backend_unavailable", message}` (with `…install ffmpeg (e.g. brew install ffmpeg)…`), mirroring the existing `missing_provider` 400 shape.
- backend-availability: replaced the hardcoded `name === "onnx-asr"` ffmpeg gate with a **`needsFfmpeg` flag** on parakeet-mlx + whisper + onnx-asr — so all three local backends now `warning` (binary present, ffmpeg missing, names ffmpeg + fix) or name ffmpeg in the install fix (binary missing) in the admin UI.

**ffmpeg-detection regex:** co-occurrence in combined output of `/ffmpeg/i` **and** `/not (?:installed|found)|no such file/i` (the two halves need not be adjacent — a multi-line traceback that names ffmpeg on one line and "No such file" on another still matches; ordinary `ffmpeg version 6.0…` output does not).

**How vault's worker consumes the 503 (verified):** `parachute-vault/src/transcription-worker.ts` `callScribe` JSON-parses `{error, error_code, message}` from a non-OK body and keys **retriability on `status >= 500`** (not on `error_code`). So `backend_unavailable` (503) lands as a normal **retriable** failure — exactly right: the backoff window gives the operator time to install ffmpeg, then the next sweep succeeds without a manual re-queue; after `maxAttempts` it flips to `failed` with `transcribe_error` + `transcribe_error_code: "backend_unavailable"`. No unhandled shape. (Contrast `missing_provider` at 400 → terminal-immediate.)

## Part 2 (#3) — surface the silent cleanup skip + real claude auth probe

- **Cleanup-skip signal (additive, backwards-compatible).** The transcribe response now carries a `cleanup` field: `{applied: true, provider}` on success, `{applied: false, provider, error}` when cleanup was skipped. Still **200 + raw transcript** (semantics unchanged). The log line is now an unmissable `[scribe] WARNING: cleanup skipped (provider=…): … — RAW transcript returned, proper-noun correction NOT applied` (was one quiet `console.error`).
- **Real `claude -p` auth probe.** `checkClaudeCode` never executed `claude` — it only read `~/.claude.json`, which is **unreliable on macOS**: Claude Code's interactive-login credential lives in the **login keychain**, which a launchd-spawned scribe can't unlock (that's the live "Not logged in" mechanism). Added a timeout-bounded (~4s) `claude -p` probe.
  - **How it's gated:** behind an explicit `?probe=1` query — the admin UI's existing Refresh button now sends it (`checkAvailability(true)`); initial page load + selection changes call the fast file-token-only path, so **no subprocess spawns on the default per-call path**. Not cached — the operator triggers it on demand.
  - Maps: exit 0 → `available`; non-zero + `/not logged in|invalid api key|unauthorized|authentication/i` → new `unauthenticated` status with fix "…Under launchd the login keychain is unavailable — run `claude setup-token` (file-based token) or set ANTHROPIC_API_KEY, then Refresh."; ENOENT → `unavailable`. Inconclusive / timeout / throw → non-fatal `warning` so a hung probe can't break the endpoint. Runner seam injected for tests.
- **claude-token-status.ts:** on macOS, file-absence-of-token now maps to `unknown` (advisory) rather than a definitive `not-configured`, deferring to the live probe (non-macOS keeps crisp `not-configured`). Platform is injectable for tests.

**New `cleanup` response field shape:**
```jsonc
// success: { "text": "...", "cleanup": { "applied": true, "provider": "anthropic" } }
// skipped: { "text": "<raw>", "cleanup": { "applied": false, "provider": "anthropic", "error": "<short msg>" } }
// no cleanup attempted (provider none / disabled): field omitted
```

## Gates
- `bun test`: **443 pass / 0 fail / 929 expect() calls across 25 files** (baseline 415/24 → **+28 tests**, +1 new test file).
- `bun run typecheck` (`tsc --noEmit`): clean (exit 0).
- **No version bump** (per RC-when-ready governance).
- All probes go through injectable seams — **no real parakeet-mlx / ffmpeg / claude invocations** in tests; nothing binds :1943 or touches the live `~/.parachute`.

## Patterns touched
- Adds a typed-error → structured-error-code response path alongside the existing `missing_provider` convention (stable `error_code` strings as the cross-service contract — vault branches on them).
- Extends the admin backend-availability seam pattern (`which`/`reach`) with a `claudeProbeFn` runner seam + a `probeClaude` opt-in flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)