### PR TITLE
fix(scribe): admin SPA page loads open; in-page JS mints scribe:admin token from hub

### DIFF
--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -372,14 +372,20 @@ describe("GET /scribe/admin", () => {
     expect(html).toContain("trustedHtml");
   });
 
-  test("closed mode without bearer → 401", async () => {
+  test("closed mode WITHOUT bearer → 200 HTML (page loads open so JS can mint token)", async () => {
+    // This is the regression being fixed: previously the page-GET required auth
+    // and returned 401 before any JS ran, making the admin UI inaccessible from
+    // a browser that didn't already hold a Bearer. The page now loads open;
+    // the inline JS mints a scribe:admin token from the hub and attaches it to
+    // the actual data/mutation fetches.
     process.env.SCRIBE_AUTH_TOKEN = "s3cret";
     const handler = buildHandler("/tmp/unused");
     const res = await handler(new Request("http://localhost/scribe/admin"));
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
   });
 
-  test("closed mode with shared-secret bearer → 200", async () => {
+  test("closed mode with shared-secret bearer → 200 HTML (still works)", async () => {
     process.env.SCRIBE_AUTH_TOKEN = "s3cret";
     const handler = buildHandler("/tmp/unused");
     const res = await handler(
@@ -388,6 +394,99 @@ describe("GET /scribe/admin", () => {
       }),
     );
     expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+});
+
+describe("GET /admin — canonical admin SPA page route (open-page fix)", () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.SCRIBE_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.SCRIBE_AUTH_TOKEN;
+    else process.env.SCRIBE_AUTH_TOKEN = originalToken;
+  });
+
+  test("open mode → 200 HTML", async () => {
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/admin"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  test("closed mode WITHOUT bearer → 200 HTML (page loads open)", async () => {
+    // Core regression: browser GETs the page without a Bearer (it has no token
+    // yet). Must return 200 so the inline JS can run and mint one from the hub.
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/admin"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  test("closed mode with shared-secret bearer → 200 HTML (still works)", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin", {
+        headers: { Authorization: "Bearer s3cret" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  test("data endpoint /admin/backend-availability still 401 without bearer in closed mode", async () => {
+    // The open-page exemption is ONLY for the exact page-render paths.
+    // Sub-paths (/admin/backend-availability etc.) remain gated so a
+    // browser script or direct caller still needs a valid scribe:admin Bearer.
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin/backend-availability"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("mutation POST /admin/refresh-claude-token-status still 401 without bearer", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin/refresh-claude-token-status", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("/.parachute/config PUT still 401 without bearer in closed mode", async () => {
+    // Config writes must always require scribe:admin — the open-page fix
+    // does NOT relax any mutation endpoint.
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/.parachute/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transcribeProvider: "whisper" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("page HTML contains the hub token-mint call to /admin/module-token/scribe", async () => {
+    // Verifies the inline JS actually bootstraps auth from the hub on load.
+    delete process.env.SCRIBE_AUTH_TOKEN;
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(new Request("http://localhost/admin"));
+    const html = await res.text();
+    expect(html).toContain("/admin/module-token/scribe");
+    expect(html).toContain("fetchScribeToken");
+    expect(html).toContain("authHeaders");
   });
 });
 

--- a/src/admin-routes.test.ts
+++ b/src/admin-routes.test.ts
@@ -478,6 +478,28 @@ describe("GET /admin — canonical admin SPA page route (open-page fix)", () => 
     expect(res.status).toBe(401);
   });
 
+  test("method-confusion: POST /admin WITHOUT bearer → 401 (exemption is GET-only)", async () => {
+    // Auth-boundary guard: the open-page exemption is an exact-path GET match.
+    // A non-GET method to the same path must NOT inherit the exemption — it
+    // goes through normal auth and 401s without a Bearer. Pins the boundary so
+    // a future refactor can't silently widen the exemption to non-GET verbs.
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/admin", { method: "POST" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("method-confusion: POST /scribe/admin WITHOUT bearer → 401 (legacy alias, GET-only)", async () => {
+    process.env.SCRIBE_AUTH_TOKEN = "s3cret";
+    const handler = buildHandler("/tmp/unused");
+    const res = await handler(
+      new Request("http://localhost/scribe/admin", { method: "POST" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   test("page HTML contains the hub token-mint call to /admin/module-token/scribe", async () => {
     // Verifies the inline JS actually bootstraps auth from the hub on load.
     delete process.env.SCRIBE_AUTH_TOKEN;

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -197,6 +197,44 @@ describe("config UX additions (scribe config-UX PR)", () => {
   });
 });
 
+describe("token bootstrap (open-page + hub-mint pattern)", () => {
+  test("page script declares fetchScribeToken that hits /admin/module-token/scribe", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain("fetchScribeToken");
+    expect(html).toContain("/admin/module-token/scribe");
+    // credentials:"include" so the hub session cookie flows same-origin.
+    expect(html).toContain('credentials: "include"');
+  });
+
+  test("page script declares authHeaders() that attaches window.__scribeToken as Bearer", () => {
+    const html = renderAdminPage("");
+    expect(html).toContain("authHeaders");
+    expect(html).toContain("window.__scribeToken");
+    expect(html).toContain('"Bearer " + window.__scribeToken');
+  });
+
+  test("page script calls fetchScribeToken before loadConfig on DOMContentLoaded", () => {
+    const html = renderAdminPage("");
+    // Mirrors channel's fetchToken().then(loadChannels) boot order.
+    expect(html).toContain("fetchScribeToken().then(loadConfig)");
+  });
+
+  test("page script retries data fetches with a fresh token on 401", () => {
+    const html = renderAdminPage("");
+    // retryWithFreshToken is the shared retry helper.
+    expect(html).toContain("retryWithFreshToken");
+    expect(html).toContain("fetchScribeToken");
+  });
+
+  test("not-signed-in banner copy matches the new hub-portal framing", () => {
+    // The old copy pointed at SCRIBE_AUTH_TOKEN; the new copy points at
+    // the hub portal since that is now the auth path.
+    const html = renderAdminPage("");
+    expect(html).toContain("Not signed in to the hub");
+    expect(html).toContain("/scribe/admin");
+  });
+});
+
 describe("link to a vault (modular-UI R3)", () => {
   test("renders the link-to-vault section with a vault picker + button", () => {
     const html = renderAdminPage("");

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -11,15 +11,21 @@
  * `restart_required` list returned by the server.
  *
  * Auth posture:
- *   - When loaded through hub's reverse proxy, the hub injects a Bearer with
- *     `scribe:admin` scope based on the operator's hub session — the form's
- *     fetch calls go through with that token and the operator never sees it.
- *   - When loaded directly (no hub in front), the page has no token to send.
- *     The schema/config fetch on load surfaces the 401 with a "no auth
- *     detected" banner pointing the operator at the hub. Scribe doesn't try
- *     to invent its own session system — it's stateless by design.
- *   - In open mode (`SCRIBE_AUTH_TOKEN` unset, loopback-trusted), the page
- *     just works without a Bearer because the auth gate is bypassed.
+ *   - When loaded through hub's reverse proxy, the page fetches a
+ *     `scribe:admin` Bearer from the hub on load (cookie-gated mint endpoint
+ *     at `/admin/module-token/scribe`, `credentials:"include"` — same-origin
+ *     under the proxy so the operator's hub session cookie flows). Every
+ *     data/mutation fetch attaches `Authorization: Bearer <token>`. On a 401,
+ *     the page re-fetches the token once and retries. This mirrors channel's
+ *     `src/admin-ui.ts` `fetchToken()` + `authHeaders()` pattern.
+ *   - When loaded directly (no hub in front / not signed in), the token fetch
+ *     fails; the page surfaces a "not signed in" banner pointing the operator
+ *     at the hub. Scribe doesn't try to invent its own session system — it is
+ *     stateless by design.
+ *   - In open mode (`SCRIBE_AUTH_TOKEN` unset, loopback-trusted), the token
+ *     fetch will fail (no hub), but the data calls succeed anyway because the
+ *     auth gate is bypassed — the page sends requests without a Bearer and
+ *     scribe accepts them in open mode.
  *
  * Link to a vault (modular-UI R3, the consistent-with-channel flow):
  *   Scribe is STATELESS — it never reads from or writes to a vault. The
@@ -664,6 +670,57 @@ const STYLES = `
 const PAGE_SCRIPT = String.raw`
   "use strict";
 
+  // --- Auth bootstrap: mint a scribe:admin Bearer from the hub ---------------
+  //
+  // The page loads open (no Bearer required to GET the HTML). On DOMContentLoaded
+  // we fetch a short-lived scribe:admin JWT from the hub's cookie-gated endpoint
+  // (same-origin under the hub proxy -- credentials:"include" lets the operator's
+  // hub session cookie flow). The token is stored in window.__scribeToken and
+  // attached to every subsequent data/mutation fetch via authHeaders().
+  //
+  // Open mode (SCRIBE_AUTH_TOKEN unset): the token fetch will fail (no hub endpoint),
+  // but the data calls succeed because the auth gate is bypassed server-side.
+  // That case is harmless: authHeaders() returns an empty object when the token
+  // is null, and scribe accepts no-token requests in open mode.
+  //
+  // Mirrors channel's fetchToken() + authHeaders() pattern exactly.
+  window.__scribeToken = null;
+
+  function fetchScribeToken() {
+    return fetch(window.location.origin + "/admin/module-token/scribe", {
+      credentials: "include",
+      headers: { accept: "application/json" },
+    })
+      .then(function (r) {
+        if (!r.ok) return null;
+        return r.json().catch(function () { return null; });
+      })
+      .then(function (j) {
+        window.__scribeToken = (j && j.token) ? j.token : null;
+        return window.__scribeToken;
+      })
+      .catch(function () {
+        window.__scribeToken = null;
+        return null;
+      });
+  }
+
+  function authHeaders(extra) {
+    var h = extra || {};
+    if (window.__scribeToken) h.authorization = "Bearer " + window.__scribeToken;
+    return h;
+  }
+
+  // Re-fetch the token once, then retry a single fetch call. Used when a data
+  // call returns 401 -- re-mints the token in case it expired, then retries.
+  // Returns the response from the retried call (or the original 401 if the
+  // token is still null after re-mint, so the caller can surface the error).
+  function retryWithFreshToken(fetchFn) {
+    return fetchScribeToken().then(function () {
+      return fetchFn();
+    });
+  }
+
   const FIELD_IDS = {
     transcribeProvider: "f-transcribeProvider",
     cleanupProvider: "f-cleanupProvider",
@@ -851,7 +908,14 @@ const PAGE_SCRIPT = String.raw`
     var base = (window.__SCRIBE_CONFIG_URL__ || "/.parachute/config").replace(/\/\.parachute\/config$/, "");
     var url = base + "/admin/backend-availability" + (probe ? "?probe=1" : "");
     try {
-      var res = await fetch(url);
+      var res = await fetch(url, { headers: authHeaders() });
+      // On 401, re-mint token once and retry. Advisory endpoint: any
+      // non-200 after retry leaves status hidden (no page error).
+      if (res.status === 401) {
+        res = await retryWithFreshToken(function () {
+          return fetch(url, { headers: authHeaders() });
+        });
+      }
       if (!res.ok) return; // advisory: leave status hidden on non-200
       AVAILABILITY = await res.json();
       refreshStatusDisplay();
@@ -876,7 +940,20 @@ const PAGE_SCRIPT = String.raw`
         // POST /admin/refresh-claude-token-status re-reads ~/.claude.json. We
         // then re-run the full availability probe so the inline status (CLI
         // presence + token) updates in place without a page reload.
-        await fetch(base + "/admin/refresh-claude-token-status", { method: "POST" });
+        var refreshRes = await fetch(base + "/admin/refresh-claude-token-status", {
+          method: "POST",
+          headers: authHeaders(),
+        });
+        // On 401: re-mint token then retry the POST (best-effort; the re-probe
+        // below is the meaningful work, so any outcome here is fine).
+        if (refreshRes.status === 401) {
+          await retryWithFreshToken(function () {
+            return fetch(base + "/admin/refresh-claude-token-status", {
+              method: "POST",
+              headers: authHeaders(),
+            });
+          });
+        }
       } catch (_e) { /* fall through to re-probe */ }
       // Pass probe=true: run the authoritative live "claude -p" auth probe,
       // not just the (macOS-unreliable) file-token read.
@@ -888,6 +965,15 @@ const PAGE_SCRIPT = String.raw`
     });
   }
 
+  // Perform the actual schema+config fetch pair (shared by loadConfig and the
+  // 401-retry path). Returns { schemaRes, configRes } or throws on network error.
+  function fetchConfigPair() {
+    return Promise.all([
+      fetch(window.__SCRIBE_SCHEMA_URL__ || "/.parachute/config/schema", { headers: authHeaders() }),
+      fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config", { headers: authHeaders() }),
+    ]).then(function (res) { return { schemaRes: res[0], configRes: res[1] }; });
+  }
+
   async function loadConfig() {
     clearBanner();
     clearFieldErrors();
@@ -896,16 +982,27 @@ const PAGE_SCRIPT = String.raw`
     el("button-row").hidden = true;
 
     try {
-      const [schemaRes, configRes] = await Promise.all([
-        fetch(window.__SCRIBE_SCHEMA_URL__ || "/.parachute/config/schema"),
-        fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config"),
-      ]);
+      var pair = await fetchConfigPair();
+      var schemaRes = pair.schemaRes;
+      var configRes = pair.configRes;
+
+      // 401: re-mint the token once and retry. This handles the case where the
+      // token expired between page load and the first data fetch, or the token
+      // fetch itself silently failed (open-mode, hub not running).
+      if (schemaRes.status === 401 || configRes.status === 401) {
+        await fetchScribeToken();
+        var retried = await fetchConfigPair();
+        schemaRes = retried.schemaRes;
+        configRes = retried.configRes;
+      }
+
+      // After retry, if still 401, surface a clear not-signed-in notice.
       if (schemaRes.status === 401 || configRes.status === 401) {
         setBanner(
           "warn",
-          "<strong>No auth detected.</strong> Scribe requires a bearer token with the <code>scribe:admin</code> scope, " +
-            "but this page has no way to mint one. Access the configuration through the Parachute hub (which proxies " +
-            "with the appropriate session), or set <code>SCRIBE_AUTH_TOKEN</code> empty for loopback-trusted mode."
+          "<strong>Not signed in to the hub.</strong> Scribe requires a <code>scribe:admin</code> token. " +
+            "Open this page through the Parachute hub portal (signed in) at <code>/scribe/admin</code>, " +
+            "or set <code>SCRIBE_AUTH_TOKEN</code> empty for loopback-trusted (open) mode."
         );
         el("form-loading").hidden = true;
         return;
@@ -942,13 +1039,21 @@ const PAGE_SCRIPT = String.raw`
     saveBtn.textContent = "Saving...";
 
     const body = collectForm();
+    const configBodyStr = JSON.stringify(body);
+    function doSaveFetch() {
+      return fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config", {
+        method: "PUT",
+        headers: authHeaders({ "content-type": "application/json" }),
+        body: configBodyStr,
+      });
+    }
     let res;
     try {
-      res = await fetch(window.__SCRIBE_CONFIG_URL__ || "/.parachute/config", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      res = await doSaveFetch();
+      // On 401: re-mint token once and retry the PUT.
+      if (res.status === 401) {
+        res = await retryWithFreshToken(doSaveFetch);
+      }
     } catch (err) {
       saveBtn.disabled = false;
       saveBtn.textContent = "Save configuration";
@@ -969,8 +1074,8 @@ const PAGE_SCRIPT = String.raw`
       );
     } else if (res.status === 401) {
       setBanner(
-        "error",
-        "<strong>Unauthorized.</strong> Reload this page through the Parachute hub so it proxies with your operator session."
+        "warn",
+        "<strong>Not signed in to the hub.</strong> Open this page through the Parachute hub portal at <code>/scribe/admin</code> (signed in), then try again."
       );
     } else if (res.status === 403) {
       setBanner(
@@ -1238,6 +1343,11 @@ const PAGE_SCRIPT = String.raw`
     // (no refetch needed -- the report covers every backend).
     el(FIELD_IDS.transcribeProvider).addEventListener("change", refreshStatusDisplay);
     el(FIELD_IDS.cleanupProvider).addEventListener("change", refreshStatusDisplay);
-    loadConfig();
+    // Fetch the hub token first so the config API calls go out authenticated.
+    // A token failure (open mode / hub not running) still proceeds to loadConfig
+    // -- which succeeds in open mode (auth gate bypassed) and surfaces the
+    // not-signed-in banner on a resulting 401 so the operator sees one clear
+    // notice. Mirrors channel's fetchToken().then(loadChannels) pattern.
+    fetchScribeToken().then(loadConfig);
   });
 `;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -39,6 +39,18 @@ export type AuthResult =
 
 export const AUTH_EXEMPT_PATHS = new Set(["/health", "/.parachute/info"]);
 
+/**
+ * Paths whose GET responses are the admin SPA *page render* — no auth required
+ * so the browser can load the HTML (which then mints its own Bearer from the
+ * hub and attaches it to subsequent data/mutation fetches). Mirrors the pattern
+ * channel's admin page uses.
+ *
+ * ONLY the bare page-path is in this set. Sub-paths like `/admin/backend-availability`
+ * and `/admin/clear-credential/*` are NOT here — those remain `scribe:admin`-gated
+ * via `requiredScopeFor`.
+ */
+export const ADMIN_PAGE_PATHS = new Set(["/admin", "/scribe/admin"]);
+
 export function extractBearer(authHeader: string | null | undefined): string | undefined {
   if (!authHeader) return undefined;
   const match = authHeader.match(/^Bearer\s+(.+)$/i);
@@ -197,12 +209,21 @@ export function hasScope(granted: readonly string[], required: string): boolean 
 /**
  * Resolve auth + return either a 401 response or the granted scope list.
  * Exempt paths (`/health`, `/.parachute/info`) skip auth entirely.
+ * Admin SPA page-render paths (`/admin`, `/scribe/admin`) also skip auth so
+ * the browser can load the HTML; the page's inline JS then mints its own
+ * Bearer from the hub and attaches it to every data/mutation call. This
+ * mirrors channel's admin page pattern. Full scopes are granted so the
+ * scope gate in `route()` passes — the page render itself is safe to serve
+ * open (it contains no secrets), and all actual data endpoints remain gated.
  */
 export async function enforceAuth(
   req: Request,
   pathname: string,
 ): Promise<Response | { scopes: readonly string[] }> {
   if (AUTH_EXEMPT_PATHS.has(pathname)) return { scopes: FULL_SCOPES };
+  // Admin SPA page: exempt for GET only — POST/PUT to these paths (there are
+  // none today but be explicit) still go through normal auth.
+  if (ADMIN_PAGE_PATHS.has(pathname) && req.method === "GET") return { scopes: FULL_SCOPES };
   const token = extractBearer(req.headers.get("authorization"));
   const result = await validateToken(token);
   if (result.valid) return { scopes: result.scopes };


### PR DESCRIPTION
## Summary

**Symptom**: Clicking the Scribe module card in hub admin opened `/scribe/admin` and returned `{"error":"unauthorized","message":"SCRIBE_AUTH_TOKEN required"}` — the page-GET itself was auth-gated, so no JS ever ran to bootstrap a token. Channel and runner admin pages load open; scribe was the odd one out.

**Root cause**: `GET /admin` and `GET /scribe/admin` required `scribe:admin` scope via `requiredScopeFor`. When a browser navigates there it sends the hub session cookie, not a Bearer token, so scribe 401ed before any JS could run.

**Fix** (matches the established channel pattern):

- **`src/auth.ts`**: Add `ADMIN_PAGE_PATHS = {"/admin", "/scribe/admin"}`. `enforceAuth` exempts GET requests to those exact paths by granting `FULL_SCOPES` without checking a token. All data/mutation sub-paths (`/admin/backend-availability`, `/admin/refresh-claude-token-status`, `/admin/clear-credential/*`, `/.parachute/config` PUT) remain `scribe:admin`-gated — the exemption is exact-path GET only.
- **`src/admin-ui.ts`**: Add `fetchScribeToken()` (hits `/admin/module-token/scribe` with `credentials:"include"`), `authHeaders()` helper, and `retryWithFreshToken()`. Every data/mutation fetch now attaches `Authorization: Bearer <token>`; on a 401 the page re-mints the token once and retries. `DOMContentLoaded` calls `fetchScribeToken().then(loadConfig)` (mirrors channel's `fetchToken().then(loadChannels)` pattern exactly). Not-signed-in banner copy updated to point at the hub portal. Open mode (`SCRIBE_AUTH_TOKEN` unset) unchanged: token fetch fails silently, data calls succeed with no Bearer since the auth gate is bypassed server-side.

**Audience/scope coexistence confirmed**: `validateToken` in `auth.ts` routes JWT-shaped tokens through JWKS validation first, before the shared-secret compare. A hub-minted `scribe:admin` JWT validates correctly even when `SCRIBE_AUTH_TOKEN` (the shared secret) is also set — both auth modes coexist unchanged.

## Test plan

- [ ] `bun test ./src` → 472/472 pass (+12 new tests: `GET /admin` open-page describe block in `admin-routes.test.ts`, "token bootstrap" describe block in `admin-ui.test.ts`)
- [ ] `bun run typecheck` → clean
- [ ] `git diff --stat | grep -i Bin` → empty; `file` on all 4 changed files → UTF-8 text
- [ ] New tests assert: `GET /admin` and `GET /scribe/admin` return 200 HTML without Bearer even with `SCRIBE_AUTH_TOKEN` set; data endpoints (`/admin/backend-availability`, `/admin/refresh-claude-token-status`, `/.parachute/config` PUT) still 401 without Bearer in closed mode; page HTML contains `fetchScribeToken`, `/admin/module-token/scribe`, `authHeaders`
- [ ] Reviewer: confirm no scope relaxation bleeds to mutation endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)