### PR TITLE
ci: bump actions/checkout + setup-node v4 → v6 (Node-20 migration #462)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
@@ -62,11 +62,11 @@ jobs:
       # Required for npm provenance attestation + Trusted Publishing OIDC.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
           # support built in. Node 20 LTS only has npm 10 and would


### PR DESCRIPTION
Bumps the bare `actions/checkout@v4` + `actions/setup-node@v4` aliases in `release.yml` to `@v6`, ahead of GitHub's 2026-06-16 Node-20→24 force-migration. `@v6` natively targets Node 24 and matches parachute-surface. `setup-bun@v2` left as-is. yaml.safe_load + actionlint both clean. Part of ParachuteComputer/parachute-vault#462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)