### PR TITLE
release: v0.5.1 — promote to @latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scribe",
-  "version": "0.5.1-rc.2",
+  "version": "0.5.1",
   "description": "Audio transcription + LLM cleanup. Whisper-compatible API for Parachute.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Promote the soaked rc chain to stable. Drops the `-rc` suffix on package.json (0.5.1-rc.2 → 0.5.1) — **same code, same patch number**, now shipped as `@latest`. On merge I push tag `v0.5.1` → CI publishes `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)