### PR TITLE
docs(scribe): newcomer onboarding — hub install path + API-key setup + fix stale provider name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@
 #   groq / openai  — Cloud API
 TRANSCRIBE_PROVIDER=parakeet-mlx
 
-# Cleanup provider: claude | claude-code | ollama | openai | gemini | groq | custom | none
-#   claude        — Anthropic API (requires ANTHROPIC_API_KEY)
+# Cleanup provider: anthropic | claude-code | ollama | openai | gemini | groq | custom | none
+#   anthropic     — Anthropic API (requires ANTHROPIC_API_KEY). Renamed from
+#                   `claude` in 0.4.4 — legacy configs auto-migrate on load.
 #   claude-code   — shells out to the `claude` CLI (uses your existing Claude Code auth)
 CLEANUP_PROVIDER=none
 
@@ -46,9 +47,9 @@ SCRIBE_PORT=1943
 
 # --- Cleanup provider config ---
 
-# Claude
+# Anthropic (cleanup provider `anthropic`)
 # ANTHROPIC_API_KEY=
-# CLAUDE_MODEL=claude-sonnet-4-20250514
+# CLAUDE_MODEL=claude-3-5-haiku-20241022   # env var name is CLAUDE_MODEL (unchanged)
 
 # Ollama
 # OLLAMA_URL=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Optional LLM pass that fixes transcription artifacts — filler words, punctuati
 
 Local providers (`parakeet-mlx`, `onnx-asr`, `whisper`, `ollama`, `claude-code`) need no key. Cloud providers need one. Scribe reads a provider's key from three places, in precedence order — **config file > env var > built-in default**:
 
-1. **The admin SPA (hub installs).** Open `<hub-origin>/scribe/admin`, pick your provider, paste the key. Scribe writes it into `~/.parachute/scribe/config.json` under `transcribeProviders.<name>` / `cleanupProviders.<name>`, and the **next** transcription request picks it up — no restart. This is the path for hub-managed installs.
+1. **The admin SPA (hub installs).** Open `<hub-origin>/scribe/admin`, pick your provider, paste the key. Scribe writes it into `~/.parachute/scribe/config.json` under `transcribeProviders.<name>` / `cleanupProviders.<name>`. Updating a **key** for the provider you're already on takes effect on the next request. **Selecting or switching a provider needs a restart** (`parachute restart scribe`) — the admin SPA flags this too. This is the path for hub-managed installs.
 2. **An env var** — the right path for source / CLI runs. Put keys in `~/.parachute/scribe/.env` (or your shell environment):
 
    | Provider | Key env var | Used for |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,29 @@ Audio transcription + LLM cleanup for [Parachute](https://parachute.computer). W
 
 Takes audio in, returns clean text out. The opposite direction of [`@openparachute/narrate`](https://github.com/ParachuteComputer/parachute-narrate).
 
+Conventions (naming, ports, scopes, governance) follow [`parachute-patterns`](https://github.com/ParachuteComputer/parachute-patterns) — the ecosystem-wide source of truth.
+
 ## Quick start
+
+Two ways in: install via the **hub** (the canonical Parachute path), or **clone** the repo to run from source.
+
+### Install via the hub (recommended)
+
+If you've got the Parachute [hub](https://github.com/ParachuteComputer/parachute-hub) running (the portal on `:1939`), one command installs scribe, assigns its canonical port (`1943`), registers it under the hub supervisor, and starts it:
+
+```bash
+parachute install scribe
+```
+
+In a terminal this prompts for a transcription provider + API key. To set them non-interactively:
+
+```bash
+parachute install scribe --scribe-provider groq --scribe-key gsk_…
+```
+
+Once installed, scribe is reachable **through the hub** at `<hub-origin>/scribe/...` — e.g. its admin/config UI is `<hub-origin>/scribe/admin` and the Whisper endpoint is `<hub-origin>/scribe/v1/audio/transcriptions`. The hub proxies `/scribe/*` from `:1939` to scribe on loopback `:1943`. For a local hub, `<hub-origin>` is `http://127.0.0.1:1939`.
+
+### Clone and run from source
 
 Requires [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`).
 
@@ -20,7 +42,7 @@ Transcribe a file:
 bun src/cli.ts recording.wav
 ```
 
-Start the HTTP server:
+Start the HTTP server (port `1943`):
 
 ```bash
 bun src/cli.ts serve
@@ -157,6 +179,25 @@ Optional LLM pass that fixes transcription artifacts — filler words, punctuati
 | `groq` | Cloud | Fast. Requires `GROQ_API_KEY`. |
 | `custom` | Cloud | Any OpenAI-compatible endpoint. See env vars below. |
 | `none` | - | Skip cleanup. Default. |
+
+## Provider setup — where does my API key go?
+
+Local providers (`parakeet-mlx`, `onnx-asr`, `whisper`, `ollama`, `claude-code`) need no key. Cloud providers need one. Scribe reads a provider's key from three places, in precedence order — **config file > env var > built-in default**:
+
+1. **The admin SPA (hub installs).** Open `<hub-origin>/scribe/admin`, pick your provider, paste the key. Scribe writes it into `~/.parachute/scribe/config.json` under `transcribeProviders.<name>` / `cleanupProviders.<name>`, and the **next** transcription request picks it up — no restart. This is the path for hub-managed installs.
+2. **An env var** — the right path for source / CLI runs. Put keys in `~/.parachute/scribe/.env` (or your shell environment):
+
+   | Provider | Key env var | Used for |
+   |---|---|---|
+   | `groq` | `GROQ_API_KEY` | transcription + cleanup |
+   | `openai` | `OPENAI_API_KEY` | transcription + cleanup |
+   | `anthropic` | `ANTHROPIC_API_KEY` | cleanup |
+   | `gemini` | `GEMINI_API_KEY` | cleanup |
+   | `custom` | `CLEANUP_API_KEY` | cleanup |
+
+   `claude-code` is the no-key Anthropic path: it shells out to the [Claude Code CLI](https://claude.com/claude-code) and uses your existing subscription auth — run `claude setup-token` on the host instead of setting a key.
+
+The full env-var surface (model overrides, endpoints) is in [Environment variables](#environment-variables) below; `.env.example` is the copy-paste starting point.
 
 ## Environment variables
 


### PR DESCRIPTION
## Why

Launch on 2026-06-23 invites more people in, and Scribe's onboarding has newcomer gaps. This is docs-only — closing those gaps, grounded in the actual repo (code, `.env.example`, `module.json`, `src/` entrypoints).

## Changes

**README**
- **Hub-install path (new).** The Quick start only showed `git clone`. Added the canonical `parachute install scribe` path — assigns the canonical port (`1943`), registers under the hub supervisor, starts it. Documents reaching scribe *through* the hub at `<hub-origin>/scribe/...` (admin UI `/scribe/admin`, Whisper endpoint `/scribe/v1/audio/transcriptions`; hub proxies `/scribe/*` from `:1939` → loopback `:1943`). Verified against `parachute-hub/src/help.ts` + `module.json` (port 1943, `uiUrl` `/scribe/admin`).
- **"Provider setup — where does my API key go?" (new).** A real newcomer wall. Explains the config-file > env-var > default precedence, the admin-SPA vs `~/.parachute/scribe/.env` paths, and a per-provider key env-var table (only real env vars the code reads). `claude-code` flagged as the no-key path.
- **`parachute-patterns` link** near the top (adoption-checklist convention).

**`.env.example`**
- Fixed the stale cleanup-**provider name** `claude` → `anthropic` (renamed in 0.4.4; legacy configs auto-migrate on load — `migrateClaudeToAnthropic` in `config.ts`).
- Kept the **env var** `CLAUDE_MODEL` — the code genuinely reads `CLAUDE_MODEL` (not `ANTHROPIC_MODEL`); see [provider-config.ts:77](https://github.com/ParachuteComputer/parachute-scribe/blob/ag-scribe-onboarding/src/provider-config.ts#L77). Clarified the label + corrected the example model to the actual code default (`claude-3-5-haiku-20241022`, per `provider-config.ts:56` / `cleanup/anthropic.ts:24`); the old `claude-sonnet-4-20250514` example didn't match the default.

## Verification

- `bun run typecheck` — clean (exit 0).
- `bun test src/` — **474 pass, 0 fail**.
- `.env.example` is documentation only; no code reads/parses it (the two `src/` references are doc comments). The provider name + key env vars match the live registry.

## Note on the provider env-var name (per brief)

The brief asked to verify the env var the code reads before changing `.env.example`. The **provider name** `claude` was stale; the **env var** `CLAUDE_MODEL` is current. `provider-config.ts:77` maps `anthropic → { apiKey: "ANTHROPIC_API_KEY", model: "CLAUDE_MODEL" }`, and there is no `ANTHROPIC_MODEL` anywhere in `src/`. So I changed the provider name and kept `CLAUDE_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)