### PR TITLE
feat(scribe): adopt scope-guard 0.5.0 multi-origin iss-set

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-scribe",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openparachute/scope-guard": "^0.2.0",
+        "@openparachute/scope-guard": "^0.5.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -22,7 +22,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.2.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HbL1ZFBD0Kl/IiEXbEVLEGSQXGKL9sjRltye5RtqVLdwkR7Y9qOM9SSYmxa9np7nqzbRXrwDjEbRRQubKju9xg=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.5.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-cnX4hutteyIWPSj1I5UvIGShBNLrQSrW1DpP2CNJfHl0ndi5DrdvQvxjXQj3S8/F/FDlhTbFyTNqmyErATuN4Q=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1-rc.2",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openparachute/scope-guard": "^0.2.0"
+    "@openparachute/scope-guard": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { enforceAuth, validateToken } from "./auth.ts";
-import { resetJwksCache, resetRevocationCache } from "./hub-jwt.ts";
+import { parseHubOrigins, resetJwksCache, resetRevocationCache } from "./hub-jwt.ts";
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -239,5 +239,100 @@ describe("hub JWT integration — revocation enforcement", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe("parseHubOrigins — comma-separated hub-origin set parser", () => {
+  test("undefined → []", () => {
+    expect(parseHubOrigins(undefined)).toEqual([]);
+  });
+
+  test("empty string → []", () => {
+    expect(parseHubOrigins("")).toEqual([]);
+  });
+
+  test("whitespace / commas only → []", () => {
+    expect(parseHubOrigins("  , ,  ")).toEqual([]);
+  });
+
+  test("trims, strips trailing slash, drops empties, dedupes", () => {
+    // "a,b/, ,a" → [a, b] — b/ loses its trailing slash, the empty middle
+    // entry is dropped, and the duplicate a collapses to one.
+    expect(parseHubOrigins("https://a.example,https://b.example/, ,https://a.example")).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ]);
+  });
+});
+
+describe("hub JWT integration — multi-origin iss-set (PARACHUTE_HUB_ORIGINS)", () => {
+  // The fixture origin is the canonical `PARACHUTE_HUB_ORIGIN` (so JWKS fetch
+  // works); a SECOND origin is added only to `PARACHUTE_HUB_ORIGINS`. A token
+  // minted with `iss` = the second origin must validate (signature still proves
+  // THIS hub minted it — the JWKS came from the canonical origin); an unlisted
+  // origin must be rejected; and with the SET env unset, only the canonical
+  // origin validates.
+  const SECOND_ORIGIN = "https://scribe.box.sslip.io";
+  const UNLISTED_ORIGIN = "https://attacker.example";
+
+  test("token whose iss is a second origin in PARACHUTE_HUB_ORIGINS → accepted", async () => {
+    process.env.PARACHUTE_HUB_ORIGINS = `${SECOND_ORIGIN},${fixture.origin}`;
+    resetJwksCache();
+    const token = await signJwt(kp, {
+      iss: SECOND_ORIGIN,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+    try {
+      const result = await validateToken(token);
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.mode).toBe("hub-jwt");
+        expect(result.scopes).toEqual(["scribe:transcribe"]);
+      }
+    } finally {
+      delete process.env.PARACHUTE_HUB_ORIGINS;
+    }
+  });
+
+  test("token whose iss is NOT in the set → rejected (issuer pin holds)", async () => {
+    process.env.PARACHUTE_HUB_ORIGINS = SECOND_ORIGIN;
+    resetJwksCache();
+    const token = await signJwt(kp, {
+      iss: UNLISTED_ORIGIN,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+    try {
+      const result = await validateToken(token);
+      expect(result.valid).toBe(false);
+    } finally {
+      delete process.env.PARACHUTE_HUB_ORIGINS;
+    }
+  });
+
+  test("env UNSET → only the canonical hubOrigin validates (back-compat collapse)", async () => {
+    // PARACHUTE_HUB_ORIGINS is unset (beforeEach never sets it; we assert it).
+    expect(process.env.PARACHUTE_HUB_ORIGINS).toBeUndefined();
+    resetJwksCache();
+
+    // Canonical origin (PARACHUTE_HUB_ORIGIN === fixture.origin) → accepted.
+    const canonical = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+    const okResult = await validateToken(canonical);
+    expect(okResult.valid).toBe(true);
+
+    // A second-origin token that WOULD have passed with the set configured is
+    // now rejected — proving the unset path is byte-identical to single-origin.
+    const second = await signJwt(kp, {
+      iss: SECOND_ORIGIN,
+      aud: "scribe",
+      scope: "scribe:transcribe",
+    });
+    const rejectedResult = await validateToken(second);
+    expect(rejectedResult.valid).toBe(false);
   });
 });

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -39,12 +39,43 @@ export function getHubOrigin(): string {
   return DEFAULT_HUB_LOOPBACK;
 }
 
+/**
+ * Parse the hub's legitimate-origin SET from a comma-separated env value
+ * (`PARACHUTE_HUB_ORIGINS`). Split on `,`, trim each entry, strip a trailing
+ * slash, drop empties, dedupe. These widen the accepted `iss` claim beyond the
+ * single canonical `getHubOrigin()` — see the multi-origin iss-set refactor
+ * (hub#692). The values must be the hub's OWN legitimate origins, published
+ * out-of-band by the hub/operator; never derived from a request Host header.
+ *
+ * Back-compat invariant: when `PARACHUTE_HUB_ORIGINS` is UNSET, this returns
+ * `[]`, and scope-guard collapses to the single canonical `hubOrigin` — the
+ * `iss` check is byte-identical to before this seam existed.
+ */
+export function parseHubOrigins(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  for (const part of raw.split(",")) {
+    const origin = part.trim().replace(/\/$/, "");
+    if (origin.length > 0) seen.add(origin);
+  }
+  return [...seen];
+}
+
 // Process-wide guard. The resolver form lets tests flip
 // `PARACHUTE_HUB_ORIGIN` between cases — the lib re-resolves on every
 // `validateHubJwt` and `resetJwksCache` call so the env-var change picks up
 // without a server restart. JWKS cache (5min/30s defaults) lives inside the
 // guard, shared across requests.
-const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
+//
+// `allowedIssuers` widens the accepted `iss` to the hub's full legitimate-origin
+// set (one box reachable on several URLs at once). Unset env → `parseHubOrigins`
+// returns `[]` → scope-guard collapses to the single canonical `hubOrigin`,
+// byte-identical to before this seam existed. Re-evaluated per call so an
+// operator widening the box's origins is picked up without a restart.
+const guard = createScopeGuard({
+  hubOrigin: () => getHubOrigin(),
+  allowedIssuers: () => parseHubOrigins(process.env.PARACHUTE_HUB_ORIGINS),
+});
 
 /**
  * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any


### PR DESCRIPTION
## What

Scribe-side adapter for the **multi-origin iss-set refactor** (hub#692; `@openparachute/scope-guard@0.5.0` published on npm). Mirrors the vault adapter. Lets scribe accept a hub-signed JWT whose `iss` is any of the hub's legitimate origins for a box reachable on several URLs at once (loopback + `<ip>.sslip.io` + a custom domain), not just the single canonical origin.

## Changes

1. **`package.json`** — bump `@openparachute/scope-guard` `^0.2.0` → `^0.5.0` (lockfile updated; resolves to `0.5.0`). rc bump `0.5.1-rc.1` → `0.5.1-rc.2`.
2. **`src/hub-jwt.ts`** — add a small local `parseHubOrigins(raw)` helper (split on `,`, trim, strip trailing slash, drop empties, dedupe) and wire `allowedIssuers: () => parseHubOrigins(process.env.PARACHUTE_HUB_ORIGINS)` into `createScopeGuard`. `hubOrigin` left as-is. No import from a private hub path.
3. **Back-compat invariant** (stated in comments + verified by test): when `PARACHUTE_HUB_ORIGINS` is UNSET, `parseHubOrigins` returns `[]` → scope-guard collapses to the single canonical `hubOrigin` — byte-identical to today.

## 0.2.0 → 0.5.0 jump — consumer check

Grepped all scope-guard usages in scribe (only `src/hub-jwt.ts` constructs/consumes the lib; tests import only `reset*`/`parseHubOrigins`). Inspected the published 0.5.0 `.d.ts`:
- `createScopeGuard(opts)` — same signature; `allowedIssuers`, `jwksOrigin`, legacy-jti flag are all **optional + additive**.
- `validateHubJwt(token, opts?)` — `opts` optional; scribe calls with one arg.
- `HubJwtError`, `HubJwtClaims`, `looksLikeJwt`, `resetJwksCache`, `resetRevocationCache` — exported, signatures unchanged.
- `HubJwtClaims` shape (`sub`/`scopes`/`aud`/`jti`/`clientId`) unchanged; scribe consumes only `scopes`.

No breaking change touches a scribe call site. The new accept-set sits *on top of* the unconditional JWKS signature verify (a foreign-key token fails signature regardless of `iss`).

## Tests

`src/auth-hub-jwt.test.ts`:
- `parseHubOrigins` unit cases (undefined/empty/whitespace → `[]`; `"a,b/, ,a"` → `[a,b]` deduped + trailing-slash-stripped).
- Signed-JWT multi-origin harness: a token with `iss` = a second origin listed in `PARACHUTE_HUB_ORIGINS` validates; an unlisted origin is rejected; env-unset → only the canonical origin validates (back-compat collapse).

## Gates

- `bun run typecheck` — clean (exit 0).
- `bun test src` — **511 pass / 0 fail / 1076 expect() calls across 27 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)