### PR TITLE
docs(scribe): Linux-friendly onnx-asr install + honest RAM caveat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,17 @@
 # Transcription provider: parakeet-mlx | onnx-asr | whisper | groq | openai
-#   parakeet-mlx  — Mac (Apple Silicon, MLX)
-#   onnx-asr      — Linux (Parakeet via ONNX, pip install onnx-asr[cpu,hub])
-#   whisper        — Any platform (pip install whisper-ctranslate2)
-#   groq / openai  — Cloud API
+#   parakeet-mlx  — macOS / Apple Silicon only (MLX). The default on Mac.
+#   onnx-asr      — the LOCAL backend for Linux (incl. a DigitalOcean droplet).
+#                   Debian/Ubuntu:  sudo apt install -y python3-pip ffmpeg
+#                                   pip install "onnx-asr[cpu,hub]"
+#                   Cross-platform; needs real RAM (see caveat below).
+#   whisper       — any platform (pip install whisper-ctranslate2; needs ffmpeg)
+#   groq / openai — Cloud API. No local model — best for small boxes (set the
+#                   matching *_API_KEY below).
+#
+# RAM caveat for local ASR (onnx-asr / whisper): the model + ONNX Runtime want
+# real memory. A 1 GB droplet likely can't run it (OOM / heavy swap). Use ~2 GB
+# as a floor, 4 GB+ for comfort — or pick a cloud provider (groq/openai) and let
+# the provider's hardware do the work. See README "Local transcription backends".
 TRANSCRIBE_PROVIDER=parakeet-mlx
 
 # Cleanup provider: anthropic | claude-code | ollama | openai | gemini | groq | custom | none

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Transcription provider: parakeet-mlx | onnx-asr | whisper | groq | openai
 #   parakeet-mlx  — macOS / Apple Silicon only (MLX). The default on Mac.
 #   onnx-asr      — the LOCAL backend for Linux (incl. a DigitalOcean droplet).
-#                   Debian/Ubuntu:  sudo apt install -y python3-pip ffmpeg
+#                   Debian/Ubuntu:  sudo apt install -y python3 python3-pip python3-venv ffmpeg
 #                                   pip install "onnx-asr[cpu,hub]"
 #                   Cross-platform; needs real RAM (see caveat below).
 #   whisper       — any platform (pip install whisper-ctranslate2; needs ffmpeg)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ pip install "onnx-asr[cpu,hub]"
 
 # 3. Make `onnx-asr` reachable on scribe's PATH, then select the backend:
 #   TRANSCRIBE_PROVIDER=onnx-asr
+# NOTE: a venv only exports `onnx-asr` while activated — for scribe-as-a-daemon,
+# add ~/.venvs/scribe-asr/bin to scribe's service PATH, or use `uv tool install`
+# above (it puts the binary on PATH directly, no activation needed).
 ```
 
 `onnx-asr[cpu,hub]` pulls in CPU ONNX Runtime plus the model-download helpers.

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ schema declares them under `x-scopes` for forward compat.
 
 | Provider | Type | Notes |
 |----------|------|-------|
-| `parakeet-mlx` | Local | Mac only. NVIDIA Parakeet via MLX. Fastest local option. Default. |
-| `onnx-asr` | Local | Cross-platform. Sherpa-ONNX ASR. |
+| `parakeet-mlx` | Local | macOS / Apple Silicon only (MLX). Fastest local option. Default on Mac. |
+| `onnx-asr` | Local | Cross-platform (the local backend for **Linux**, e.g. a DigitalOcean droplet). Parakeet via ONNX Runtime. See [Local transcription backends](#local-transcription-backends--install--sizing) for install + RAM. |
 | `whisper` | Local | Any platform. Requires `whisper-ctranslate2` (`pip install whisper-ctranslate2`). |
 | `groq` | Cloud | Fast, cheap (~$0.06/hr). Requires `GROQ_API_KEY`. |
 | `openai` | Cloud | Reference Whisper API. Requires `OPENAI_API_KEY`. |
@@ -179,6 +179,85 @@ Optional LLM pass that fixes transcription artifacts — filler words, punctuati
 | `groq` | Cloud | Fast. Requires `GROQ_API_KEY`. |
 | `custom` | Cloud | Any OpenAI-compatible endpoint. See env vars below. |
 | `none` | - | Skip cleanup. Default. |
+
+## Local transcription backends — install & sizing
+
+The local backends (`parakeet-mlx`, `onnx-asr`, `whisper`) run an ASR model on
+your own CPU/GPU — no API key, no per-minute cost, audio never leaves the box.
+The tradeoff is that they need to be installed, and they need real RAM and CPU.
+
+Pick the backend that matches your platform:
+
+- **macOS / Apple Silicon →** `parakeet-mlx` (the default; uses Apple's MLX).
+- **Linux (incl. a DigitalOcean / Hetzner droplet) →** `onnx-asr` (Parakeet via
+  ONNX Runtime). `parakeet-mlx` is macOS-only and won't run here.
+- **Either platform →** `whisper` (`whisper-ctranslate2`), if you prefer Whisper.
+
+### macOS (Apple Silicon)
+
+```bash
+brew install ffmpeg              # decode non-WAV audio (mp3/m4a/…)
+uv tool install parakeet-mlx    # or: pip install parakeet-mlx
+# Make sure the tool is on PATH, then point scribe at it:
+#   TRANSCRIBE_PROVIDER=parakeet-mlx   (the default)
+```
+
+For `onnx-asr` on Mac, follow the Linux `pip install onnx-asr[cpu,hub]` step
+below — it's cross-platform.
+
+### Linux (Debian / Ubuntu — the DigitalOcean case)
+
+```bash
+# 1. System prerequisites: Python + pip + ffmpeg.
+sudo apt update
+sudo apt install -y python3 python3-pip python3-venv ffmpeg
+
+# 2. Install the onnx-asr CLI. A venv keeps it off the system Python:
+python3 -m venv ~/.venvs/scribe-asr
+source ~/.venvs/scribe-asr/bin/activate
+pip install "onnx-asr[cpu,hub]"
+# (uv works too: `uv tool install "onnx-asr[cpu,hub]"`)
+
+# 3. Make `onnx-asr` reachable on scribe's PATH, then select the backend:
+#   TRANSCRIBE_PROVIDER=onnx-asr
+```
+
+`onnx-asr[cpu,hub]` pulls in CPU ONNX Runtime plus the model-download helpers.
+The model (default `nemo-parakeet-tdt-0.6b-v3`) is fetched from Hugging Face on
+first use. `ffmpeg` is required to decode anything that isn't already WAV.
+
+> The admin SPA's backend check (and `GET /scribe/admin/backend-availability`)
+> tells you exactly which binary or system dep is missing — if a backend shows as
+> unavailable, that report names the precise `pip install` / `apt install` fix.
+
+### Sizing caveat — local ASR needs real RAM
+
+The ONNX Parakeet model is **not** tiny once loaded into memory. Be honest with
+yourself about the box:
+
+- **A 1 GB droplet (DigitalOcean's smallest) will struggle.** Loading the model
+  plus ONNX Runtime can exceed available RAM — expect the process to be killed
+  by the OOM killer, or to swap so hard that a few minutes of audio takes a very
+  long time. Don't plan on running local ASR there.
+- **~2 GB RAM is a realistic floor**, and **4 GB+** is comfortable for routine
+  use. More CPU cores = faster transcription; there's no GPU requirement, but a
+  bigger box helps a lot.
+
+If you're on a small droplet and don't want to size up, **use a cloud
+transcription provider instead** — `groq` (fast, ~$0.06/hr) or `openai`. These
+do the heavy lifting on the provider's hardware, so scribe stays light:
+
+```bash
+# Switch scribe to a hosted transcription backend (no local model needed):
+TRANSCRIBE_PROVIDER=groq
+GROQ_API_KEY=gsk_…
+# or: TRANSCRIBE_PROVIDER=openai  +  OPENAI_API_KEY=sk-…
+```
+
+See [Provider setup](#provider-setup--where-does-my-api-key-go) for where that
+key goes (admin SPA, env var, or config file). The other option is to keep local
+ASR but run scribe on a larger box / a dedicated transcription host that vault
+and the hub reach over the network.
 
 ## Provider setup — where does my API key go?
 


### PR DESCRIPTION
## What & why

The local-ASR (`onnx-asr` / ONNX Runtime) install instructions were Mac-centric, but scribe is more likely run on Linux — especially a DigitalOcean droplet. This makes the guidance Linux-friendly and adds an honest RAM/sizing caveat.

## Where the instructions actually were

There is **no `docs/` dir**. The onnx-asr install guidance lived in two doc files:
- **`README.md`** — the transcription-providers table (`onnx-asr` row) + the "Provider setup" section. There was **no dedicated local-backend install section** (no apt prerequisites, no RAM guidance).
- **`.env.example`** — the `TRANSCRIBE_PROVIDER` comment block.

The code already had a cross-platform install `fix` string (`src/backend-availability.ts`: `pip install onnx-asr[cpu,hub]`, and the ffmpeg note already covers `brew` vs `apt`). **No code was touched** — the gap was purely documentation.

## What changed

- **README**: new section **"Local transcription backends — install & sizing"** with a clear **macOS / Linux (Debian/Ubuntu)** split. The Linux path gives the apt prerequisites (`python3 python3-pip python3-venv ffmpeg`) + a venv `pip install "onnx-asr[cpu,hub]"` (uv alternative noted). The `onnx-asr` provider-table row now flags it as the Linux/droplet local backend and deep-links to the new section.
- **RAM caveat** (honest, not hand-wavy): a **1 GB DigitalOcean droplet likely can't run local ASR** (OOM / heavy swap); **~2 GB is a floor, 4 GB+ comfortable**. For small boxes, switch to a cloud provider (`groq`/`openai`) so scribe stays light, or run scribe on a larger / dedicated transcription host. Points at the existing "Provider setup" section for where the key goes.
- **.env.example**: provider comments now name the Linux backend + its apt deps, and carry the same RAM caveat inline.

## Versioning

**Doc-only** (`README.md` + `.env.example`) — per governance's doc-only exemption, **no rc bump**, no code, no gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)