### PR TITLE
release: v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump for the stable push (Aaron's ship call, 2026-06-09 — post-boundary-arc). First stable since 0.4.5: security #66/#69 (loopback-default bind + config-token bridge), modular-UI conformance #71/#72, admin load-open fix #73. Minor bump for the security-posture change. Tag v0.5.0 follows merge; CI publishes to npm @latest on the tag push. 🤖 Generated with [Claude Code](https://claude.com/claude-code)