### PR TITLE
feat(scribe): runnable local-backend install routine (doctor --fix / install-backend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ first use. `ffmpeg` is required to decode anything that isn't already WAV.
 > tells you exactly which binary or system dep is missing — if a backend shows as
 > unavailable, that report names the precise `pip install` / `apt install` fix.
 
+**Don't want to run the steps by hand?** Scribe can install the local backend
+for this platform for you — the runnable companion to the diagnose-only report:
+
+```bash
+parachute-scribe doctor              # diagnose every backend (no changes)
+parachute-scribe doctor --fix        # diagnose, then INSTALL the local backend
+parachute-scribe install-backend     # install only (onnx-asr on Linux, parakeet-mlx on macOS)
+parachute-scribe install-backend onnx-asr --skip-model   # explicit backend, skip the model warm-pull
+```
+
+`--fix` / `install-backend` is **idempotent + non-fatal** (safe to re-run; a
+failed step reports and exits non-zero but never leaves a half-install). On
+Linux it apt-installs `python3`/`python3-venv`/`ffmpeg` (using `sudo` when not
+root) and installs the CLI via `uv tool install` or a venv + `pip`; on macOS it
+installs via `uv`/`pip` and instructs `brew install ffmpeg` if ffmpeg is
+missing. It then warm-pulls the default model (`nemo-parakeet-tdt-0.6b-v3`) and
+re-runs the detector to verify. It **refuses** on a box with less than ~2 GB
+available RAM and steers you to a cloud provider (see the sizing caveat below).
+
 ### Sizing caveat — local ASR needs real RAM
 
 The ONNX Parakeet model is **not** tiny once loaded into memory. Be honest with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",

--- a/src/backend-availability.ts
+++ b/src/backend-availability.ts
@@ -209,8 +209,12 @@ const defaultClaudeProbe: ClaudeProbeFn = async () => {
 const CLAUDE_UNAUTH_SIGNATURE = /not logged in|invalid api key|unauthorized|authentication/i;
 
 /**
- * Install command per local transcription CLI. Sourced from README +
- * .env.example.
+ * Install spec per local transcription CLI. The single source of truth for
+ * BOTH the diagnose-only `fix` prose (rendered in the admin SPA) and the
+ * runnable install routine (`src/install-backend.ts`). The `pipPackage` /
+ * `pipExtras` fields are the canonical install target — the prose `fix` is
+ * *derived* from them (see `derivePipFix`) so the two can never drift, and the
+ * installer reuses the same fields rather than re-hardcoding pip args.
  *
  * `needsFfmpeg` marks backends that shell to `ffmpeg` internally to decode
  * non-WAV audio. ffmpeg is a *silent* prerequisite: when it's missing these
@@ -221,28 +225,76 @@ const CLAUDE_UNAUTH_SIGNATURE = /not logged in|invalid api key|unauthorized|auth
  * hardcoded `name === "onnx-asr"` gate), which is why parakeet-mlx/whisper
  * operators hit the silent ffmpeg failure with no warning.
  */
-const TRANSCRIBE_INSTALL: Record<
-  string,
-  { bin: string; fix: string; needsFfmpeg?: boolean }
-> = {
+export type TranscribeInstallSpec = {
+  /** Binary on PATH that proves the backend is installed (the `Bun.which` target). */
+  bin: string;
+  /** Bare pip/PyPI package name (no extras). */
+  pipPackage: string;
+  /** Optional pip "extras" suffix, e.g. `[cpu,hub]` → installs `onnx-asr[cpu,hub]`. */
+  pipExtras?: string;
+  /** Platform restriction, when the backend only runs on one OS. */
+  platform?: "darwin" | "linux";
+  /** Short human label used in the derived prose fix. */
+  label: string;
+  /** The pre-derived diagnose-only fix prose (computed once at module load). */
+  fix: string;
+  needsFfmpeg?: boolean;
+};
+
+/** The pip install target string, e.g. `onnx-asr[cpu,hub]` or `parakeet-mlx`. */
+export function pipTarget(spec: { pipPackage: string; pipExtras?: string }): string {
+  return spec.pipExtras ? `${spec.pipPackage}${spec.pipExtras}` : spec.pipPackage;
+}
+
+/**
+ * Derive the diagnose-only `fix` prose from the structured install spec, so
+ * the prose and the runnable installer share one source for the pip target.
+ */
+function derivePipFix(
+  spec: Omit<TranscribeInstallSpec, "fix">,
+): string {
+  const target = pipTarget(spec);
+  const platformNote =
+    spec.platform === "darwin"
+      ? " (macOS / Apple Silicon only)"
+      : spec.platform === "linux"
+        ? " (Linux)"
+        : " (cross-platform)";
+  // uv is the recommended installer for the macOS tool; pip is the universal fallback.
+  if (spec.platform === "darwin") {
+    return `Install the ${spec.label} CLI${platformNote}: \`uv tool install ${target}\` (or \`pip install ${target}\`), then ensure it's on PATH.`;
+  }
+  return `Install the ${spec.label} CLI: \`pip install ${target}\`${platformNote}, then ensure it's on PATH.`;
+}
+
+function buildSpec(s: Omit<TranscribeInstallSpec, "fix">): TranscribeInstallSpec {
+  return { ...s, fix: derivePipFix(s) };
+}
+
+export const TRANSCRIBE_INSTALL: Record<string, TranscribeInstallSpec> = {
   // parakeet-mlx: macOS / Apple-Silicon only (MLX). Published as a uv/pip tool.
-  "parakeet-mlx": {
+  "parakeet-mlx": buildSpec({
     bin: "parakeet-mlx",
-    fix: "Install the parakeet-mlx CLI (macOS / Apple Silicon only): `uv tool install parakeet-mlx` (or `pip install parakeet-mlx`), then ensure it's on PATH.",
+    pipPackage: "parakeet-mlx",
+    platform: "darwin",
+    label: "parakeet-mlx",
     needsFfmpeg: true,
-  },
-  "onnx-asr": {
+  }),
+  "onnx-asr": buildSpec({
     bin: "onnx-asr",
-    fix: "Install the onnx-asr CLI: `pip install onnx-asr[cpu,hub]` (cross-platform), then ensure it's on PATH.",
+    pipPackage: "onnx-asr",
+    pipExtras: "[cpu,hub]",
+    label: "onnx-asr",
     needsFfmpeg: true,
-  },
+  }),
   // The `whisper` backend shells to the `whisper-ctranslate2` binary, NOT a
   // bare `whisper` — the install command + the PATH check both target it.
-  whisper: {
+  whisper: buildSpec({
     bin: "whisper-ctranslate2",
-    fix: "Install whisper-ctranslate2: `pip install whisper-ctranslate2`, then ensure it's on PATH.",
+    pipPackage: "whisper-ctranslate2",
+    label: "whisper-ctranslate2",
     needsFfmpeg: true,
-  },
+  }),
 };
 
 /** API-backend env-var names — mirrors provider-config.ts so the message names the real var. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,12 @@ import { transcribers, cleaners, getProvider } from "./providers.ts";
 import { startServer } from "./server.ts";
 import { loadConfig } from "./config.ts";
 import { UrlFetchError, fetchAudioFromUrl } from "./url-fetch.ts";
+import { computeBackendAvailability } from "./backend-availability.ts";
+import {
+  buildDefaultDeps,
+  installBackend,
+  platformLocalProvider,
+} from "./install-backend.ts";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -24,6 +30,13 @@ Usage:
   parachute-scribe <file|url>         Transcribe an audio file or URL
   parachute-scribe serve              Start the HTTP server
   parachute-scribe providers          List available providers
+  parachute-scribe doctor             Diagnose every backend's prerequisites
+  parachute-scribe doctor --fix       Diagnose, then INSTALL the platform's
+                                      local backend (apt/pip/uv + ffmpeg + model)
+  parachute-scribe install-backend [provider]
+                                      Install a local backend (default: the one
+                                      matching this platform — onnx-asr on Linux,
+                                      parakeet-mlx on macOS)
 
 Options:
   --transcribe <provider>             Transcription provider (default: parakeet-mlx)
@@ -37,6 +50,14 @@ Serve-only options:
                                       (e.g. --mount /scribe → routes at
                                       /scribe/health, /scribe/v1/...).
                                       Default "" = bare routes at root.
+
+doctor / install-backend options:
+  --fix                               (doctor) Install the platform's local
+                                      backend after diagnosing.
+  --provider <name>                   Backend to install (onnx-asr | parakeet-mlx).
+                                      Default: matches this platform.
+  --skip-model                        Don't warm-pull the model (it downloads
+                                      lazily on first transcription).
 
 Environment:
   TRANSCRIBE_PROVIDER                 Default transcription provider
@@ -71,6 +92,14 @@ switch (command) {
   case "providers":
     console.log(`Transcription: ${Object.keys(transcribers).join(", ")}`);
     console.log(`Cleanup:       ${Object.keys(cleaners).join(", ")}`);
+    break;
+
+  case "doctor":
+    await cmdDoctor();
+    break;
+
+  case "install-backend":
+    await cmdInstallBackend(args[1] && !args[1].startsWith("-") ? args[1] : undefined);
     break;
 
   case "help":
@@ -119,6 +148,67 @@ async function cmdTranscribe(input: string) {
     console.log(JSON.stringify({ text }));
   } else {
     console.log(text);
+  }
+}
+
+/**
+ * `doctor` — diagnose every backend's prerequisites (the same report the admin
+ * SPA renders), and with `--fix`, run the install routine for the platform's
+ * local backend. Exits non-zero when `--fix` was requested but the install
+ * didn't verify, so init/the install script can branch on the exit code.
+ */
+async function cmdDoctor() {
+  const scribeConfig = await loadConfig(getFlag("--config"));
+  const report = await computeBackendAvailability({ scribeConfig });
+
+  console.log("Transcription backends:");
+  for (const [name, v] of Object.entries(report.transcribe)) {
+    console.log(`  ${name.padEnd(14)} ${v.status.padEnd(13)} ${v.detail}`);
+    if (v.fix && (v.status === "unavailable" || v.status === "warning")) {
+      console.log(`  ${" ".repeat(14)}   fix: ${v.fix}`);
+    }
+  }
+  console.log("Cleanup backends:");
+  for (const [name, v] of Object.entries(report.cleanup)) {
+    console.log(`  ${name.padEnd(14)} ${v.status.padEnd(13)} ${v.detail}`);
+    if (v.fix && (v.status === "unavailable" || v.status === "warning" || v.status === "unauthenticated")) {
+      console.log(`  ${" ".repeat(14)}   fix: ${v.fix}`);
+    }
+  }
+
+  if (!hasFlag("--fix")) {
+    console.log("\nRun `parachute-scribe doctor --fix` to install the local backend for this platform.");
+    return;
+  }
+
+  console.log("");
+  await cmdInstallBackend(getFlag("--provider"));
+}
+
+/**
+ * `install-backend [provider]` — install + verify a local transcription
+ * backend. Idempotent + non-fatal; exits non-zero on failure (so a `set -e`
+ * install script can detect it without the whole `curl|bash` aborting if it
+ * chooses to swallow the code).
+ */
+async function cmdInstallBackend(providerArg?: string) {
+  const deps = await buildDefaultDeps();
+  const provider = providerArg ?? getFlag("--provider");
+  const outcome = await installBackend(deps, {
+    provider,
+    skipModel: hasFlag("--skip-model"),
+  });
+  // The human-readable step log already streamed via deps.log; print the final
+  // summary line and set the exit code.
+  if (outcome.ok) {
+    console.log(`\n✓ ${outcome.summary}`);
+  } else {
+    console.error(`\n✗ ${outcome.summary}`);
+    const local = platformLocalProvider(deps.platform);
+    if (local) {
+      console.error(`  Re-run \`parachute-scribe install-backend ${local}\` after addressing the above.`);
+    }
+    process.exit(1);
   }
 }
 

--- a/src/install-backend.test.ts
+++ b/src/install-backend.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Unit tests for the runnable local-backend install routine.
+ *
+ * Every subprocess + platform probe goes through the injected `InstallDeps`
+ * seam, so these tests exercise the orchestration logic, the RAM guard, the
+ * privilege split, and idempotency WITHOUT ever apt/pip-installing anything.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  installBackend,
+  platformLocalProvider,
+  pipTargetFor,
+  DEFAULT_MODEL,
+  MIN_RAM_MIB,
+  type InstallDeps,
+  type RunResult,
+} from "./install-backend.ts";
+
+/** A recorded subprocess invocation. */
+type Recorded = { cmd: string[]; cwd?: string };
+
+type Overrides = Partial<InstallDeps> & {
+  /** Bins reported present by `which`. */
+  present?: string[];
+  /** Per-command-prefix scripted exit codes (matched by join(" ").startsWith). */
+  scripted?: Array<{ match: string; result: RunResult }>;
+};
+
+function ok(stdout = ""): RunResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+function fail(stderr = "boom", exitCode = 1): RunResult {
+  return { exitCode, stdout: "", stderr };
+}
+
+/** Build deps with a recording run() and a which() over the `present` set. */
+function makeDeps(o: Overrides = {}): { deps: InstallDeps; calls: Recorded[] } {
+  const present = new Set(o.present ?? []);
+  const calls: Recorded[] = [];
+  const run: InstallDeps["run"] = async (cmd, opts) => {
+    calls.push({ cmd, cwd: opts?.cwd });
+    const joined = cmd.join(" ");
+    const scripted = (o.scripted ?? []).find((s) => joined.includes(s.match));
+    if (scripted) return scripted.result;
+    return ok();
+  };
+  const deps: InstallDeps = {
+    run: o.run ?? run,
+    which: o.which ?? ((bin) => (present.has(bin) ? `/usr/local/bin/${bin}` : null)),
+    platform: o.platform ?? "linux",
+    availableRamMib: o.availableRamMib ?? (() => 4096),
+    uid: o.uid ?? (() => 0),
+    homeDir: o.homeDir ?? (() => "/home/op"),
+    log: o.log ?? (() => {}),
+    // Hermetic verify: never read the host's ~/.parachute config.
+    loadScribeConfig: o.loadScribeConfig ?? (async () => ({})),
+  };
+  return { deps, calls };
+}
+
+describe("platformLocalProvider", () => {
+  test("linux → onnx-asr", () => {
+    expect(platformLocalProvider("linux")).toBe("onnx-asr");
+  });
+  test("darwin → parakeet-mlx", () => {
+    expect(platformLocalProvider("darwin")).toBe("parakeet-mlx");
+  });
+  test("other → null", () => {
+    expect(platformLocalProvider("win32")).toBeNull();
+  });
+});
+
+describe("RAM guard", () => {
+  test("refuses below the floor and steers to cloud", async () => {
+    const { deps, calls } = makeDeps({ availableRamMib: () => MIN_RAM_MIB - 1 });
+    const out = await installBackend(deps);
+    expect(out.ok).toBe(false);
+    const guard = out.steps.find((s) => s.name === "ram-guard")!;
+    expect(guard.status).toBe("refused");
+    expect(out.summary.toLowerCase()).toContain("groq");
+    // Refusal happens BEFORE any install command runs.
+    expect(calls.length).toBe(0);
+  });
+
+  test("proceeds at exactly the floor", async () => {
+    const { deps } = makeDeps({
+      availableRamMib: () => MIN_RAM_MIB,
+      // already installed so the run is a clean no-op success path
+      present: ["python3", "ffmpeg", "onnx-asr"],
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    const guard = out.steps.find((s) => s.name === "ram-guard")!;
+    expect(guard.status).toBe("ok");
+    expect(out.ok).toBe(true);
+  });
+
+  test("unknown RAM → proceeds (no refusal)", async () => {
+    const { deps } = makeDeps({
+      availableRamMib: () => null,
+      present: ["python3", "ffmpeg", "onnx-asr"],
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    const guard = out.steps.find((s) => s.name === "ram-guard")!;
+    expect(guard.status).toBe("skipped");
+    expect(out.ok).toBe(true);
+  });
+});
+
+describe("idempotency", () => {
+  test("everything present → all skips, no install commands, verifies ok", async () => {
+    const { deps, calls } = makeDeps({
+      present: ["python3", "ffmpeg", "onnx-asr"],
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    expect(out.ok).toBe(true);
+    expect(out.steps.find((s) => s.name === "system-deps")!.status).toBe("skipped");
+    expect(out.steps.find((s) => s.name === "backend-package")!.status).toBe("skipped");
+    // No apt/pip/uv invocations when nothing needs installing.
+    const installCmds = calls.filter((c) =>
+      ["apt-get", "apt", "pip", "uv", "python3"].some((t) => c.cmd[0]?.endsWith(t) || c.cmd[1] === t),
+    );
+    expect(installCmds.length).toBe(0);
+  });
+
+  test("re-running after a partial install does not error", async () => {
+    // First run: nothing present, full install path.
+    const first = makeDeps({ present: [], availableRamMib: () => 4096 });
+    await installBackend(first.deps, { skipModel: true });
+    // Second run: now binary present → idempotent skip.
+    const second = makeDeps({ present: ["python3", "ffmpeg", "onnx-asr"] });
+    const out = await installBackend(second.deps, { skipModel: true });
+    expect(out.ok).toBe(true);
+  });
+});
+
+describe("Linux install path (onnx-asr)", () => {
+  test("installs apt deps + venv pip when nothing present", async () => {
+    const { deps, calls } = makeDeps({
+      present: ["apt-get"], // apt available, nothing else
+      // verify needs onnx-asr present after install — simulate via a which that
+      // flips to present after the pip step. Simpler: override which to report
+      // onnx-asr present (post-install state) for the verify call.
+      which: (() => {
+        let installed = false;
+        return (bin: string) => {
+          if (bin === "apt-get") return "/usr/bin/apt-get";
+          if (bin === "onnx-asr" && installed) return "/home/op/.venvs/scribe-asr/bin/onnx-asr";
+          if (bin === "ffmpeg") return installed ? "/usr/bin/ffmpeg" : null;
+          if (bin === "python3") return installed ? "/usr/bin/python3" : null;
+          // Flip after first apt/pip activity is recorded.
+          return null;
+        };
+      })(),
+    });
+    // Drive the "installed" flip by scripting: after apt install + pip install,
+    // the which above won't auto-flip; instead assert the commands ran.
+    const out = await installBackend(deps, { skipModel: true });
+    const aptUpdate = calls.find((c) => c.cmd.includes("update"));
+    const aptInstall = calls.find((c) => c.cmd.includes("install") && c.cmd.includes("ffmpeg"));
+    const venv = calls.find((c) => c.cmd.includes("venv"));
+    const pip = calls.find((c) => c.cmd.some((a) => a.endsWith("/pip")) && c.cmd.includes("install"));
+    expect(aptUpdate).toBeTruthy();
+    expect(aptInstall).toBeTruthy();
+    expect(venv).toBeTruthy();
+    expect(pip).toBeTruthy();
+    // apt install includes python3-venv (the venv prerequisite).
+    expect(aptInstall!.cmd).toContain("python3-venv");
+    // pip target carries the [cpu,hub] extras from the single-source spec.
+    expect(pip!.cmd.some((a) => a.includes("onnx-asr[cpu,hub]"))).toBe(true);
+    // Did not verify available (which never flipped) → not ok, but non-throwing.
+    expect(out.ok).toBe(false);
+  });
+
+  test("prefers `uv tool install` over a venv when uv is present", async () => {
+    const { deps, calls } = makeDeps({
+      present: ["apt-get", "python3", "ffmpeg", "uv"],
+    });
+    await installBackend(deps, { skipModel: true });
+    const uv = calls.find((c) => c.cmd[0] === "uv" && c.cmd[1] === "tool");
+    const venv = calls.find((c) => c.cmd.includes("venv"));
+    expect(uv).toBeTruthy();
+    expect(uv!.cmd).toContain("onnx-asr[cpu,hub]");
+    expect(venv).toBeUndefined(); // venv fallback not taken
+  });
+
+  test("falls back to venv when uv tool install fails", async () => {
+    const { deps, calls } = makeDeps({
+      present: ["apt-get", "python3", "ffmpeg", "uv"],
+      scripted: [{ match: "uv tool install", result: fail("uv exploded") }],
+    });
+    await installBackend(deps, { skipModel: true });
+    const venv = calls.find((c) => c.cmd.includes("venv"));
+    expect(venv).toBeTruthy();
+  });
+});
+
+describe("privilege split (apt)", () => {
+  test("uses sudo when not root and sudo present", async () => {
+    const { deps, calls } = makeDeps({
+      uid: () => 1000,
+      present: ["apt-get", "sudo"],
+    });
+    await installBackend(deps, { skipModel: true });
+    const aptInstall = calls.find((c) => c.cmd.includes("install") && c.cmd.includes("ffmpeg"));
+    expect(aptInstall!.cmd[0]).toBe("sudo");
+  });
+
+  test("no sudo + not root → system-deps fails with an instruct, no apt run", async () => {
+    const { deps, calls } = makeDeps({
+      uid: () => 1000,
+      present: ["apt-get"], // no sudo, not root
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    const sys = out.steps.find((s) => s.name === "system-deps")!;
+    expect(sys.status).toBe("failed");
+    expect(sys.detail).toContain("sudo");
+    expect(out.ok).toBe(false);
+    // Did not attempt apt without privilege.
+    expect(calls.some((c) => c.cmd.includes("apt-get"))).toBe(false);
+  });
+
+  test("root needs no sudo prefix", async () => {
+    const { deps, calls } = makeDeps({
+      uid: () => 0,
+      present: ["apt-get"],
+    });
+    await installBackend(deps, { skipModel: true });
+    const aptInstall = calls.find((c) => c.cmd.includes("install") && c.cmd.includes("ffmpeg"));
+    expect(aptInstall!.cmd[0]).toBe("apt-get");
+  });
+});
+
+describe("platform mismatch + unsupported", () => {
+  test("parakeet-mlx requested on linux → refused, no install", async () => {
+    const { deps, calls } = makeDeps({ platform: "linux" });
+    const out = await installBackend(deps, { provider: "parakeet-mlx" });
+    expect(out.ok).toBe(false);
+    const step = out.steps.find((s) => s.name === "resolve-backend")!;
+    expect(step.status).toBe("refused");
+    expect(step.detail).toContain("onnx-asr"); // steers to the right one
+    expect(calls.length).toBe(0);
+  });
+
+  test("unknown provider → failed resolve", async () => {
+    const { deps } = makeDeps();
+    const out = await installBackend(deps, { provider: "nope" });
+    expect(out.ok).toBe(false);
+    expect(out.steps[0]!.status).toBe("failed");
+  });
+
+  test("unsupported platform, no provider → failed with cloud steer", async () => {
+    const { deps } = makeDeps({ platform: "win32" });
+    const out = await installBackend(deps);
+    expect(out.ok).toBe(false);
+    expect(out.summary).toContain("win32");
+  });
+});
+
+describe("macOS path (parakeet-mlx)", () => {
+  test("does not apt-install; instructs brew for ffmpeg when missing", async () => {
+    const { deps, calls } = makeDeps({
+      platform: "darwin",
+      present: ["python3"], // no ffmpeg, no parakeet-mlx
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    expect(calls.some((c) => c.cmd.includes("apt-get"))).toBe(false);
+    const sys = out.steps.find((s) => s.name === "system-deps")!;
+    expect(sys.detail).toContain("brew install ffmpeg");
+  });
+
+  test("uses pip/venv (or uv) for parakeet-mlx, model step skipped (no warm-pull verb)", async () => {
+    const { deps, calls } = makeDeps({
+      platform: "darwin",
+      present: ["ffmpeg", "python3", "uv"],
+    });
+    const out = await installBackend(deps, { skipModel: false });
+    const uv = calls.find((c) => c.cmd[0] === "uv" && c.cmd[1] === "tool");
+    expect(uv!.cmd).toContain("parakeet-mlx");
+    const model = out.steps.find((s) => s.name === "model-warm-pull")!;
+    expect(model.status).toBe("skipped"); // parakeet has no separate pull
+  });
+});
+
+describe("model warm-pull (onnx-asr)", () => {
+  test("warm-pulls the default model when not skipped", async () => {
+    const { deps, calls } = makeDeps({
+      present: ["python3", "ffmpeg", "onnx-asr"],
+    });
+    const out = await installBackend(deps, { skipModel: false });
+    const pull = calls.find((c) => c.cmd.includes(DEFAULT_MODEL));
+    expect(pull).toBeTruthy();
+    const step = out.steps.find((s) => s.name === "model-warm-pull")!;
+    expect(step.status).toBe("ok");
+  });
+
+  test("warm-pull failure is non-fatal (skipped, not failed)", async () => {
+    const { deps } = makeDeps({
+      present: ["python3", "ffmpeg", "onnx-asr"],
+      scripted: [{ match: DEFAULT_MODEL, result: fail("model server down") }],
+    });
+    const out = await installBackend(deps, { skipModel: false });
+    const step = out.steps.find((s) => s.name === "model-warm-pull")!;
+    expect(step.status).toBe("skipped");
+    // Backend still verifies available → overall ok despite the model miss.
+    expect(out.ok).toBe(true);
+  });
+
+  test("skipModel records a skipped step and runs no model command", async () => {
+    const { deps, calls } = makeDeps({ present: ["python3", "ffmpeg", "onnx-asr"] });
+    const out = await installBackend(deps, { skipModel: true });
+    expect(out.steps.find((s) => s.name === "model-warm-pull")!.detail).toContain("Skipped by request");
+    expect(calls.some((c) => c.cmd.includes(DEFAULT_MODEL))).toBe(false);
+  });
+});
+
+describe("apt failure is reported, non-throwing", () => {
+  test("apt install failure → system-deps failed, overall not ok", async () => {
+    const { deps } = makeDeps({
+      present: ["apt-get"],
+      uid: () => 0,
+      scripted: [{ match: "apt-get install", result: fail("E: unable to locate package", 100) }],
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    const sys = out.steps.find((s) => s.name === "system-deps")!;
+    expect(sys.status).toBe("failed");
+    expect(out.ok).toBe(false);
+    // Did not proceed to pip after a hard system-dep failure.
+    expect(out.steps.find((s) => s.name === "backend-package")).toBeUndefined();
+  });
+});
+
+describe("verify: installed-but-ffmpeg-missing is a partial success, not a hard fail", () => {
+  test("onnx-asr present, ffmpeg absent → detector warning → ok=true with caveat", async () => {
+    // Linux, root, apt present. python3 + onnx-asr present so package step skips;
+    // ffmpeg ABSENT throughout so apt would try to install it — script that apt
+    // to succeed but keep ffmpeg absent in `which`, so the verify sees a warning.
+    const { deps } = makeDeps({
+      platform: "linux",
+      uid: () => 0,
+      present: ["apt-get", "python3", "onnx-asr"], // no ffmpeg
+      scripted: [{ match: "apt-get install", result: ok() }], // apt "succeeds" but which still lacks ffmpeg
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    const verify = out.steps.find((s) => s.name === "verify")!;
+    expect(verify.status).toBe("skipped");
+    expect(out.ok).toBe(true); // installed; ffmpeg is an operator follow-up, not a fail
+    expect(out.summary).toContain("ffmpeg");
+  });
+
+  test("macOS parakeet present, ffmpeg absent → ok=true (brew instructed, exit 0)", async () => {
+    const { deps } = makeDeps({
+      platform: "darwin",
+      present: ["python3", "parakeet-mlx"], // no ffmpeg
+    });
+    const out = await installBackend(deps, { skipModel: true });
+    expect(out.ok).toBe(true);
+    const verify = out.steps.find((s) => s.name === "verify")!;
+    expect(verify.status).toBe("skipped");
+  });
+});
+
+describe("whisper backend (explicit --provider only)", () => {
+  test("install-backend whisper installs whisper-ctranslate2 via uv", async () => {
+    const { deps, calls } = makeDeps({
+      platform: "linux",
+      uid: () => 0,
+      present: ["apt-get", "python3", "ffmpeg", "uv", "whisper-ctranslate2"],
+    });
+    const out = await installBackend(deps, { provider: "whisper", skipModel: true });
+    // already-present binary → idempotent skip; verify available.
+    expect(out.steps.find((s) => s.name === "backend-package")!.status).toBe("skipped");
+    expect(out.ok).toBe(true);
+    // No uv/pip run since the binary was already present.
+    expect(calls.some((c) => c.cmd[0] === "uv")).toBe(false);
+  });
+
+  test("whisper not present → installs via uv with the bare package name", async () => {
+    const { deps, calls } = makeDeps({
+      platform: "linux",
+      uid: () => 0,
+      present: ["apt-get", "python3", "ffmpeg", "uv"], // whisper-ctranslate2 absent
+    });
+    await installBackend(deps, { provider: "whisper", skipModel: true });
+    const uv = calls.find((c) => c.cmd[0] === "uv" && c.cmd[1] === "tool");
+    expect(uv!.cmd).toContain("whisper-ctranslate2");
+  });
+});
+
+describe("summary carries the venv PATH caveat", () => {
+  test("venv fallback (no uv) → summary mentions adding the venv bin to PATH", async () => {
+    // No uv → venv+pip path. After install, the binary lands in the venv but
+    // `which` won't find it (not on PATH) → detector reports unavailable →
+    // verify failed. To exercise the OK+caveat summary we need verify to pass,
+    // so flip `which` to report onnx-asr present (post-install) for the verify.
+    let installed = false;
+    const { deps } = makeDeps({
+      platform: "linux",
+      uid: () => 0,
+      which: (bin) => {
+        if (["apt-get", "python3", "ffmpeg"].includes(bin)) return `/usr/bin/${bin}`;
+        if (bin === "onnx-asr" && installed) return "/home/op/.venvs/scribe-asr/bin/onnx-asr";
+        return null; // uv absent, onnx-asr absent until installed
+      },
+      scripted: [
+        // mark "installed" once the venv pip install runs
+        { match: "/pip install", result: ok() },
+      ],
+    });
+    // Drive the flip: the run() in makeDeps records calls; we toggle via a custom run.
+    const calls: string[] = [];
+    deps.run = async (cmd) => {
+      calls.push(cmd.join(" "));
+      if (cmd.join(" ").includes("/pip install")) installed = true;
+      return ok();
+    };
+    const out = await installBackend(deps, { skipModel: true });
+    expect(out.ok).toBe(true);
+    expect(out.summary).toContain(".venvs/scribe-asr/bin");
+  });
+});
+
+describe("pipTargetFor", () => {
+  test("onnx-asr carries the [cpu,hub] extras", () => {
+    expect(pipTargetFor("onnx-asr")).toBe("onnx-asr[cpu,hub]");
+  });
+  test("parakeet-mlx is bare", () => {
+    expect(pipTargetFor("parakeet-mlx")).toBe("parakeet-mlx");
+  });
+});

--- a/src/install-backend.ts
+++ b/src/install-backend.ts
@@ -1,0 +1,597 @@
+/**
+ * Runnable install routine for a local transcription backend.
+ *
+ * Companion to `backend-availability.ts`: that module *diagnoses* (reports the
+ * `fix` string an operator would run by hand); this one *runs* it. The
+ * onboarding-streamline arc (2026-06-25) needs `parachute init`, the hub, and
+ * the DigitalOcean install script to actually SET UP local transcription, not
+ * just print what to type. This is the foundational piece those layers call.
+ *
+ * It reuses `TRANSCRIBE_INSTALL` from `backend-availability.ts` as the single
+ * source of truth for the pip package + extras (so the runnable command can
+ * never drift from the diagnosed `fix` prose), and re-runs
+ * `computeBackendAvailability` at the end as the verification step.
+ *
+ * Design contract:
+ *
+ *   - **Diagnose-only path untouched.** Nothing here is wired into the SPA's
+ *     `/admin/backend-availability` endpoint or `computeBackendAvailability`.
+ *     This is an additive runnable layer on top of the existing detector.
+ *   - **Non-fatal + idempotent.** Re-running is safe: an already-present binary
+ *     is a no-op success; `apt install` / `pip install` of present packages is
+ *     a no-op; the model warm-pull is skippable. A failed step reports + sets a
+ *     non-zero exit but never leaves a half-state we can't recover from on the
+ *     next run.
+ *   - **RAM guard.** Below ~2 GB available the routine REFUSES to install a
+ *     local backend (it would OOM) and points the operator at a cloud provider.
+ *   - **Privilege split.** pip/uv run user-level (a venv, or `uv tool`); apt is
+ *     system-level and needs root — we use `sudo` when not already root, and if
+ *     neither root nor sudo is available we instruct rather than fail opaquely.
+ *   - **Injected runner.** Every subprocess + platform probe goes through the
+ *     `InstallDeps` seam so tests exercise the logic, the RAM guard, and
+ *     idempotency WITHOUT ever apt/pip-installing anything.
+ */
+
+import {
+  TRANSCRIBE_INSTALL,
+  pipTarget,
+  computeBackendAvailability,
+  type WhichFn,
+} from "./backend-availability.ts";
+import { loadConfig, type ScribeConfig } from "./config.ts";
+
+/** The pip install target for a named backend, or null if not a local backend. */
+export function pipTargetFor(provider: string): string | null {
+  const spec = TRANSCRIBE_INSTALL[provider];
+  return spec ? pipTarget(spec) : null;
+}
+
+/** Default model warm-pulled for the onnx-asr / parakeet backends. */
+export const DEFAULT_MODEL = "nemo-parakeet-tdt-0.6b-v3";
+
+/** Minimum available RAM (in MiB) below which a local backend is refused. */
+export const MIN_RAM_MIB = 2048;
+
+/** The cloud-provider steer shown when RAM is too low (mirrors the README). */
+export const CLOUD_STEER =
+  "This box has too little RAM for a local ASR model (it would be OOM-killed). " +
+  "Use a cloud transcription provider instead — `groq` (fast, ~$0.06/hr) or `openai`: " +
+  "set `TRANSCRIBE_PROVIDER=groq` and `GROQ_API_KEY=gsk_…` (or via the admin SPA). " +
+  "See README → Local transcription backends — install & sizing.";
+
+/** Outcome of one subprocess step. */
+export type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+/**
+ * Injectable side-effect seam. Defaults run real subprocesses / read real
+ * platform state; tests inject stubs so nothing is actually installed.
+ */
+export type InstallDeps = {
+  /** Run a command, capturing exit code + output. Never throws. */
+  run: (cmd: string[], opts?: { cwd?: string }) => Promise<RunResult>;
+  /** PATH lookup — mirrors backend-availability's `WhichFn`. */
+  which: WhichFn;
+  /** `process.platform` — `"darwin"` | `"linux"` | other. */
+  platform: NodeJS.Platform;
+  /** Available RAM in MiB, or `null` when it can't be determined. */
+  availableRamMib: () => number | null;
+  /** Effective uid; `0` means root. */
+  uid: () => number;
+  /** Home directory (for the venv path). */
+  homeDir: () => string;
+  /** Sink for human-readable progress lines. */
+  log: (line: string) => void;
+  /**
+   * Load the scribe config the verify step passes to the detector. Optional —
+   * defaults to the real `loadConfig()`; tests inject `{}` so verification
+   * stays hermetic (the detector's binary check still flows through `which`).
+   */
+  loadScribeConfig?: () => Promise<ScribeConfig>;
+};
+
+/** Read MemAvailable from /proc/meminfo (Linux). Returns MiB or null. */
+async function readLinuxAvailableRamMib(): Promise<number | null> {
+  try {
+    const text = await Bun.file("/proc/meminfo").text();
+    // MemAvailable is the honest figure (free + reclaimable). Fall back to
+    // MemFree only if MemAvailable is absent (very old kernels).
+    const avail = /^MemAvailable:\s+(\d+)\s*kB/m.exec(text);
+    const free = /^MemFree:\s+(\d+)\s*kB/m.exec(text);
+    const kb = avail ? Number(avail[1]) : free ? Number(free[1]) : null;
+    if (kb === null || !Number.isFinite(kb)) return null;
+    return Math.floor(kb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+/** Default RAM probe: /proc/meminfo on Linux; null elsewhere (no refusal). */
+function defaultAvailableRamMib(): number | null {
+  // Synchronous-shaped seam over an async read: we resolve it eagerly in the
+  // default deps builder so the seam stays sync for tests. See buildDefaultDeps.
+  return null;
+}
+
+/** Real subprocess runner — captures combined output, never throws. */
+const defaultRun: InstallDeps["run"] = async (cmd, opts) => {
+  try {
+    const proc = Bun.spawn(cmd, {
+      cwd: opts?.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+  } catch (err) {
+    // ENOENT / spawn failure: surface as a non-zero result rather than throw,
+    // so a missing tool (e.g. no `apt`) is a reportable step failure.
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 127, stdout: "", stderr: message };
+  }
+};
+
+/** Build the default (real-side-effect) deps. RAM is read eagerly on Linux. */
+export async function buildDefaultDeps(): Promise<InstallDeps> {
+  const ramMib =
+    process.platform === "linux" ? await readLinuxAvailableRamMib() : null;
+  return {
+    run: defaultRun,
+    which: (bin) => Bun.which(bin),
+    platform: process.platform,
+    availableRamMib: () => ramMib ?? defaultAvailableRamMib(),
+    uid: () => (typeof process.getuid === "function" ? process.getuid() : 0),
+    homeDir: () => process.env.HOME ?? process.env.USERPROFILE ?? "/root",
+    log: (line) => console.log(line),
+    loadScribeConfig: () => loadConfig(),
+  };
+}
+
+/** Result of an install run. */
+export type InstallOutcome = {
+  /** `true` when the backend is verified available at the end. */
+  ok: boolean;
+  /** Resolved provider that was targeted. */
+  provider: string;
+  /** Ordered step log (machine-readable companion to the human `log`). */
+  steps: InstallStep[];
+  /** One-line summary for the caller (hub / install script). */
+  summary: string;
+};
+
+export type InstallStep = {
+  name: string;
+  status: "ok" | "skipped" | "failed" | "refused";
+  detail: string;
+};
+
+/**
+ * The local backend that matches the host platform. The onboarding flow uses
+ * this to pick the CORRECT provider (the bug hub PR1 also fixes: the
+ * unconditional `→ parakeet-mlx`). Linux → onnx-asr, macOS → parakeet-mlx.
+ */
+export function platformLocalProvider(
+  platform: NodeJS.Platform,
+): "onnx-asr" | "parakeet-mlx" | null {
+  if (platform === "darwin") return "parakeet-mlx";
+  if (platform === "linux") return "onnx-asr";
+  return null;
+}
+
+type InstallOptions = {
+  /** Explicit provider; when omitted, derive from the platform. */
+  provider?: string;
+  /** Skip the (slow) model warm-pull. */
+  skipModel?: boolean;
+  /** Model id to warm-pull. Defaults to DEFAULT_MODEL. */
+  model?: string;
+};
+
+/**
+ * Install + verify a local transcription backend. Pure orchestration over the
+ * injected `deps`; returns a structured outcome and never throws (every
+ * failure mode is a `failed`/`refused` step).
+ */
+export async function installBackend(
+  deps: InstallDeps,
+  opts: InstallOptions = {},
+): Promise<InstallOutcome> {
+  const steps: InstallStep[] = [];
+  const record = (s: InstallStep): InstallStep => {
+    steps.push(s);
+    return s;
+  };
+
+  const provider = opts.provider ?? platformLocalProvider(deps.platform) ?? "";
+  const spec = TRANSCRIBE_INSTALL[provider];
+
+  // --- Guard: a known local backend on a supported platform ---------------
+  if (!spec) {
+    const detail =
+      provider === ""
+        ? `No local transcription backend is supported on platform "${deps.platform}". Use a cloud provider (groq/openai).`
+        : `"${provider}" is not an installable local backend. Local backends: ${Object.keys(TRANSCRIBE_INSTALL).join(", ")}.`;
+    deps.log(detail);
+    record({ name: "resolve-backend", status: "failed", detail });
+    return { ok: false, provider, steps, summary: detail };
+  }
+
+  // Platform mismatch (e.g. parakeet-mlx on Linux) — refuse loudly.
+  if (spec.platform && spec.platform !== deps.platform) {
+    const detail = `"${provider}" only runs on ${spec.platform}; this host is ${deps.platform}. ${
+      platformLocalProvider(deps.platform)
+        ? `Use \`${platformLocalProvider(deps.platform)}\` here instead.`
+        : "Use a cloud provider (groq/openai)."
+    }`;
+    deps.log(detail);
+    record({ name: "resolve-backend", status: "refused", detail });
+    return { ok: false, provider, steps, summary: detail };
+  }
+
+  deps.log(`Installing local transcription backend: ${provider}`);
+
+  // --- RAM guard ----------------------------------------------------------
+  const ram = deps.availableRamMib();
+  if (ram !== null && ram < MIN_RAM_MIB) {
+    const detail = `Available RAM ${ram} MiB is below the ${MIN_RAM_MIB} MiB floor for local ASR. ${CLOUD_STEER}`;
+    deps.log(detail);
+    record({ name: "ram-guard", status: "refused", detail });
+    return { ok: false, provider, steps, summary: detail };
+  }
+  record({
+    name: "ram-guard",
+    status: ram === null ? "skipped" : "ok",
+    detail:
+      ram === null
+        ? "Could not determine available RAM — proceeding (no refusal)."
+        : `Available RAM ${ram} MiB ≥ ${MIN_RAM_MIB} MiB floor.`,
+  });
+
+  // --- System deps (ffmpeg + python toolchain) via apt --------------------
+  // Only Linux has apt; on macOS we instruct (brew) rather than install, since
+  // python3 ships and ffmpeg is a brew concern we don't want to drive blindly.
+  if (deps.platform === "linux") {
+    const aptStep = await ensureLinuxSystemDeps(deps, spec.needsFfmpeg === true);
+    record(aptStep);
+    if (aptStep.status === "failed") {
+      return {
+        ok: false,
+        provider,
+        steps,
+        summary: `System dependency install failed: ${aptStep.detail}`,
+      };
+    }
+  } else {
+    // macOS: ffmpeg via brew is the operator's call; we check + instruct.
+    const ffStep = checkFfmpegInstruct(deps, spec.needsFfmpeg === true);
+    record(ffStep);
+  }
+
+  // --- Python package (pip in a venv, or uv tool) -------------------------
+  const pkgStep = await ensurePythonPackage(deps, provider, spec);
+  record(pkgStep);
+  if (pkgStep.status === "failed") {
+    return {
+      ok: false,
+      provider,
+      steps,
+      summary: `Backend package install failed: ${pkgStep.detail}`,
+    };
+  }
+
+  // --- Warm-pull the default model ----------------------------------------
+  if (opts.skipModel) {
+    record({ name: "model-warm-pull", status: "skipped", detail: "Skipped by request." });
+  } else {
+    const model = opts.model ?? DEFAULT_MODEL;
+    const modelStep = await warmPullModel(deps, provider, model);
+    record(modelStep);
+    // A model warm-pull failure is non-fatal: the model fetches lazily on the
+    // first real transcription. Report it but don't abort the verify.
+  }
+
+  // --- Verify via the existing detector (single source of truth) ----------
+  const verifyStep = await verifyBackend(deps, provider);
+  record(verifyStep);
+
+  // `ok` (fully available) and `skipped` (installed, but a secondary dep like
+  // ffmpeg still needs the operator) both count as a successful install — the
+  // backend binary is in place. Only a hard `failed` verify is an install fail.
+  const ok = verifyStep.status === "ok" || verifyStep.status === "skipped";
+  // Carry the venv PATH caveat into the summary when the venv fallback ran, so a
+  // caller reading only `summary` (hub / install script) doesn't miss it.
+  const pkgStepFinal = steps.find((s) => s.name === "backend-package");
+  const venvCaveat =
+    pkgStepFinal?.status === "ok" && pkgStepFinal.detail.includes(".venvs/scribe-asr")
+      ? ` NOTE: installed into a venv — add \`${venvDir(deps)}/bin\` to scribe's service PATH (or install \`uv\` and re-run for an on-PATH binary).`
+      : "";
+  let summary: string;
+  if (verifyStep.status === "ok") {
+    summary =
+      `${provider} installed and verified available. ` +
+      (opts.skipModel
+        ? "Model warm-pull skipped — it will download on first transcription."
+        : `Set TRANSCRIBE_PROVIDER=${provider} (or pick it in the admin SPA) and restart scribe.`) +
+      venvCaveat;
+  } else if (verifyStep.status === "skipped") {
+    // Installed, but one more operator step remains (carried in verifyStep.detail).
+    summary = `${provider} installed. ${verifyStep.detail}${venvCaveat}`;
+  } else {
+    summary = `${provider} install ran but verification did not report it available. ${verifyStep.detail}`;
+  }
+  deps.log(summary);
+  return { ok, provider, steps, summary };
+}
+
+/** sudo-if-needed prefix: `[]` when root, `["sudo"]` otherwise (when sudo exists). */
+function sudoPrefix(deps: InstallDeps): { prefix: string[]; haveRoot: boolean; haveSudo: boolean } {
+  const haveRoot = deps.uid() === 0;
+  const haveSudo = deps.which("sudo") !== null;
+  return { prefix: haveRoot ? [] : haveSudo ? ["sudo"] : [], haveRoot, haveSudo };
+}
+
+/**
+ * Ensure ffmpeg + python toolchain on Debian/Ubuntu via apt. Idempotent: apt
+ * is a no-op for already-present packages. Needs root or sudo; instructs if
+ * neither is available rather than producing an opaque permission error.
+ */
+async function ensureLinuxSystemDeps(
+  deps: InstallDeps,
+  needsFfmpeg: boolean,
+): Promise<InstallStep> {
+  // Already satisfied? Then nothing to do (the common idempotent re-run path).
+  const pyOk = deps.which("python3") !== null;
+  const ffOk = !needsFfmpeg || deps.which("ffmpeg") !== null;
+  if (pyOk && ffOk) {
+    return {
+      name: "system-deps",
+      status: "skipped",
+      detail: "python3" + (needsFfmpeg ? " + ffmpeg" : "") + " already present.",
+    };
+  }
+
+  const apt = deps.which("apt-get") ?? deps.which("apt");
+  if (apt === null) {
+    return {
+      name: "system-deps",
+      status: "failed",
+      detail:
+        "No apt found and python3/ffmpeg missing. Install them with your package manager, then re-run.",
+    };
+  }
+
+  const { prefix, haveRoot, haveSudo } = sudoPrefix(deps);
+  if (!haveRoot && !haveSudo) {
+    return {
+      name: "system-deps",
+      status: "failed",
+      detail:
+        "Need root or sudo to apt-install python3/python3-venv" +
+        (needsFfmpeg ? "/ffmpeg" : "") +
+        ". Re-run as root, or run: `sudo apt-get install -y python3 python3-venv" +
+        (needsFfmpeg ? " ffmpeg" : "") +
+        "`, then re-run this command.",
+    };
+  }
+
+  const pkgs = ["python3", "python3-venv", "python3-pip"];
+  if (needsFfmpeg) pkgs.push("ffmpeg");
+
+  deps.log(`Installing system deps via apt: ${pkgs.join(" ")} …`);
+  // `apt-get update` is best-effort — a failure here (e.g. transient mirror)
+  // shouldn't abort if the cache is already warm; we report but continue.
+  const update = await deps.run([...prefix, "apt-get", "update"]);
+  if (update.exitCode !== 0) {
+    deps.log(`apt-get update returned ${update.exitCode} (continuing): ${update.stderr.trim()}`);
+  }
+  const install = await deps.run([
+    ...prefix,
+    "apt-get",
+    "install",
+    "-y",
+    ...pkgs,
+  ]);
+  if (install.exitCode !== 0) {
+    return {
+      name: "system-deps",
+      status: "failed",
+      detail: `apt-get install failed (exit ${install.exitCode}): ${install.stderr.trim() || install.stdout.trim()}`,
+    };
+  }
+  return {
+    name: "system-deps",
+    status: "ok",
+    detail: `Installed: ${pkgs.join(", ")}.`,
+  };
+}
+
+/** macOS: check ffmpeg; instruct the brew install rather than driving it. */
+function checkFfmpegInstruct(deps: InstallDeps, needsFfmpeg: boolean): InstallStep {
+  if (!needsFfmpeg || deps.which("ffmpeg") !== null) {
+    return {
+      name: "system-deps",
+      status: "skipped",
+      detail: needsFfmpeg ? "ffmpeg already present." : "No system deps needed.",
+    };
+  }
+  return {
+    name: "system-deps",
+    status: "skipped",
+    detail:
+      "ffmpeg is missing (needed to decode non-WAV audio). Install it with `brew install ffmpeg`, then re-run.",
+  };
+}
+
+/** The venv directory under the user's home. */
+function venvDir(deps: InstallDeps): string {
+  return `${deps.homeDir()}/.venvs/scribe-asr`;
+}
+
+/**
+ * Install the backend's python package. Two user-level strategies, in order of
+ * preference:
+ *
+ *   1. `uv tool install <pkg>` — puts the binary directly on PATH, no venv
+ *      activation needed (the daemon-friendly path the README recommends).
+ *   2. A dedicated venv + `pip install <pkg>` — keeps it off the system Python.
+ *
+ * Idempotent: if the binary is already on PATH we no-op; uv/pip re-install of a
+ * present package is itself a no-op.
+ */
+async function ensurePythonPackage(
+  deps: InstallDeps,
+  provider: string,
+  spec: { bin: string; pipPackage: string; pipExtras?: string },
+): Promise<InstallStep> {
+  // Already installed? Idempotent no-op.
+  if (deps.which(spec.bin) !== null) {
+    return {
+      name: "backend-package",
+      status: "skipped",
+      detail: `\`${spec.bin}\` already on PATH — nothing to install.`,
+    };
+  }
+
+  const target = pipTarget(spec);
+
+  // Strategy 1: uv tool install (on-PATH binary, no activation).
+  if (deps.which("uv") !== null) {
+    deps.log(`Installing ${target} via \`uv tool install\` …`);
+    const r = await deps.run(["uv", "tool", "install", target]);
+    if (r.exitCode === 0) {
+      return {
+        name: "backend-package",
+        status: "ok",
+        detail: `Installed ${target} via uv tool (on PATH).`,
+      };
+    }
+    deps.log(`uv tool install failed (exit ${r.exitCode}); falling back to a venv + pip.`);
+  }
+
+  // Strategy 2: venv + pip.
+  const venv = venvDir(deps);
+  const pip = `${venv}/bin/pip`;
+  const venvBin = `${venv}/bin/${spec.bin}`;
+
+  // Create the venv (idempotent: re-creating an existing venv is harmless).
+  const mk = await deps.run(["python3", "-m", "venv", venv]);
+  if (mk.exitCode !== 0) {
+    return {
+      name: "backend-package",
+      status: "failed",
+      detail: `Could not create venv at ${venv} (exit ${mk.exitCode}): ${mk.stderr.trim() || mk.stdout.trim()}. Is python3-venv installed?`,
+    };
+  }
+
+  deps.log(`Installing ${target} into ${venv} via pip …`);
+  const install = await deps.run([pip, "install", target]);
+  if (install.exitCode !== 0) {
+    return {
+      name: "backend-package",
+      status: "failed",
+      detail: `pip install ${target} failed (exit ${install.exitCode}): ${install.stderr.trim() || install.stdout.trim()}`,
+    };
+  }
+  return {
+    name: "backend-package",
+    status: "ok",
+    detail:
+      `Installed ${target} into ${venv}. NOTE: a venv only exports \`${spec.bin}\` while activated — ` +
+      `add \`${venv}/bin\` to scribe's service PATH (or install \`uv\` and re-run for an on-PATH binary). ` +
+      `Binary at: ${venvBin}.`,
+  };
+}
+
+/**
+ * Warm-pull the default model so the first real transcription isn't a long
+ * cold download. Best-effort: a failure here is non-fatal (the model fetches
+ * lazily anyway), so this always returns `ok` or `skipped`, never `failed`.
+ * Resolves the just-installed binary from PATH or the venv.
+ */
+async function warmPullModel(
+  deps: InstallDeps,
+  provider: string,
+  model: string,
+): Promise<InstallStep> {
+  // onnx-asr can warm-pull a named model directly. parakeet-mlx fetches its
+  // model implicitly on first use and has no separate pull verb, so we skip it.
+  if (provider !== "onnx-asr") {
+    return {
+      name: "model-warm-pull",
+      status: "skipped",
+      detail: `${provider} downloads its model on first use — no separate warm-pull.`,
+    };
+  }
+
+  const bin =
+    deps.which("onnx-asr") ?? `${venvDir(deps)}/bin/onnx-asr`;
+
+  deps.log(`Warm-pulling model ${model} (one-time download) …`);
+  // `onnx-asr <model> --help` is enough to trigger the model fetch+cache
+  // without needing an audio file; if that interface changes the worst case is
+  // a no-op skip (the model still lazy-loads on first transcription).
+  const r = await deps.run([bin, model, "--help"]);
+  if (r.exitCode === 0) {
+    return {
+      name: "model-warm-pull",
+      status: "ok",
+      detail: `Model ${model} cached.`,
+    };
+  }
+  return {
+    name: "model-warm-pull",
+    status: "skipped",
+    detail: `Could not warm-pull ${model} now (exit ${r.exitCode}); it will download on first transcription.`,
+  };
+}
+
+/**
+ * Verify the install by re-running the EXISTING detector
+ * (`computeBackendAvailability`). Single source of truth: if the SPA would
+ * show this backend as available, so do we.
+ */
+async function verifyBackend(deps: InstallDeps, provider: string): Promise<InstallStep> {
+  let scribeConfig: ScribeConfig;
+  try {
+    scribeConfig = await (deps.loadScribeConfig ?? loadConfig)();
+  } catch {
+    scribeConfig = {};
+  }
+  const report = await computeBackendAvailability({
+    which: deps.which,
+    scribeConfig,
+  });
+  const verdict = report.transcribe[provider];
+  if (!verdict) {
+    return {
+      name: "verify",
+      status: "failed",
+      detail: `Detector returned no verdict for ${provider}.`,
+    };
+  }
+  if (verdict.status === "available") {
+    return { name: "verify", status: "ok", detail: verdict.detail };
+  }
+  // "warning" means the backend BINARY is installed but a secondary dependency
+  // the operator must address remains (e.g. ffmpeg missing on macOS, where we
+  // instruct `brew install ffmpeg` rather than driving it). The install itself
+  // succeeded — treat it as a partial success ("skipped", non-fatal) carrying
+  // the detector's own fix, NOT a hard failure that exits 1 on an installed box.
+  if (verdict.status === "warning") {
+    return {
+      name: "verify",
+      status: "skipped",
+      detail: `${verdict.detail}${verdict.fix ? " " + verdict.fix : ""}`,
+    };
+  }
+  // unavailable / unknown / etc — the backend isn't usable. Hard fail.
+  return {
+    name: "verify",
+    status: "failed",
+    detail: `${verdict.detail}${verdict.fix ? " " + verdict.fix : ""}`,
+  };
+}

--- a/src/install-backend.ts
+++ b/src/install-backend.ts
@@ -49,10 +49,17 @@ export function pipTargetFor(provider: string): string | null {
 /** Default model warm-pulled for the onnx-asr / parakeet backends. */
 export const DEFAULT_MODEL = "nemo-parakeet-tdt-0.6b-v3";
 
-/** Minimum available RAM (in MiB) below which a local backend is refused. */
+/**
+ * Minimum available RAM (in MiB) below which a local backend is refused.
+ * Exported for hub / the DO install script to read the same floor (don't
+ * rename without updating those consumers).
+ */
 export const MIN_RAM_MIB = 2048;
 
-/** The cloud-provider steer shown when RAM is too low (mirrors the README). */
+/**
+ * The cloud-provider steer shown when RAM is too low (mirrors the README).
+ * Exported for hub / the DO install script to reuse verbatim.
+ */
 export const CLOUD_STEER =
   "This box has too little RAM for a local ASR model (it would be OOM-killed). " +
   "Use a cloud transcription provider instead — `groq` (fast, ~$0.06/hr) or `openai`: " +
@@ -531,9 +538,11 @@ async function warmPullModel(
     deps.which("onnx-asr") ?? `${venvDir(deps)}/bin/onnx-asr`;
 
   deps.log(`Warm-pulling model ${model} (one-time download) …`);
-  // `onnx-asr <model> --help` is enough to trigger the model fetch+cache
-  // without needing an audio file; if that interface changes the worst case is
-  // a no-op skip (the model still lazy-loads on first transcription).
+  // FRAGILE: assumes `onnx-asr <model> --help` triggers the model fetch+cache
+  // without needing an audio file. If that CLI interface changes the worst case
+  // is a no-op skip (the model still lazy-loads on first transcription) — but a
+  // regression here would silently lose the warm-pull, so verify against the
+  // real onnx-asr CLI when bumping it.
   const r = await deps.run([bin, model, "--help"]);
   if (r.exitCode === 0) {
     return {


### PR DESCRIPTION
## What

Item 1 (the **foundational** piece) of the onboarding-streamline arc: turn the per-backend `fix` install-command strings that `src/backend-availability.ts` already **computes** into a **runnable** install routine. `parachute init`, the hub, and the DigitalOcean install script can now **set up** local transcription, not just diagnose it.

## Interface (what hub + the install script call)

```bash
parachute-scribe doctor                       # diagnose every backend (no changes; read-only)
parachute-scribe doctor --fix                 # diagnose, then INSTALL the platform's local backend
parachute-scribe install-backend [provider]   # install only; default = platform's backend
parachute-scribe install-backend onnx-asr --skip-model   # explicit backend, skip the model warm-pull
```

- Default provider is **platform-resolved**: Linux → `onnx-asr`, macOS → `parakeet-mlx` (also fixes the unconditional `→ parakeet-mlx` bug hub PR1 targets).
- **Exit code**: `0` on success (incl. installed-but-ffmpeg-missing partial success), **non-zero** on a hard failure — so init / the install script can branch on it.
- Library entry: `installBackend(deps: InstallDeps, opts)` in `src/install-backend.ts` returns a structured `{ ok, provider, steps[], summary }` and never throws. `platformLocalProvider(platform)` + `pipTargetFor(provider)` are exported helpers.

## What it installs per platform

- **Linux (Debian/Ubuntu)**: `apt-get install python3 python3-venv python3-pip` (+ `ffmpeg` when the backend needs it), using `sudo` when not root; then `uv tool install <pkg>` (on-PATH) **or** a venv + `pip install <pkg>`; then warm-pulls the model.
- **macOS**: no apt — installs via `uv`/`pip`; **instructs** `brew install ffmpeg` if ffmpeg is missing (doesn't drive brew). parakeet-mlx fetches its model on first use (no separate warm-pull verb).
- Default model warm-pulled for `onnx-asr`: `nemo-parakeet-tdt-0.6b-v3`.

## Guardrails (all from the arc plan)

- **NON-FATAL + IDEMPOTENT** — present binary → skip; a failed step reports + exits non-zero but never half-installs. Re-running is safe.
- **RAM guard** — reads `/proc/meminfo` `MemAvailable` on Linux; below ~2 GB **refuses** local and steers to a cloud provider (groq), matching the README sizing caveat. Unknown RAM → proceeds (no refusal). Non-Linux → no refusal.
- **Privilege split** — pip/uv user-level (venv); apt system-level via sudo-if-needed, or a clear instruct when neither root nor sudo is available.
- **Diagnose-only path unchanged** — the SPA's `/scribe/admin/backend-availability` + `computeBackendAvailability` are behaviorally untouched; `backend-availability.test.ts` passes unmodified.
- **Single source of truth** — `TRANSCRIBE_INSTALL` refactored into structured specs (`pipPackage` + `pipExtras`); the diagnose-only `fix` prose is **derived** from them and the runnable installer reuses the same pip target, so they can't drift.

## Tests / gates

- `bun run typecheck`: clean. `bun test src/`: **504 pass, 0 fail** (30 new hermetic cases over an injected subprocess runner — RAM guard at/below/above floor + null, idempotency, privilege split, platform mismatch, uv-vs-venv fallback, model warm-pull non-fatality, partial-success verify, whisper explicit path). **Nothing apt/pip-installs in tests.**
- Live-verified on this Mac: `doctor` renders the report; `install-backend` is an idempotent no-op (skips, verifies via the detector, exits 0); unknown provider exits 1.

## Versioning

rc bump (committed-core): `0.5.0` → `0.5.1-rc.1`.

## Reviewer

Independent reviewer pass: **LGTM with nits, no critical issues**. Addressed inline: macOS installed-but-ffmpeg-missing now exits 0 as a partial success (was a misleading exit 1); venv PATH caveat now carried into `outcome.summary` for callers that read only the summary; added whisper-path + partial-success tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)