### PR TITLE
security(scribe): loopback-default bind + bridge config token to auth gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,19 @@ CLEANUP_PROVIDER=none
 # Server port (PORT also honored for back-compat; SCRIBE_PORT takes precedence)
 SCRIBE_PORT=1943
 
+# Bind address. Default 127.0.0.1 (loopback only) — the hub proxy and vault's
+# transcription worker both reach scribe over loopback, so this is safe by
+# default. Set to 0.0.0.0 for Docker bridge networking or an intentional LAN
+# setup; set to a specific interface IP on a multi-homed host. If you expose
+# scribe beyond loopback, set SCRIBE_AUTH_TOKEN too (see below).
+# SCRIBE_BIND=127.0.0.1
+
 # Auth: if set, require "Authorization: Bearer <token>" on all routes except
 # /health and /.parachute/info. Leave unset for open (loopback-only) deployments.
+# When the hub auto-wires vault → scribe it writes this token into
+# ~/.parachute/scribe/config.json (auth.required_token); scribe bridges that
+# into SCRIBE_AUTH_TOKEN at boot, so a configured token enforces even without
+# setting this env var. An explicit value here always wins over the config file.
 # SCRIBE_AUTH_TOKEN=
 
 # --- Transcription provider config ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Library (import transcribe)    ─┘
 ## Key design decisions
 
 - **Stateless by design** — scribe never initiates outbound HTTP. Callers provide whatever context they want cleaned-up around (names, project glossary) in the request payload via the `context` multipart part. The built-in vault client was removed in 0.3.0 (stateless-scribe initiative complete). A stale `vault:` block in an old config logs a one-time warning and is ignored.
-- **Auth gate is opt-in** — `SCRIBE_AUTH_TOKEN` unset = open (loopback-trusted). Set = require `Authorization: Bearer <token>` on every route except `/health` and `/.parachute/info` (liveness probes and module discovery stay open so hub/CLI can reach scribe without knowing a secret). 401 responses carry full CORS headers so browser clients can read the error.
+- **Loopback bind by default** — `Bun.serve` binds `127.0.0.1` (via `src/bind.ts:resolveBindHostname`, `SCRIBE_BIND` override; mirrors vault's `VAULT_BIND`). The hub proxies `/<mount>/*` from :1939 → scribe and vault's transcription worker calls `http://127.0.0.1:1943`, both over loopback — so loopback-default breaks no documented path. Set `SCRIBE_BIND=0.0.0.0` for Docker bridge networking or an intentional LAN exposure. (Pre-scribe#66 scribe bound `0.0.0.0` unconditionally.)
+- **Auth gate is opt-in, and a configured token actually enforces** — `SCRIBE_AUTH_TOKEN` unset = open (loopback-trusted). Set = require `Authorization: Bearer <token>` on every route except `/health` and `/.parachute/info` (liveness probes and module discovery stay open so hub/CLI can reach scribe without knowing a secret). The hub's install-time auto-wire writes the shared secret into `config.json` (`auth.required_token`); scribe bridges that into `SCRIBE_AUTH_TOKEN` at boot (`bridgeConfigAuthToken` in `src/auth.ts`) when the env var isn't already set, so a token configured on disk enforces the gate — an explicit env value always wins. (Pre-scribe#66 the config token was never read, so a configured scribe still ran open.) 401 responses carry full CORS headers so browser clients can read the error.
 - **Scopes declared, not yet enforced** — `scribe:transcribe` + `scribe:admin` are listed under `x-scopes` in the config schema. When the hub starts issuing JWTs, scribe enforces without an API-shape change.
 - **Provider resolution precedence**: `--flag` > `config.json` > env > default. Same three-tier pattern for every knob.
 - **Fail loud, not silent** — malformed `services.json` throws rather than get overwritten (protects sibling services' entries). Malformed config.json throws with the file path in the error.
@@ -57,7 +58,9 @@ Env knobs (full list in `src/cli.ts` `usage()` and `.env.example`):
 
 ```
 SCRIBE_PORT=1943              # server port. PORT also honored for PaaS back-compat.
+SCRIBE_BIND=127.0.0.1         # bind address. Loopback default; 0.0.0.0 to expose.
 SCRIBE_AUTH_TOKEN=            # optional; when set, bearer required on non-exempt routes.
+                              # Also bridged from config.json auth.required_token at boot.
 PARACHUTE_HOME=~/.parachute   # ecosystem root. Overrides default.
 TRANSCRIBE_PROVIDER=parakeet-mlx
 CLEANUP_PROVIDER=none

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -3,6 +3,7 @@ import {
   AUTH_EXEMPT_PATHS,
   SCOPE_ADMIN,
   SCOPE_TRANSCRIBE,
+  bridgeConfigAuthToken,
   constantTimeStringEqual,
   enforceAuth,
   extractBearer,
@@ -262,6 +263,76 @@ describe("auth", () => {
     test("silent when SCRIBE_AUTH_TOKEN is unset (open mode)", () => {
       warnIfTokenLooksJwt();
       expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("bridgeConfigAuthToken (config.json auth.required_token → env)", () => {
+    test("adopts the configured token when the env var is unset", () => {
+      const env: NodeJS.ProcessEnv = {};
+      const source = bridgeConfigAuthToken("cfg-secret", env);
+      expect(source).toBe("config");
+      expect(env.SCRIBE_AUTH_TOKEN).toBe("cfg-secret");
+    });
+
+    test("adopts the configured token when the env var is blank", () => {
+      const env: NodeJS.ProcessEnv = { SCRIBE_AUTH_TOKEN: "   " };
+      const source = bridgeConfigAuthToken("cfg-secret", env);
+      expect(source).toBe("config");
+      expect(env.SCRIBE_AUTH_TOKEN).toBe("cfg-secret");
+    });
+
+    test("explicit env value always wins over the config token", () => {
+      const env: NodeJS.ProcessEnv = { SCRIBE_AUTH_TOKEN: "env-secret" };
+      const source = bridgeConfigAuthToken("cfg-secret", env);
+      expect(source).toBe("env");
+      expect(env.SCRIBE_AUTH_TOKEN).toBe("env-secret");
+    });
+
+    test("no-op when neither env nor config carries a token (stays open)", () => {
+      const env: NodeJS.ProcessEnv = {};
+      const source = bridgeConfigAuthToken(undefined, env);
+      expect(source).toBe("none");
+      expect(env.SCRIBE_AUTH_TOKEN).toBeUndefined();
+    });
+
+    test("ignores a blank configured token (stays open)", () => {
+      const env: NodeJS.ProcessEnv = {};
+      const source = bridgeConfigAuthToken("   ", env);
+      expect(source).toBe("none");
+      expect(env.SCRIBE_AUTH_TOKEN).toBeUndefined();
+    });
+
+    test("bridged token enforces auth: 401 without, 200-equivalent (scopes) with", async () => {
+      const env: NodeJS.ProcessEnv = {};
+      bridgeConfigAuthToken("cfg-secret", env);
+      // Drive the real env-reading seam to prove the bridge enforces.
+      const original = process.env.SCRIBE_AUTH_TOKEN;
+      process.env.SCRIBE_AUTH_TOKEN = env.SCRIBE_AUTH_TOKEN;
+      try {
+        expect(isAuthRequired()).toBe(true);
+
+        const missing = await enforceAuth(
+          new Request("http://localhost/v1/models"),
+          "/v1/models",
+        );
+        expect(missing).toBeInstanceOf(Response);
+        expect((missing as Response).status).toBe(401);
+
+        const ok = await enforceAuth(
+          new Request("http://localhost/v1/models", {
+            headers: { Authorization: "Bearer cfg-secret" },
+          }),
+          "/v1/models",
+        );
+        expect(ok).not.toBeInstanceOf(Response);
+        if (!(ok instanceof Response)) {
+          expect(ok.scopes).toContain(SCOPE_TRANSCRIBE);
+          expect(ok.scopes).toContain(SCOPE_ADMIN);
+        }
+      } finally {
+        if (original === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+        else process.env.SCRIBE_AUTH_TOKEN = original;
+      }
     });
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -112,6 +112,38 @@ export function isAuthRequired(): boolean {
 }
 
 /**
+ * Bridge a token configured on disk (`config.json` `auth.required_token`)
+ * into `SCRIBE_AUTH_TOKEN` so the env-driven auth gate (`isAuthRequired` /
+ * `validateToken`) actually enforces it.
+ *
+ * The hub's install-time auto-wire writes the shared secret into scribe's
+ * `config.json` (`{ auth: { required_token: "<value>" } }`) but does NOT
+ * export `SCRIBE_AUTH_TOKEN` into scribe's process env. Without this bridge,
+ * `isAuthRequired()` (which reads only the env var) returns false even when a
+ * token IS configured — so scribe ran fully open despite the operator having
+ * set a secret. See scribe#66.
+ *
+ * Precedence: an explicit `SCRIBE_AUTH_TOKEN` in the env always wins — the
+ * operator (or a supervisor) set it deliberately, and we never silently
+ * override it with the on-disk value. Only when the env var is unset/blank do
+ * we adopt the config token. Returns the source that won so the caller can
+ * log it; mutates `env` in place (default `process.env`) so `validateToken`
+ * sees the bridged value.
+ */
+export function bridgeConfigAuthToken(
+  configuredToken: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): "env" | "config" | "none" {
+  const fromEnv = env.SCRIBE_AUTH_TOKEN;
+  if (fromEnv && fromEnv.trim()) return "env";
+  if (configuredToken && configuredToken.trim()) {
+    env.SCRIBE_AUTH_TOKEN = configuredToken;
+    return "config";
+  }
+  return "none";
+}
+
+/**
  * Operator footgun guard. The shared-secret compare in `validateToken` runs
  * AFTER the JWT-shape branch — so if SCRIBE_AUTH_TOKEN itself starts with
  * `eyJ` (the base64 prefix of a JWT header), inbound bearers matching that

--- a/src/bind.test.ts
+++ b/src/bind.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBindHostname } from "./bind.ts";
+
+describe("resolveBindHostname", () => {
+  test("defaults to loopback when SCRIBE_BIND is unset", () => {
+    expect(resolveBindHostname({})).toBe("127.0.0.1");
+  });
+
+  test("defaults to loopback when SCRIBE_BIND is empty / whitespace", () => {
+    expect(resolveBindHostname({ SCRIBE_BIND: "" })).toBe("127.0.0.1");
+    expect(resolveBindHostname({ SCRIBE_BIND: "   " })).toBe("127.0.0.1");
+  });
+
+  test("honors an explicit SCRIBE_BIND override (0.0.0.0 to expose)", () => {
+    expect(resolveBindHostname({ SCRIBE_BIND: "0.0.0.0" })).toBe("0.0.0.0");
+  });
+
+  test("honors a specific interface IP and trims surrounding whitespace", () => {
+    expect(resolveBindHostname({ SCRIBE_BIND: "  10.0.0.5 " })).toBe("10.0.0.5");
+  });
+});

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the hostname scribe's HTTP server binds to.
+ *
+ * Default is `127.0.0.1` — loopback-only at the socket level. This is a
+ * defense-in-depth default: the canonical topology reaches scribe over
+ * loopback already (the hub proxies `/<mount>/*` from :1939 → scribe on the
+ * same host; vault's transcription worker calls `http://127.0.0.1:1943`), so
+ * loopback-by-default breaks neither documented path. The previous
+ * `0.0.0.0` bind exposed scribe on every interface — combined with the
+ * formerly-open auth gate (config token not bridged to the check), a
+ * LAN/exposed box let anyone reach `/v1/audio/transcriptions`, the admin
+ * routes, and `/mcp` with no credential. See scribe#66.
+ *
+ * Escape hatch: `SCRIBE_BIND`. Set to `0.0.0.0` for Docker bridge networking
+ * or an intentional LAN setup; set to a specific interface IP for a
+ * multi-homed host. Empty / whitespace values are treated as unset.
+ *
+ * Mirrors `parachute-vault`'s `VAULT_BIND` loopback-default (its
+ * `src/bind.ts:resolveBindHostname`) so the two committed-core daemons share
+ * the same bind story.
+ */
+export function resolveBindHostname(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.SCRIBE_BIND?.trim();
+  if (override) return override;
+  return "127.0.0.1";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,8 +44,11 @@ Environment:
   SCRIBE_CONFIG                       Path to config.json (default: ~/.parachute/scribe/config.json)
   PARACHUTE_HOME                      Override ~/.parachute base (e.g. Docker: /app/.parachute)
   SCRIBE_PORT                         Server port (default: 1943; PORT also honored)
+  SCRIBE_BIND                         Bind address (default: 127.0.0.1 loopback;
+                                      set 0.0.0.0 to expose on all interfaces)
   SCRIBE_AUTH_TOKEN                   Require Bearer <token> on all routes except
-                                      /health and /.parachute/info (optional)
+                                      /health and /.parachute/info (optional;
+                                      also bridged from config.json auth.required_token)
   SCRIBE_URL_MAX_BYTES                Max bytes for /transcribe-url downloads (default: 100 MiB)
   SCRIBE_URL_TIMEOUT_MS               Timeout for /transcribe-url downloads (default: 5 min)
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -43,6 +43,16 @@ describe("config loading + legacy migration", () => {
     expect(cfg.cleanup?.provider).toBe("ollama");
   });
 
+  test("surfaces the auth.required_token block the hub auto-wire writes (scribe#66)", async () => {
+    mkdirSync(join(home, "scribe"), { recursive: true });
+    writeFileSync(
+      join(home, "scribe", "config.json"),
+      JSON.stringify({ auth: { required_token: "hub-wired-secret" } }),
+    );
+    const cfg = await loadConfig();
+    expect(cfg.auth?.required_token).toBe("hub-wired-secret");
+  });
+
   test("migrates legacy config on first load and reads contents", async () => {
     const legacy = join(home, "scribe.config.json");
     const canonical = join(home, "scribe", "config.json");

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,18 @@ export type ProviderBlock = {
 };
 
 export type ScribeConfig = {
+  /**
+   * Auth block. `required_token` is the shared secret the hub's install-time
+   * auto-wire writes here (`{ auth: { required_token: "<value>" } }`) so a
+   * configured operator never has to hand-set an env var. Scribe bridges this
+   * into `SCRIBE_AUTH_TOKEN` at boot (see `bridgeConfigAuthToken` in
+   * `auth.ts`) when the env var isn't already set, so a token configured on
+   * disk actually enforces the bearer gate. Owned by the hub, not the admin
+   * SPA — it is intentionally NOT part of the `PUT /.parachute/config` shape.
+   */
+  auth?: {
+    required_token?: string;
+  };
   transcribe?: {
     provider?: string;
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,12 +41,14 @@ import { renderAdminPage } from "./admin-ui.ts";
 import {
   SCOPE_ADMIN,
   SCOPE_TRANSCRIBE,
+  bridgeConfigAuthToken,
   enforceAuth,
   hasScope,
   insufficientScopeResponse,
   isAuthRequired,
   warnIfTokenLooksJwt,
 } from "./auth.ts";
+import { resolveBindHostname } from "./bind.ts";
 export type ServerDeps = {
   transcribe: ((file: File) => Promise<string>) | null;
   cleanup: Cleaner;
@@ -731,6 +733,14 @@ export async function startServer(opts: StartServerOptions = {}) {
   const config = await loadConfig();
   const mount = normalizeMount(opts.mount ?? "");
 
+  // Bridge a token configured on disk (`config.json` auth.required_token,
+  // written by the hub's install-time auto-wire) into SCRIBE_AUTH_TOKEN so the
+  // env-driven auth gate enforces it. Explicit env always wins. scribe#66.
+  const authSource = bridgeConfigAuthToken(config.auth?.required_token);
+  if (authSource === "config") {
+    console.log("  auth token: bridged from config.json auth.required_token");
+  }
+
   // Transcribe provider: config > env > built-in `parakeet-mlx` default.
   // When even the default isn't viable on the host (e.g. Render container
   // without MLX) the request-time call still raises a runtime error; the
@@ -764,11 +774,20 @@ export async function startServer(opts: StartServerOptions = {}) {
     port: PORT,
   };
 
-  console.log(`scribe listening on :${PORT} (port source: ${portResolution.source})`);
+  const hostname = resolveBindHostname();
+  console.log(`scribe listening on ${hostname}:${PORT} (port source: ${portResolution.source})`);
   console.log(`  transcribe: ${transcribeProviderName}`);
   console.log(`  cleanup:    ${CLEANUP}${CLEANUP !== "none" ? ` (default: ${CLEANUP_DEFAULT})` : ""}`);
   console.log(`  auth:       ${isAuthRequired() ? "bearer (SCRIBE_AUTH_TOKEN or hub JWT)" : "open"}`);
+  console.log(`  bind:       ${hostname}${hostname === "127.0.0.1" ? " (loopback — set SCRIBE_BIND to expose)" : ""}`);
   console.log(`  mount:      ${mount === "" ? "(none — bare routes at origin root)" : mount}`);
+  if (hostname !== "127.0.0.1" && !isAuthRequired()) {
+    console.warn(
+      `[scribe] WARNING: bound to ${hostname} (non-loopback) with auth OPEN — ` +
+        "anyone who can reach this port can transcribe + hit admin routes with no credential. " +
+        "Set SCRIBE_AUTH_TOKEN (or configure auth.required_token via the hub) before exposing scribe.",
+    );
+  }
   warnIfTokenLooksJwt();
 
   const handler = createFetchHandler({
@@ -781,7 +800,7 @@ export async function startServer(opts: StartServerOptions = {}) {
 
   try {
     Bun.serve({
-      hostname: "0.0.0.0",
+      hostname,
       port: PORT,
       fetch: handler,
     });


### PR DESCRIPTION
Closes #66.

## The exposure

Found in the parachute-hub `0.0.0.0`-bind blast-radius review. Two coupled latent problems — not deployed exposed today (aaron/gitcoin/friends don't run scribe), but a real exposure if scribe ever lands on a reachable interface.

1. **Binds all interfaces.** `startServer` hardcoded `Bun.serve({ hostname: "0.0.0.0" })`.
2. **A configured token didn't enforce.** The hub's install-time auto-wire writes the shared secret into scribe's `config.json` as `{ auth: { required_token: "<value>" } }`, but **nothing bridged that into the auth check**. `isAuthRequired()` / `validateToken()` read only `process.env.SCRIBE_AUTH_TOKEN`, and the hub never exports that env var for scribe (it writes provider API keys into scribe's `.env`, but not the auth token). So even a scribe the operator *configured* a token for ran fully **open**.

Combined: a scribe on `0.0.0.0` was reachable with **no credential** on `/v1/audio/transcriptions`, `/.parachute/config`, `/admin/clear-credential/*`, and `/mcp`.

## The fix (both prongs the issue prescribes)

**Bind default → loopback.** New `src/bind.ts:resolveBindHostname` — `127.0.0.1` default, `SCRIBE_BIND` escape hatch. Mirrors vault's `VAULT_BIND` (`parachute-vault/src/bind.ts`) so the two committed-core daemons share one bind story.

**Bridge the config token.** New `bridgeConfigAuthToken(configuredToken, env)` in `src/auth.ts`, called once at boot in `startServer` right after `loadConfig()`. When `config.json auth.required_token` is set **and** `SCRIBE_AUTH_TOKEN` is unset/blank, it adopts the config value into the env var the auth seam already reads. **Explicit env always wins** — we never silently override an operator/supervisor-set token. The `validateToken` seam itself is untouched; it just now receives the value it should have all along. `ScribeConfig.auth?.required_token` is now a typed field (it was already on disk, just never read).

Plus a loud boot `WARNING` when bound non-loopback **and** auth is open.

## Why this keeps both canonical paths working

- **Hub proxy path** (`/<mount>/*` from :1939 → scribe): hub and scribe co-locate; the proxy targets scribe over loopback. Loopback bind keeps it working. Verified against hub's `auto-wire.ts` (`defaultScribeUrl()` → `http://127.0.0.1:1943`).
- **Vault worker path** (`callScribe` in `parachute-vault/src/transcription-worker.ts`): resolves scribe via `resolveScribeUrl()` → `SCRIBE_URL` env or `http://127.0.0.1:<port>` from `services.json` — **loopback**. It sends `Authorization: Bearer <token>` only when `resolveScribeAuthToken()` finds `SCRIBE_AUTH_TOKEN`/`SCRIBE_TOKEN` in vault's env. The hub auto-wire writes the **same** shared secret into both vault's `.env` (`SCRIBE_AUTH_TOKEN`) and scribe's `config.json` (`auth.required_token`). So after this change, scribe enforces the token the worker is already sending — they match, worker keeps working. A standard install therefore stays green; binding loopback doesn't touch it (it was already loopback).

## Operator-visible compatibility

- **LAN-direct callers:** anyone reaching scribe directly over a non-loopback interface today must now set `SCRIBE_BIND=0.0.0.0` (Docker bridge / intentional LAN). This is the safe-and-intended trade-off — open-on-all-interfaces was the bug.
- **Auto-wired token now enforces:** a scribe the hub wired a token into now correctly **requires** the bearer. Vault sends the matching token (unaffected); any *other* caller hitting that scribe with no/wrong token now gets `401` (previously: served open). This is the security fix, not a regression — but it is operator-visible for anyone who was relying on the silently-open behavior of a token-configured box.
- Genuinely-open loopback installs (no token configured, no `SCRIBE_BIND`) are unchanged: loopback + open, exactly as before.

## Tests / gates

- `src/bind.test.ts` — default / empty / `0.0.0.0` override / specific-IP + trim.
- `src/auth.test.ts` — `bridgeConfigAuthToken`: adopt-when-unset, adopt-when-blank, **env-wins**, no-op, blank-config-ignored, plus an end-to-end `enforceAuth` proving `401` without / scoped-pass with the bridged token.
- `src/config.test.ts` — `loadConfig` surfaces the `auth.required_token` block the hub writes.
- `bun test src/`: **454 pass / 0 fail**. `tsc --noEmit`: clean. **No version bump** (per governance — tag-when-ready, not per-PR).

Live-machine safety: all tests run via `createFetchHandler` / tmp homes / injected env — none bind the live :1943 daemon, which was left running untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)